### PR TITLE
fix(footer): reduce CLS while footer data loads

### DIFF
--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -29,19 +29,44 @@ export default function Footer({ data }: FooterProps) {
   const createLocaleUrlHelper = (path: string) => createLocaleUrl(path, locale);
   const isCampsRoute = pathname === '/camps' || pathname.startsWith('/camps/');
 
-  // Reserve the same visual shell while Redux/API loads — returning null caused the footer to
-  // pop in after fetch and shifted the whole page (felt like flicker on long pages like /camp/*).
+  // Reserve the same layout shell while Redux/API loads — height + padding must match the
+  // loaded footer or Lighthouse reports CLS when content swaps (especially on mobile stacks).
   if (!footer) {
     return (
       <footer
-        className="bg-gradient-to-br from-[#1F396D]/20 via-[#29335C]/15 to-[#1F396D]/20 py-16 px-4 lg:px-8 relative overflow-hidden text-gray-800 min-h-[280px] md:min-h-[320px]"
+        className={[
+          'bg-gradient-to-br from-[#1F396D]/20 via-[#29335C]/15 to-[#1F396D]/20',
+          'pt-16 px-4 lg:px-8 relative overflow-hidden text-gray-800',
+          isCampsRoute ? 'pb-44 sm:pb-52' : 'pb-16',
+        ].join(' ')}
         aria-busy="true"
         aria-label="Site footer loading"
       >
         <div className="absolute top-10 right-20 w-32 h-32 bg-[#F16112]/10 rounded-full blur-3xl" aria-hidden />
         <div className="absolute bottom-20 left-10 w-40 h-40 bg-[#F1894F]/10 rounded-full blur-3xl" aria-hidden />
         <div className="max-w-7xl mx-auto relative z-10">
-          <div className="h-36 rounded-xl bg-white/25 animate-pulse" />
+          <div className="flex flex-col md:flex-row gap-10 items-start">
+            <div className="flex-1 w-full space-y-4">
+              <div className="h-24 w-56 max-w-full rounded-lg bg-white/25 animate-pulse" />
+              <div className="h-16 rounded-lg bg-white/20 animate-pulse" />
+              <div className="space-y-2">
+                <div className="h-4 w-48 max-w-full bg-white/20 rounded animate-pulse" />
+                <div className="h-4 w-52 max-w-full bg-white/20 rounded animate-pulse" />
+                <div className="h-4 w-64 max-w-full bg-white/20 rounded animate-pulse" />
+              </div>
+            </div>
+            {[0, 1, 2].map((k) => (
+              <div key={k} className="flex-1 w-full space-y-4">
+                <div className="h-7 w-40 bg-white/25 rounded animate-pulse" />
+                <div className="space-y-2.5">
+                  {[0, 1, 2, 3, 4].map((j) => (
+                    <div key={j} className="h-4 w-full max-w-[220px] bg-white/20 rounded animate-pulse" />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-12 h-5 w-72 max-w-full mx-auto bg-white/20 rounded animate-pulse" />
         </div>
       </footer>
     );


### PR DESCRIPTION
Match loading skeleton layout to the real footer (columns + copyright), align padding with loaded state including camp route bottom padding.

Made-with: Cursor