### PR TITLE
fix(capi): forward email and name PII on Lead events for better match quality

### DIFF
--- a/src/app/[locale]/camps/summer/page.tsx
+++ b/src/app/[locale]/camps/summer/page.tsx
@@ -265,7 +265,10 @@ export default function SummerCampPage() {
         }
         return;
       }
-      trackSummerCampGuideLead(lotteryCampInterest, lotteryChildGrade);
+      trackSummerCampGuideLead(lotteryCampInterest, lotteryChildGrade, {
+        em: emailTrim,
+        fn: lotteryParentName.trim(),
+      });
       const qs = new URLSearchParams({
         interest: lotteryCampInterest,
         grade: lotteryChildGrade,

--- a/src/lib/capiClient.ts
+++ b/src/lib/capiClient.ts
@@ -12,12 +12,13 @@ import type { CAPICustomData } from '@/lib/capi';
  * Usage:
  *   const eventId = generateEventId();
  *   window.fbq('track', 'Lead', params, { eventID: eventId });
- *   sendCAPIEventFromBrowser('Lead', params, eventId);
+ *   sendCAPIEventFromBrowser('Lead', params, eventId, { em: email, fn: firstName });
  */
 export function sendCAPIEventFromBrowser(
   event_name: string,
   custom_data?: CAPICustomData,
-  event_id?: string
+  event_id?: string,
+  user_data?: { em?: string; ph?: string; fn?: string; ln?: string }
 ): void {
   // Guard: never fire during Lighthouse or automated audits.
   if (typeof window === 'undefined' || isAutomatedAuditEnvironment()) return;
@@ -33,6 +34,7 @@ export function sendCAPIEventFromBrowser(
       event_id: id,
       event_source_url: window.location.href,
       custom_data,
+      ...(user_data ? { user_data } : {}),
     }),
     keepalive: true,
   }).catch(() => {

--- a/src/lib/meta-pixel.ts
+++ b/src/lib/meta-pixel.ts
@@ -31,14 +31,18 @@ function generateEventId(): string {
  *
  * CAPI call is fire-and-forget — it never blocks the UI or throws.
  */
-function trackWithCAPI(event: string, params?: CAPICustomData): void {
+function trackWithCAPI(
+  event: string,
+  params?: CAPICustomData,
+  userData?: { em?: string; ph?: string; fn?: string; ln?: string }
+): void {
   const eventId = generateEventId();
 
   if (typeof window !== 'undefined' && typeof window.fbq === 'function') {
     window.fbq('track', event, params ?? {}, { eventID: eventId });
   }
 
-  sendCAPIEventFromBrowser(event, params, eventId);
+  sendCAPIEventFromBrowser(event, params, eventId, userData);
 }
 
 /** Browser-only fbq track — for non-standard events not in the CAPI allowed list. */
@@ -53,14 +57,18 @@ function track(event: string, params?: Record<string, unknown>): void {
 // ---------------------------------------------------------------------------
 
 /** Summer camp "Get guide + 15% off" form submission. */
-export function trackSummerCampGuideLead(interest: string, grade: string): void {
+export function trackSummerCampGuideLead(
+  interest: string,
+  grade: string,
+  userData?: { em?: string; ph?: string; fn?: string; ln?: string }
+): void {
   trackWithCAPI('Lead', {
     content_name: 'Summer Camp Guide',
     content_category: interest,
     content_ids: [grade],
     value: 0,
     currency: 'USD',
-  });
+  }, userData);
 }
 
 /** @deprecated Use trackSummerCampGuideLead */


### PR DESCRIPTION
## Summary

- `sendCAPIEventFromBrowser` in `capiClient.ts` now accepts an optional `user_data` param (`em`, `ph`, `fn`, `ln`) and spreads it into the `/api/capi` POST body only when provided
- `trackWithCAPI` and `trackSummerCampGuideLead` in `meta-pixel.ts` thread the `userData` param through the call chain
- The guide form submit handler in `camps/summer/page.tsx` now passes the validated email and parent name as PII so Meta can hash and match them server-side

## Problem

Email, First Name, and Last Name were only present on ~1.85% of Lead events in Meta Events Manager — the form collected this data but it was never forwarded to CAPI. Match quality score was 6.1/10.

## Test plan

- [ ] Submit the summer camp guide form and verify the Lead event appears in Meta's Test Events tool with `em` and `fn` populated
- [ ] Confirm raw PII is not logged anywhere (hashing happens server-side in `capi.ts`)
- [ ] Check Meta Events Manager event coverage after deploy — email/name coverage should climb toward 100%

Made with [Cursor](https://cursor.com)