### PR TITLE
GWA-171: Summer camp 2026 dates, schema, hero UX, perf, and a11y

### DIFF
--- a/docs/summer-camp-2026-status.md
+++ b/docs/summer-camp-2026-status.md
@@ -1,0 +1,113 @@
+# Summer camp 2026 — implementation status
+
+Tracks **Plan 1** (dates across UI, schema) and **Plan 2** (hero above-the-fold). Brochure PDF updates are out of scope for this pass. Update this file as work ships.
+
+| Field | Value |
+|--------|--------|
+| **Jira** | [GWA-171](https://thegrowwise-school.atlassian.net/browse/GWA-171) |
+| **Primary repo** | `growwise_newui` |
+| **Plan reference** | `.cursor/plans/summer_camp_dates_ux_17dfba25.plan.md` (local Cursor plan, if present). JSON-LD / AEO: changelog **2026-04-23**. **This file is the only local status doc** for summer 2026 + Lighthouse. |
+
+---
+
+## Engineering change log (perf / Lighthouse / a11y)
+
+_Applies to `growwise_newui` — summer camp route and shared pieces._
+
+1. **`src/app/[locale]/camps/summer/page.tsx`** — Meta Pixel: dynamic `import('@/lib/meta-pixel')` for guide submit + early-bird; early-bird idle sets locale ref only inside idle callback; mobile (`max-width: 768px`) longer idle timeouts for FAQ fetch, SlotsPanel (`SummerCampUI`) preload, and early-bird; hero `Image` `quality={70}`, mobile sticky logo `fetchPriority="low"` + `decoding="async"`; hero/subhead/trust text contrast (`zinc-100`, brochure `text-white`); primary CTAs / sticky bar use **`#047857` / `#065f46`**; active filter chips **`#146c43`**; **`SummerCampGuideLeadDialog`** loaded only after first open or `#lead-capture` / `#lottery` (smaller initial JS).
+2. **`src/app/[locale]/camps/summer/SummerCampGuideLeadDialog.tsx`** _(new)_ — Radix `Dialog` + lead form extracted; code-split from main page chunk.
+3. **`src/components/camps/SummerCampProgramList.tsx`** — No `priority` on program card images (hero wins LCP on mobile); `quality={70}`, `decoding="async"`; `trackCampView` via dynamic `import`; mobile “lottery” link uses **`text-[#065f46]`** for contrast.
+4. **`src/components/camps/SummerCampUI.tsx`** — `trackEnrollClick` via dynamic `import('@/lib/meta-pixel')`.
+5. **`src/components/camps/SummerCampTrustBlock.tsx`** — Testimonials as `<blockquote>` / `<footer>`; projects `Link` `aria-label` includes “opens in new tab”.
+6. **`next.config.ts`** — `images.qualities` includes **70** (matches hero/program `quality={70}`).
+7. **`scripts/lighthouse-summer-camp.mjs`** + **`package.json`** `lighthouse:summer` — Lighthouse 13 mobile/Slow 4G; writes snapshot into **this** file between HTML comments.
+8. **Removed** `docs/lighthouse-summer-camp-summary.json` — metrics live only here (single status file).
+
+---
+
+## Plan 1 — Camp season (Jun 8–Jul 31, 2026) + July 4 note
+
+| Task | Status | Notes / files |
+|------|--------|----------------|
+| `summer-camp-week-calendar.ts` (8 Mon–Fri labels + season strings) | **Done** | [`src/lib/summer-camp-week-calendar.ts`](../src/lib/summer-camp-week-calendar.ts) |
+| `expandSlotTemplate` + week labels | **Done** | [`src/lib/summer-camp-data.ts`](../src/lib/summer-camp-data.ts) |
+| Math Olympiad slot labels (tier 1 / tier 2 ranges) | **Done** | [`src/components/camps/SummerCampUI.tsx`](../src/components/camps/SummerCampUI.tsx) |
+| Tests (calendar vs JSON `count`) | **Done** | [`src/lib/summer-camp-week-calendar.test.ts`](../src/lib/summer-camp-week-calendar.test.ts), [`src/components/camps/__tests__/summer-camp-data.test.ts`](../src/components/camps/__tests__/summer-camp-data.test.ts) |
+| `ProgramDetails` + `summer-camp-programs.json` | **Done** | Optional `deliverySummary` on `ProgramDetails`; all programs in mock JSON |
+| Info modal rows (dates, note, delivery) | **Done** | `SummerCampUI.tsx` `InfoModal`; i18n labels in `en.json` `summerCamp.infoModal` |
+| JSON-LD `startDate` / `endDate` | **Done** | [`src/app/[locale]/camps/summer/layout.tsx`](../src/app/[locale]/camps/summer/layout.tsx) imports ISO from week-calendar |
+| JSON-LD schema hygiene (SEO) | **Done** | Same layout: `BreadcrumbList` middle crumb → `/camps` (not duplicate summer URL); `Event` `offers` omits misleading fixed `price` (multi-tier programs); removed unused `SUMMER_CAMP_FAQS` — FAQPage still from [`summer-camp-faq.json`](../public/api/mock/en/summer-camp-faq.json) only |
+| Brochure PDF | **Skipped** | No change to `public/assets/camps/SummerCampBrochure.pdf` for 2026 scope |
+| Guide email: PDF attachment + Brevo/SMTP | **Done** | [`src/app/api/summer-camp-lottery/route.ts`](../src/app/api/summer-camp-lottery/route.ts) attaches `SummerCampBrochure.pdf` when readable; link retained; [`src/lib/email.ts`](../src/lib/email.ts), [`src/lib/brevo.ts`](../src/lib/brevo.ts) |
+| Summer page JS weight (perf) | **Done** | Hero + conversion copy from slim [`summer-camp-canonical-en.json`](../src/i18n/messages/summer-camp-canonical-en.json) (~4.6KB) instead of full `en.json` import; hero `Image` `sizes` tightened in [`page.tsx`](../src/app/[locale]/camps/summer/page.tsx) |
+
+---
+
+## Plan 2 — Hero compact + mobile CTA
+
+| Task | Status | Notes / files |
+|------|--------|----------------|
+| Reduce hero min/max height, padding | **Done** | Hero `max-h-[600px]`, `min-h` ~48svh / md ~40vh; padding `py-8` → `md:py-14` / `lg:py-16` (removed `md:py-[120px]`) |
+| Tighter H1 / subhead | **Done** | Slightly smaller type scale + tighter `mt` / CTA `gap` |
+| Mobile: primary CTA without scroll | **Done** | Urgency + trust lines `hidden` below `sm` so primary + secondary CTAs fit first screen; brochure link slightly smaller on narrow |
+| Optional: re-export banner WebP | Not started | `public/assets/camps/summer-camp-banner.webp` — only if focal crop needed |
+
+---
+
+## Verification (local)
+
+| Check | Result | When |
+|--------|--------|------|
+| `npm test` | **184** tests, **18** suites — all passed | After JSON-LD + layout edits |
+| `npm run build` | **Next.js build** completed successfully | Same |
+| Lighthouse | Re-run updates the snapshot block below | `npm run build && PORT=38479 npm run start` then `PORT=38479 npm run lighthouse:summer` |
+| Bundle (static chunks) | **Largest JS** ~221 KiB top file after `next build` | `.next/static/chunks/*.js` — guide dialog split defers Radix until first open |
+
+**Lighthouse note:** PDF (`localhost:3002`, Performance **46**, LCP **12.7 s**) was almost certainly **`next dev`**. Use **`next start`** for realistic scores; numbers vary run-to-run on Slow 4G. Production CDN improves LCP vs local.
+
+<!-- LIGHTHOUSE_SNAPSHOT_START -->
+_Last updated: 2026-04-23T20:35:49.111Z (Lighthouse 13.0.2) — run `npm run lighthouse:summer` to refresh._
+
+| Metric | Value |
+|--------|-------|
+| URL | `http://127.0.0.1:38479/camps/summer` |
+| Performance | **59** |
+| Accessibility | **100** |
+| FCP | 1.22 s |
+| LCP | 5.20 s |
+| TBT | 137 ms |
+| CLS | 0.445 |
+| Speed Index | 1.22 s |
+| Throttling | Slow 4G (RTT 150 ms, ~1638.4 Kbps), CPU ×4 |
+| LCP element | `main > section.relative > div.absolute > img.object-cover` |
+| BFCache | Page didn't prevent back/forward cache restoration |
+| Contrast audit | Background and foreground colors have a sufficient contrast ratio |
+
+<details><summary>LCP snippet (truncated)</summary>
+
+```html
+<img alt="Students in coding, robotics, and math summer programs at GrowWise, Dublin…" draggable="false" fetchpriority="high" decoding="async" data-nimg="fill" class="object-cover object-center select-none" sizes="(max-w
+```
+
+</details>
+<!-- LIGHTHOUSE_SNAPSHOT_END -->
+
+---
+
+## Changelog (append on merge)
+
+| Date | PR / commit | Summary |
+|------|-------------|---------|
+| 2026-04-23 | _local_ | JSON-LD: breadcrumb “Camps” → `/camps`; Event `offers` without fixed price; removed dead `SUMMER_CAMP_FAQS`. Earlier same pass: guide-email PDF attach + perf (`summer-camp-canonical-en.json`, hero `sizes`). **Verified:** `npm test` (184), `npm run build`. Status + verification table updated |
+| 2026-04-23 | _local_ | Brochure PDF skipped for 2026 scope; tracker row marked **Skipped** |
+| 2026-04-24 | _local_ | Plan 1: week calendar module, slot labels, Olympiad labels, Program Details modal (dates + July 4 + delivery), JSON-LD Jun 8–Jul 31, tests |
+| 2026-04-24 | _local_ | Plan 2: summer hero shorter (`max-h` + tighter padding/type); urgency/trust hidden `< sm` for above-fold primary CTA |
+| 2026-04-24 | _local_ | Advanced Math: per-track weekly session dates (Algebra Mon/Wed/Fri, Precal Tue/Wed/Thu) in slot labels via `adv-math-week-sessions.ts` |
+| 2026-04-24 | _local_ | Lighthouse: `lighthouse:summer` embeds snapshot in this file; lazy [`SummerCampGuideLeadDialog`](../src/app/[locale]/camps/summer/SummerCampGuideLeadDialog.tsx); WCAG greens; `images.qualities` **70**; single status doc; Jira GWA-171 comment |
+
+---
+
+## Jira ticket
+
+- **Key:** GWA-171
+- **URL:** https://thegrowwise-school.atlassian.net/browse/GWA-171

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,8 +51,8 @@ const nextConfig: NextConfig = {
     formats: ['image/avif', 'image/webp'], // Use modern image formats
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-    // Allow both quality levels so next/image cache doesn't miss when quality=75 (default) or quality=85 is requested.
-    qualities: [75, 85],
+    // Include 70 for summer hero / program cards; 75 default; 85 where explicitly requested.
+    qualities: [70, 75, 85],
     // Short TTL in dev; longer in prod so repeat views hit the image optimizer cache more often.
     minimumCacheTTL: isProd ? 86_400 : 60,
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "playwright test",
     "test:e2e:chromium": "playwright test --project=chromium",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --project=chromium --headed --workers=1"
+    "test:e2e:headed": "playwright test --project=chromium --headed --workers=1",
+    "lighthouse:summer": "node scripts/lighthouse-summer-camp.mjs"
   },
   "dependencies": {
     "@next/third-parties": "^16.0.0",

--- a/public/api/mock/en/summer-camp-programs.json
+++ b/public/api/mock/en/summer-camp-programs.json
@@ -17,10 +17,11 @@
       "startingPrice": 259,
       "image": "/images/camps/banners/advanced-math-banner.webp",
       "details": {
-        "schedule": "Algebra II (Mon/Wed/Fri)\nPrecal (Tue/Wed/Thu)",
+        "schedule": "Algebra II: Mon / Wed / Fri (session dates shown per week when you enroll)\nPrecalculus: Tue / Wed / Thu (session dates shown per week when you enroll)",
         "daysPerWeek": 3,
         "dailyHours": "3 hours / day",
         "hoursLabel": "Session hours",
+        "deliverySummary": "In-person or online (choose when enrolling)",
         "includes": [
           "Choice of track: Algebra II, Advanced Algebra II, or Precalculus",
           "Expert-led instruction with concept clarity and step-by-step guidance",
@@ -67,6 +68,7 @@
         "daysPerWeek": 5,
         "dailyHours": "3 hours daily",
         "hoursLabel": "Session hours",
+        "deliverySummary": "In-person or online (choose when enrolling)",
         "includes": [
           "AMC8 & MOEMS-aligned curriculum",
           "Timed mock competition tests",
@@ -121,6 +123,7 @@
         "daysPerWeek": 5,
         "dailyHours": "3 hours per day",
         "hoursLabel": "Session hours",
+        "deliverySummary": "In-person or online (choose when enrolling)",
         "includes": [
           "Led by instructor",
           "Hands-on AI tools",
@@ -167,6 +170,7 @@
         "daysPerWeek": 5,
         "dailyHours": "3 hours per day",
         "hoursLabel": "Session hours",
+        "deliverySummary": "In-person or online (choose when enrolling)",
         "includes": [
           "Scratch visual programming environment",
           "Animated story & interactive game projects",
@@ -212,6 +216,7 @@
         "schedule": "Monday – Friday",
         "daysPerWeek": 5,
         "dailyHours": "6 hours / day",
+        "deliverySummary": "In-person only",
         "includes": [
           "Build & program a working robot from scratch",
           "Sensor arrays: ultrasonic, IR & colour sensors",
@@ -258,6 +263,7 @@
         "schedule": "Monday – Friday",
         "daysPerWeek": 5,
         "dailyHours": "6 hours / day",
+        "deliverySummary": "In-person only",
         "includes": [
           "Story structure, plot & character development",
           "Daily creative writing workshops",
@@ -305,6 +311,7 @@
         "daysPerWeek": 5,
         "dailyHours": "3 hours per day",
         "hoursLabel": "Session hours",
+        "deliverySummary": "In-person or online (choose when enrolling)",
         "includes": [
           "Lua scripting fundamentals in Roblox Studio",
           "Game mechanics design & world-building",

--- a/scripts/lighthouse-summer-camp.mjs
+++ b/scripts/lighthouse-summer-camp.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Runs Lighthouse (mobile + default Slow 4G simulation) against a running prod server.
+ * Updates the `<!-- LIGHTHOUSE_SNAPSHOT_START -->` … `END` block inside docs/summer-camp-2026-status.md.
+ *
+ * Usage: PORT=38479 npm run start  →  PORT=38479 npm run lighthouse:summer
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const port = process.env.PORT || '3000';
+const url = process.env.LH_URL || `http://127.0.0.1:${port}/camps/summer`;
+const out = join(tmpdir(), `lh-summer-${Date.now()}.json`);
+
+const r = spawnSync(
+  'npx',
+  [
+    '--yes',
+    'lighthouse@13.0.2',
+    url,
+    '--only-categories=performance,accessibility',
+    '--form-factor=mobile',
+    '--throttling-method=simulate',
+    '--output=json',
+    `--output-path=${out}`,
+    '--chrome-flags=--headless=new --no-sandbox',
+    '--quiet',
+  ],
+  { stdio: 'inherit', encoding: 'utf8' }
+);
+
+if (r.status !== 0) {
+  console.error('Lighthouse failed. Is the server running? Try: PORT=38477 npm run start');
+  process.exit(r.status ?? 1);
+}
+
+const report = JSON.parse(readFileSync(out, 'utf8'));
+try {
+  unlinkSync(out);
+} catch {
+  /* ignore */
+}
+
+const a = report.audits;
+const cat = report.categories;
+
+const legacyLcp = a['largest-contentful-paint-element']?.details?.items?.[0]?.node;
+const discoveryItems = a['lcp-discovery-insight']?.details?.items;
+const discoveryNode = Array.isArray(discoveryItems)
+  ? discoveryItems.find((x) => x && x.type === 'node')
+  : null;
+const lcpNode = legacyLcp ?? discoveryNode ?? null;
+const lcpSelector = lcpNode?.selector ?? null;
+const lcpSnippet = (lcpNode?.snippet ?? '').slice(0, 220) || null;
+/** Human-readable LCP phases when Lighthouse exposes a string; avoids multi-KB JSON blobs. */
+const lcpBreakdown =
+  typeof a['lcp-breakdown-insight']?.displayValue === 'string'
+    ? a['lcp-breakdown-insight'].displayValue
+    : typeof a['lcp-breakdown']?.displayValue === 'string'
+      ? a['lcp-breakdown'].displayValue
+      : null;
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  lighthouseVersion: report.lighthouseVersion,
+  url: report.finalUrl,
+  fetchTime: report.fetchTime,
+  formFactor: report.configSettings?.formFactor,
+  throttling: report.configSettings?.throttling,
+  scores: {
+    performance: Math.round((cat.performance?.score ?? 0) * 100),
+    accessibility: Math.round((cat.accessibility?.score ?? 0) * 100),
+  },
+  metrics: {
+    firstContentfulPaintMs: a['first-contentful-paint']?.numericValue,
+    largestContentfulPaintMs: a['largest-contentful-paint']?.numericValue,
+    totalBlockingTimeMs: a['total-blocking-time']?.numericValue,
+    cumulativeLayoutShift: a['cumulative-layout-shift']?.numericValue,
+    speedIndexMs: a['speed-index']?.numericValue,
+  },
+  lcp: {
+    selector: lcpSelector,
+    snippet: lcpSnippet,
+    breakdown: lcpBreakdown ?? null,
+  },
+  colorContrastFailures:
+    a['color-contrast']?.details?.items?.map((it) => ({
+      selector: it.node?.selector,
+      label: it.node?.nodeLabel,
+      explanation: it.node?.explanation?.split('\n')[0] ?? null,
+    })) ?? [],
+  bfCache: {
+    score: a['bf-cache']?.score,
+    title: a['bf-cache']?.title,
+    details: a['bf-cache']?.details?.items ?? a['bf-cache']?.details,
+  },
+  contrast: {
+    score: a['color-contrast']?.score,
+    title: a['color-contrast']?.title,
+  },
+};
+
+const th = summary.throttling ?? {};
+const md = `<!-- LIGHTHOUSE_SNAPSHOT_START -->
+_Last updated: ${summary.generatedAt} (Lighthouse ${summary.lighthouseVersion})_
+
+| Metric | Value |
+|--------|-------|
+| URL | \`${summary.url}\` |
+| Performance | **${summary.scores.performance}** |
+| Accessibility | **${summary.scores.accessibility}** |
+| FCP | ${(summary.metrics.firstContentfulPaintMs / 1000).toFixed(2)} s |
+| LCP | ${(summary.metrics.largestContentfulPaintMs / 1000).toFixed(2)} s |
+| TBT | ${Math.round(summary.metrics.totalBlockingTimeMs)} ms |
+| CLS | ${summary.metrics.cumulativeLayoutShift?.toFixed(3) ?? '—'} |
+| Speed Index | ${(summary.metrics.speedIndexMs / 1000).toFixed(2)} s |
+| Throttling | Slow 4G (RTT ${th.rttMs} ms, ~${th.throughputKbps} Kbps), CPU ×${th.cpuSlowdownMultiplier} |
+| LCP element | \`${lcpSelector ?? '—'}\` |
+| BFCache | ${summary.bfCache?.title ?? '—'} |
+| Contrast audit | ${summary.contrast?.title ?? '—'} |
+
+<details><summary>LCP snippet (truncated)</summary>
+
+\`\`\`html
+${(lcpSnippet ?? '—').replace(/`/g, "'")}
+\`\`\`
+
+</details>
+<!-- LIGHTHOUSE_SNAPSHOT_END -->`;
+
+const statusPath = join(__dirname, '../docs/summer-camp-2026-status.md');
+let status = readFileSync(statusPath, 'utf8');
+const start = '<!-- LIGHTHOUSE_SNAPSHOT_START -->';
+const end = '<!-- LIGHTHOUSE_SNAPSHOT_END -->';
+const si = status.indexOf(start);
+const ei = status.indexOf(end);
+if (si === -1 || ei === -1 || ei < si) {
+  console.error('Markers not found in docs/summer-camp-2026-status.md:', start, end);
+  process.exit(1);
+}
+status = status.slice(0, si) + md + status.slice(ei + end.length);
+writeFileSync(statusPath, status);
+console.log('Updated Lighthouse snapshot in', statusPath);

--- a/src/app/[locale]/camps/summer/SummerCampGuideLeadDialog.tsx
+++ b/src/app/[locale]/camps/summer/SummerCampGuideLeadDialog.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  LOTTERY_GRADES,
+  LOTTERY_INTERESTS,
+  type LotteryGrade,
+  type LotteryInterest,
+} from '@/lib/summer-lottery-keys';
+
+export type GuideLeadCopy = {
+  guideModalTitle: string;
+  guideModalSubtitle: string;
+  parentNameLabel: string;
+  parentNamePlaceholder: string;
+  guideSubmitCta: string;
+};
+
+export type LotteryErrorKind = 'invalid_form' | 'invalid_email' | 'server' | null;
+
+export function SummerCampGuideLeadDialog({
+  open,
+  onOpenChange,
+  copy,
+  lotterySelectClassName,
+  formAriaLabel,
+  parentName,
+  email,
+  childGrade,
+  campInterest,
+  status,
+  errorKind,
+  errorDetail,
+  onParentNameChange,
+  onEmailChange,
+  onChildGradeChange,
+  onCampInterestChange,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  copy: GuideLeadCopy;
+  lotterySelectClassName: string;
+  formAriaLabel: string;
+  parentName: string;
+  email: string;
+  childGrade: LotteryGrade | '';
+  campInterest: LotteryInterest | '';
+  status: 'idle' | 'loading' | 'error';
+  errorKind: LotteryErrorKind;
+  errorDetail: string | null;
+  onParentNameChange: (v: string) => void;
+  onEmailChange: (v: string) => void;
+  onChildGradeChange: (v: LotteryGrade | '') => void;
+  onCampInterestChange: (v: LotteryInterest | '') => void;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  const t = useTranslations('summerCamp');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent id="lead-capture" className="max-h-[min(90vh,720px)] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="font-heading text-xl text-slate-900">{copy.guideModalTitle}</DialogTitle>
+          <DialogDescription id="lead-modal-description" className="text-slate-600">
+            {copy.guideModalSubtitle}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="mt-2 space-y-4" noValidate aria-label={formAriaLabel}>
+          <div className="space-y-2">
+            <Label htmlFor="summer-lead-parent">{copy.parentNameLabel}</Label>
+            <Input
+              id="summer-lead-parent"
+              name="parentName"
+              type="text"
+              autoComplete="name"
+              placeholder={copy.parentNamePlaceholder}
+              value={parentName}
+              onChange={(ev) => onParentNameChange(ev.target.value)}
+              disabled={status === 'loading'}
+              aria-invalid={status === 'error' && errorKind === 'invalid_form'}
+              className="h-11"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="summer-lottery-email">{t('lottery.emailLabel')}</Label>
+            <Input
+              id="summer-lottery-email"
+              type="email"
+              name="email"
+              autoComplete="email"
+              inputMode="email"
+              placeholder={t('lottery.emailPlaceholder')}
+              value={email}
+              onChange={(ev) => onEmailChange(ev.target.value)}
+              disabled={status === 'loading'}
+              aria-invalid={
+                status === 'error' && (errorKind === 'invalid_email' || errorKind === 'invalid_form')
+              }
+              className="h-11"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="summer-lottery-grade">{t('lottery.childGradeLabel')}</Label>
+            <select
+              id="summer-lottery-grade"
+              name="childGrade"
+              value={childGrade}
+              onChange={(ev) => onChildGradeChange(ev.target.value as LotteryGrade | '')}
+              disabled={status === 'loading'}
+              aria-invalid={status === 'error' && errorKind === 'invalid_form'}
+              className={lotterySelectClassName}
+            >
+              <option value="">{t('lottery.gradePlaceholder')}</option>
+              {LOTTERY_GRADES.map((g) => (
+                <option key={g} value={g}>
+                  {t(`lottery.grades.${g}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="summer-lottery-interest">{t('lottery.campInterestLabel')}</Label>
+            <select
+              id="summer-lottery-interest"
+              name="campInterest"
+              value={campInterest}
+              onChange={(ev) => onCampInterestChange(ev.target.value as LotteryInterest | '')}
+              disabled={status === 'loading'}
+              aria-invalid={status === 'error' && errorKind === 'invalid_form'}
+              className={lotterySelectClassName}
+            >
+              <option value="">{t('lottery.interestPlaceholder')}</option>
+              {LOTTERY_INTERESTS.map((key) => (
+                <option key={key} value={key}>
+                  {t(`lottery.interests.${key}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          {status === 'error' && errorKind ? (
+            <p className="text-sm text-red-600" role="alert">
+              {errorKind === 'invalid_email'
+                ? t('lottery.errorInvalidEmail')
+                : errorKind === 'invalid_form'
+                  ? errorDetail ?? t('lottery.errorInvalidForm')
+                  : errorDetail ?? t('lottery.errorGeneric')}
+            </p>
+          ) : null}
+          <Button
+            type="submit"
+            disabled={status === 'loading'}
+            className="h-12 w-full font-bold bg-[#146c43] hover:bg-[#166534] text-white text-base"
+          >
+            {status === 'loading' ? t('lottery.submitting') : copy.guideSubmitCta}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/[locale]/camps/summer/layout.tsx
+++ b/src/app/[locale]/camps/summer/layout.tsx
@@ -4,31 +4,11 @@ import { generateEventSchema, generateBreadcrumbSchema, generateFAQPageSchema } 
 import { CONTACT_INFO } from '@/lib/constants';
 import { absoluteSiteUrl } from '@/lib/publicPath';
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
+import {
+  SUMMER_CAMP_EVENT_END_ISO,
+  SUMMER_CAMP_EVENT_START_ISO,
+} from '@/lib/summer-camp-week-calendar';
 import summerCampFaqData from '../../../../../public/api/mock/en/summer-camp-faq.json';
-
-// Q-SC1–SC4: hardcoded here so FAQPage JSON-LD lands in server HTML (page.tsx is 'use client')
-const SUMMER_CAMP_FAQS = [
-  {
-    question: 'Are STEM summer camps actually worth it, or is it just organised screen time?',
-    answer:
-      'GrowWise summer camps are built around a tangible Friday output. By the end of the week, every student has completed something real — a working game, a programmed robot, a machine learning project, or a written piece ready for sharing. Instructors are subject experts in their program, not general activity supervisors. Small groups with a maximum of 8 students mean every student is actively building throughout the week.',
-  },
-  {
-    question: 'How do I choose the right summer camp for my child if they have never done coding or robotics before?',
-    answer:
-      'Scratch camp is the recommended starting point for students with no coding experience. It uses visual block-based programming and is beginner-friendly from Grade 3. Students who enjoy Minecraft or Roblox but have not coded before typically do well in Roblox camp, which starts from the basics of Lua scripting. Robotics camp is hands-on engineering — no coding prerequisite. If you are unsure which camp fits your child, contact GrowWise before enrolling.',
-  },
-  {
-    question: 'I want a summer camp that teaches real skills and is also engaging — not just lectures. Does GrowWise fit that?',
-    answer:
-      'GrowWise camps are structured around doing, not watching. Students spend the week building a project in their chosen subject. Scratch students code an animated project. Roblox students publish a game. Robotics students build and race a robot. Math Olympiad students work through competition-style problem sets. Young Authors students finish a written piece. Every camp ends with a demo or showcase of what students built that week.',
-  },
-  {
-    question: 'What grades and ages are GrowWise summer camps designed for?',
-    answer:
-      'GrowWise summer camps are available for Grades 1 through 12. Most camps start from Grade 3. Advanced Math camps (Algebra II and Precalculus, and Math Olympiad) are designed for Grades 5 through 12. Each camp page lists the recommended grade range. Half-day and full-day formats are available depending on the camp. Camps are held at 4564 Dublin Blvd, Dublin, CA and serve families from Dublin, Pleasanton, San Ramon, and across the Tri-Valley.',
-  },
-];
 
 export async function generateMetadata({
   params,
@@ -59,8 +39,8 @@ export default async function SummerCampLayout({
     name: 'Summer Camp 2026 - Math, Coding & Robotics',
     description:
       'Enrollment open for GrowWise Summer Camp 2026! Accredited courses in Math, Coding, Robotics, and more. Half-day and full-day camps. Small cohorts. Dublin, CA.',
-    startDate: '2026-06-15T09:00:00-08:00',
-    endDate: '2026-08-08T17:00:00-08:00',
+    startDate: SUMMER_CAMP_EVENT_START_ISO,
+    endDate: SUMMER_CAMP_EVENT_END_ISO,
     location: {
       name: 'GrowWise School',
       address: {
@@ -76,8 +56,8 @@ export default async function SummerCampLayout({
       url: baseUrl,
     },
     image: `${baseUrl}/assets/growwise-logo.png`,
+    // No fixed price: programs use multiple tiers; misleading Offer.price hurts trust signals.
     offers: {
-      price: '249',
       priceCurrency: 'USD',
       availability: 'https://schema.org/InStock',
       url: absoluteSiteUrl('/camps/summer', locale, baseUrl),
@@ -88,7 +68,7 @@ export default async function SummerCampLayout({
 
   const breadcrumbSchema = generateBreadcrumbSchema([
     { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
-    { name: 'Camps', url: absoluteSiteUrl('/camps/summer', locale, baseUrl) },
+    { name: 'Camps', url: absoluteSiteUrl('/camps', locale, baseUrl) },
     { name: 'Summer Camp 2026', url: absoluteSiteUrl('/camps/summer', locale, baseUrl) },
   ]);
 

--- a/src/app/[locale]/camps/summer/page.tsx
+++ b/src/app/[locale]/camps/summer/page.tsx
@@ -12,22 +12,10 @@ import { createLocaleUrl } from '@/components/layout/Header/utils';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { trackSummerCampGuideLead, trackEarlyBirdReveal } from '@/lib/meta-pixel';
-import {
-  LOTTERY_GRADES,
-  LOTTERY_INTERESTS,
   type LotteryGrade,
   type LotteryInterest,
 } from '@/lib/summer-lottery-keys';
-import enMessages from '@/i18n/messages/en.json';
+import canonicalSummerCampEn from '@/i18n/messages/summer-camp-canonical-en.json';
 import {
   SUMMER_CAMP_PROGRAM_GROUP_IDS,
   SUMMER_CAMP_PROGRAM_TRACK_ORDER,
@@ -41,33 +29,15 @@ import {
   summerCampProgramGroupMessagePath,
 } from '@/lib/summer-camp-seo-links';
 
-/** Canonical English hero + conversion copy (en.json). */
-const SUMMER_CAMP_HERO_EN = enMessages.summerCamp.hero;
-type SummerCampConversion = {
-  programGroupsHeading: string;
-  programGroupsSub: string;
-  exploreProgramCta: string;
-  programGroups: Array<{ title: string; outcome: string; ages: string }>;
-  trustBlockHeading: string;
-  trustGoogleRatingLine: string;
-  trustProofStrip: string;
-  trustReviews: Array<{ quote: string; byline: string }>;
-  trustBullets: string[];
-  trustProjectsCta: string;
-  trustProjectsUrl: string;
-  guideModalTitle: string;
-  guideModalSubtitle: string;
-  parentNameLabel: string;
-  parentNamePlaceholder: string;
-  guideSubmitCta: string;
-  finalHeading: string;
-  finalSubtext: string;
-  finalReserveCta: string;
-  finalGuidePdfCta: string;
-  bookingSectionTitle: string;
-  bookingSectionSub: string;
-};
-const SC = (enMessages.summerCamp as { conversion: SummerCampConversion }).conversion;
+/**
+ * Slim English-only hero + conversion copy (~4KB) for this page.
+ * Keeps marketing strings identical on every locale URL; update alongside `en.json` → `summerCamp.hero` / `conversion`.
+ */
+const SUMMER_CAMP_HERO_EN = canonicalSummerCampEn.hero;
+const SC = canonicalSummerCampEn.conversion;
+
+/** Module-scoped default data — avoids per-render `getDefaultSummerCampData()` calls (singleton inside that fn anyway). */
+const DEFAULT_CAMP_DATA = getDefaultSummerCampData();
 
 const ProgramList = dynamic(
   () => import('@/components/camps/SummerCampProgramList').then((m) => ({ default: m.ProgramList })),
@@ -78,10 +48,14 @@ const SummerCampPageFaq = dynamic(
   {
     ssr: false,
     loading: () => (
-      <section className="py-16 md:py-24 bg-white border-t border-slate-200" aria-hidden>
+      <section className="py-16 md:py-24 bg-white border-t border-slate-200" aria-hidden="true">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3">
           {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="h-20 bg-slate-100 rounded-xl animate-pulse" />
+            <div
+              key={i}
+              className="h-20 bg-slate-100 rounded-xl animate-pulse"
+              aria-hidden="true"
+            />
           ))}
         </div>
       </section>
@@ -96,10 +70,16 @@ const SlotsPanel = dynamic(
     loading: () => (
       <div
         className="rounded-2xl border border-slate-200 bg-white/80 p-6 animate-pulse min-h-[320px]"
-        aria-hidden
+        aria-hidden="true"
       />
     ),
   }
+);
+/** Radix Dialog + lead form — separate chunk so initial /camps/summer load avoids Dialog until first open. */
+const SummerCampGuideLeadDialog = dynamic(
+  () =>
+    import('./SummerCampGuideLeadDialog').then((m) => ({ default: m.SummerCampGuideLeadDialog })),
+  { ssr: false }
 );
 
 export type { SummerCampFaqItem };
@@ -133,12 +113,13 @@ export default function SummerCampPage() {
   const t = useTranslations('summerCamp');
   const locale = useLocale();
   const router = useRouter();
-  const _defaultCampData = getDefaultSummerCampData();
-  const [programs, setPrograms] = useState<Program[]>(_defaultCampData.programs);
-  const [olympiadTierConfigs, setOlympiadTierConfigs] = useState<OlympiadTierConfig[]>(_defaultCampData.olympiadTierConfigs);
+  const [programs, setPrograms] = useState<Program[]>(DEFAULT_CAMP_DATA.programs);
+  const [olympiadTierConfigs, setOlympiadTierConfigs] = useState<OlympiadTierConfig[]>(
+    DEFAULT_CAMP_DATA.olympiadTierConfigs
+  );
   // English data is already loaded from the static bundle; no skeleton needed on first render.
   const [programsLoading, setProgramsLoading] = useState(false);
-  const [selectedProgram, setSelectedProgram] = useState<Program | null>(_defaultCampData.programs[0] ?? null);
+  const [selectedProgram, setSelectedProgram] = useState<Program | null>(DEFAULT_CAMP_DATA.programs[0] ?? null);
   const [programTrackFilter, setProgramTrackFilter] = useState<ProgramTrackFilter>('all');
   const [faqs, setFaqs] = useState<SummerCampFaqItem[]>([]);
   const [faqsLoading, setFaqsLoading] = useState(true);
@@ -155,17 +136,26 @@ export default function SummerCampPage() {
   const [faqMount, setFaqMount] = useState(false);
   const [showStickyCta, setShowStickyCta] = useState(false);
   const [guideModalOpen, setGuideModalOpen] = useState(false);
+  /** Load guide dialog chunk only after first open or #lead-capture / #lottery (reduces initial JS). */
+  const [guideLeadDialogMounted, setGuideLeadDialogMounted] = useState(false);
   const guideModalUserDismissedRef = useRef(false);
   /** Timestamp of last programmatic open; null until first open (avoid Date.now()-0 looking “old”). */
   const guideModalOpenedAtRef = useRef<number | null>(null);
   const slotsSectionRef = useRef<HTMLElement>(null);
   const faqSentinelRef = useRef<HTMLDivElement>(null);
+  /** Fires `trackEarlyBirdReveal` at most once per locale after programs are ready (idle + dynamic import). */
+  const earlyBirdRevealFiredForLocaleRef = useRef<string | null>(null);
 
   const openGuideModal = useCallback(() => {
     guideModalUserDismissedRef.current = false;
     guideModalOpenedAtRef.current = Date.now();
+    setGuideLeadDialogMounted(true);
     setGuideModalOpen(true);
   }, []);
+
+  useEffect(() => {
+    if (guideModalOpen) setGuideLeadDialogMounted(true);
+  }, [guideModalOpen]);
 
   const handleGuideModalOpenChange = useCallback((open: boolean) => {
     if (!open) {
@@ -265,10 +255,12 @@ export default function SummerCampPage() {
         }
         return;
       }
-      trackSummerCampGuideLead(lotteryCampInterest, lotteryChildGrade, {
-        em: emailTrim,
-        fn: lotteryParentName.trim(),
-      });
+      void import('@/lib/meta-pixel').then(({ trackSummerCampGuideLead }) =>
+        trackSummerCampGuideLead(lotteryCampInterest, lotteryChildGrade, {
+          em: emailTrim,
+          fn: lotteryParentName.trim(),
+        })
+      );
       const qs = new URLSearchParams({
         interest: lotteryCampInterest,
         grade: lotteryChildGrade,
@@ -293,7 +285,7 @@ export default function SummerCampPage() {
   useEffect(() => {
     // English data is already hydrated from the static bundle — no fetch needed.
     if (locale === 'en') {
-      const p = _defaultCampData.programs;
+      const p = DEFAULT_CAMP_DATA.programs;
       const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= 768;
       setSelectedProgram((prev) => {
         const mapped = prev ? p.find((x) => x.id === prev.id) : undefined;
@@ -338,6 +330,8 @@ export default function SummerCampPage() {
   useEffect(() => {
     if (programsLoading) return;
     let cancelled = false;
+    const narrow =
+      typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches;
     const cancelIdle = scheduleIdleTask(() => {
       if (cancelled) return;
       void (async () => {
@@ -362,7 +356,7 @@ export default function SummerCampPage() {
           if (!cancelled) setFaqsLoading(false);
         }
       })();
-    });
+    }, narrow ? 4000 : 2200);
     return () => {
       cancelled = true;
       cancelIdle();
@@ -370,12 +364,15 @@ export default function SummerCampPage() {
   }, [programsLoading, locale]);
 
   // Warm the slots/cart chunk before first interaction (same module as SlotsPanel).
+  // Phones: defer longer so hero + program thumbnails finish first (mobile Lighthouse / LCP).
   useEffect(() => {
     if (programsLoading) return;
     let cancelled = false;
+    const narrow =
+      typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches;
     const cancelIdle = scheduleIdleTask(() => {
       if (!cancelled) void import('@/components/camps/SummerCampUI');
-    }, 2800);
+    }, narrow ? 5200 : 2800);
     return () => {
       cancelled = true;
       cancelIdle();
@@ -495,7 +492,18 @@ export default function SummerCampPage() {
     return () => io.disconnect();
   }, [locale, faqMount]);
 
-  useEffect(() => { if (!programsLoading) trackEarlyBirdReveal(); }, [programsLoading]);
+  useEffect(() => {
+    if (programsLoading) return;
+    if (earlyBirdRevealFiredForLocaleRef.current === locale) return;
+    const localeWhenScheduled = locale;
+    const narrow =
+      typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches;
+    const cancel = scheduleIdleTask(() => {
+      earlyBirdRevealFiredForLocaleRef.current = localeWhenScheduled;
+      void import('@/lib/meta-pixel').then(({ trackEarlyBirdReveal }) => trackEarlyBirdReveal());
+    }, narrow ? 4000 : 2800);
+    return cancel;
+  }, [programsLoading, locale]);
 
   useEffect(() => {
     const onScroll = () => {
@@ -519,6 +527,7 @@ export default function SummerCampPage() {
       if (h === '#lead-capture' || h === '#lottery') {
         guideModalUserDismissedRef.current = false;
         guideModalOpenedAtRef.current = Date.now();
+        setGuideLeadDialogMounted(true);
         setGuideModalOpen(true);
       }
     };
@@ -532,6 +541,7 @@ export default function SummerCampPage() {
     const h = typeof window !== 'undefined' ? window.location.hash : '';
     if (!guideModalOpen && (h === '#lead-capture' || h === '#lottery')) {
       guideModalOpenedAtRef.current = Date.now();
+      setGuideLeadDialogMounted(true);
       setGuideModalOpen(true);
     }
   }, [guideModalOpen]);
@@ -544,8 +554,11 @@ export default function SummerCampPage() {
       )}
     >
       <main>
-        {/* Hero: single image + overlay, headline → context → price → CTAs → trust → discount */}
-        <section className="relative isolate min-h-[min(70vh,44rem)] w-full overflow-hidden">
+        {/* Hero: compact height so slots grid peeks; mobile keeps primary CTA above the fold */}
+        <section
+          className="relative isolate w-full min-h-[min(48svh,17rem)] max-h-[600px] overflow-hidden md:min-h-[min(40vh,22rem)]"
+          aria-label="Summer camp hero"
+        >
           <div className="absolute inset-0 z-0">
             <Image
               src="/assets/camps/summer-camp-banner.webp"
@@ -553,8 +566,9 @@ export default function SummerCampPage() {
               fill
               priority
               fetchPriority="high"
-              quality={75}
-              sizes="100vw"
+              decoding="async"
+              quality={70}
+              sizes="(max-width: 768px) 100vw, min(1100px, 85vw)"
               className="object-cover object-center select-none"
               draggable={false}
             />
@@ -563,19 +577,19 @@ export default function SummerCampPage() {
           <div
             className={cn(
               'relative z-10 mx-auto flex w-full max-w-[1100px] flex-col justify-center text-left',
-              'px-10 py-10 md:py-[120px] md:pl-20 md:pr-12'
+              'px-5 py-8 sm:px-8 md:px-12 md:py-14 lg:px-16 lg:py-16'
             )}
           >
-            <h1 className="font-heading max-w-[700px] text-[1.625rem] font-bold leading-[1.2] text-white sm:text-[1.875rem] md:text-[2.75rem] lg:text-[3rem]">
+            <h1 className="font-heading max-w-[700px] text-[1.5rem] font-bold leading-[1.15] text-white sm:text-[1.75rem] md:text-[2.25rem] lg:text-[2.625rem]">
               {SUMMER_CAMP_HERO_EN.h1}
             </h1>
-            <p className="mt-3 max-w-[650px] text-lg text-zinc-200 md:text-xl">
+            <p className="mt-2 max-w-[650px] text-base leading-snug text-zinc-100 sm:mt-2.5 md:text-lg md:leading-snug">
               {SUMMER_CAMP_HERO_EN.subhead}
             </p>
-            <div className="mt-6 flex w-full max-w-2xl flex-col gap-3 sm:flex-row sm:items-stretch sm:gap-4">
+            <div className="mt-4 flex w-full max-w-2xl flex-col gap-2.5 sm:mt-5 sm:flex-row sm:items-stretch sm:gap-3 md:gap-4">
               <Link
                 href="#slots-section"
-                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-lg bg-[#10b981] px-7 py-3.5 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#059669] sm:w-auto sm:min-w-[220px] sm:text-base"
+                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-lg bg-[#047857] px-6 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#065f46] sm:w-auto sm:min-w-[220px] sm:px-7 sm:py-3.5 sm:text-base"
               >
                 {SUMMER_CAMP_HERO_EN.primaryCta}
               </Link>
@@ -583,16 +597,17 @@ export default function SummerCampPage() {
                 href={SUMMER_CAMP_HERO_EN.brochurePdf}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex min-h-[40px] w-full items-center justify-center rounded-lg border border-white/90 bg-transparent px-5 py-2.5 text-center text-xs font-medium text-white/95 transition-colors hover:bg-white/10 sm:w-auto sm:min-w-[min(100%,11rem)] sm:max-w-[14rem] sm:text-sm"
+                className="inline-flex min-h-[40px] w-full items-center justify-center rounded-lg border border-white/90 bg-transparent px-4 py-2 text-center text-[11px] font-medium leading-tight text-white transition-colors hover:bg-white/10 sm:min-h-[44px] sm:px-5 sm:py-2.5 sm:text-xs md:text-sm"
                 aria-label={`${SUMMER_CAMP_HERO_EN.secondaryCta.trim()} — ${SUMMER_CAMP_HERO_EN.downloadBrochure}`}
               >
                 {SUMMER_CAMP_HERO_EN.secondaryCta}
               </a>
             </div>
-            <p className="mt-3 max-w-2xl text-xs font-semibold leading-snug text-amber-100 sm:text-sm sm:leading-snug">
+            {/* Below CTAs: hidden on narrow phones so Reserve stays in first viewport; visible sm+ */}
+            <p className="mt-3 hidden max-w-2xl text-xs font-semibold leading-snug text-amber-200 sm:block sm:text-sm sm:leading-snug md:mt-4">
               {SUMMER_CAMP_HERO_EN.urgencyLine}
             </p>
-            <p className="mt-4 max-w-2xl text-[15px] font-medium leading-relaxed text-zinc-200 sm:text-base sm:leading-relaxed">
+            <p className="mt-3 hidden max-w-2xl text-sm font-medium leading-relaxed text-zinc-100 sm:mt-4 sm:block md:text-base md:leading-relaxed">
               {SUMMER_CAMP_HERO_EN.trustMicro}
             </p>
           </div>
@@ -660,6 +675,8 @@ export default function SummerCampPage() {
                         alt="GrowWise"
                         fill
                         sizes="120px"
+                        fetchPriority="low"
+                        decoding="async"
                         className="object-contain object-left"
                         draggable={false}
                       />
@@ -697,8 +714,8 @@ export default function SummerCampPage() {
                         style={
                           programTrackFilter === 'all'
                             ? {
-                                background: '#1D9E75',
-                                border: '1px solid #1D9E75',
+                                background: '#146c43',
+                                border: '1px solid #146c43',
                                 color: 'white',
                               }
                             : {
@@ -727,8 +744,8 @@ export default function SummerCampPage() {
                             style={
                               programTrackFilter === track
                                 ? {
-                                    background: '#1D9E75',
-                                    border: '1px solid #1D9E75',
+                                    background: '#146c43',
+                                    border: '1px solid #146c43',
                                     color: 'white',
                                   }
                                 : {
@@ -750,8 +767,8 @@ export default function SummerCampPage() {
                           style={
                             programTrackFilter === 'fullDay'
                               ? {
-                                  background: '#1D9E75',
-                                  border: '1px solid #1D9E75',
+                                  background: '#146c43',
+                                  border: '1px solid #146c43',
                                   color: 'white',
                                 }
                               : {
@@ -805,7 +822,7 @@ export default function SummerCampPage() {
               <button
                 type="button"
                 onClick={scrollToSlots}
-                className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#10b981] px-7 py-3.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#059669] md:text-base"
+                className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#047857] px-7 py-3.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#065f46] md:text-base"
               >
                 {SC.finalReserveCta}
               </button>
@@ -904,118 +921,45 @@ export default function SummerCampPage() {
         ) : null}
       </main>
 
-      <Dialog open={guideModalOpen} onOpenChange={handleGuideModalOpenChange}>
-        <DialogContent id="lead-capture" className="max-h-[min(90vh,720px)] overflow-y-auto sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="font-heading text-xl text-slate-900">{SC.guideModalTitle}</DialogTitle>
-            <DialogDescription id="lead-modal-description" className="text-slate-600">
-              {SC.guideModalSubtitle}
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleLotterySubmit} className="mt-2 space-y-4" noValidate aria-label={t('guideForm.ariaLabel')}>
-            <div className="space-y-2">
-              <Label htmlFor="summer-lead-parent">{SC.parentNameLabel}</Label>
-              <Input
-                id="summer-lead-parent"
-                name="parentName"
-                type="text"
-                autoComplete="name"
-                placeholder={SC.parentNamePlaceholder}
-                value={lotteryParentName}
-                onChange={(ev) => {
-                  setLotteryParentName(ev.target.value);
-                  clearLotteryError();
-                }}
-                disabled={lotteryStatus === 'loading'}
-                aria-invalid={lotteryStatus === 'error' && lotteryErrorKind === 'invalid_form'}
-                className="h-11"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="summer-lottery-email">{t('lottery.emailLabel')}</Label>
-              <Input
-                id="summer-lottery-email"
-                type="email"
-                name="email"
-                autoComplete="email"
-                inputMode="email"
-                placeholder={t('lottery.emailPlaceholder')}
-                value={lotteryEmail}
-                onChange={(ev) => {
-                  setLotteryEmail(ev.target.value);
-                  clearLotteryError();
-                }}
-                disabled={lotteryStatus === 'loading'}
-                aria-invalid={
-                  lotteryStatus === 'error' &&
-                  (lotteryErrorKind === 'invalid_email' || lotteryErrorKind === 'invalid_form')
-                }
-                className="h-11"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="summer-lottery-grade">{t('lottery.childGradeLabel')}</Label>
-              <select
-                id="summer-lottery-grade"
-                name="childGrade"
-                value={lotteryChildGrade}
-                onChange={(ev) => {
-                  setLotteryChildGrade(ev.target.value as LotteryGrade | '');
-                  clearLotteryError();
-                }}
-                disabled={lotteryStatus === 'loading'}
-                aria-invalid={lotteryStatus === 'error' && lotteryErrorKind === 'invalid_form'}
-                className={lotterySelectClass}
-              >
-                <option value="">{t('lottery.gradePlaceholder')}</option>
-                {LOTTERY_GRADES.map((g) => (
-                  <option key={g} value={g}>
-                    {t(`lottery.grades.${g}`)}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="summer-lottery-interest">{t('lottery.campInterestLabel')}</Label>
-              <select
-                id="summer-lottery-interest"
-                name="campInterest"
-                value={lotteryCampInterest}
-                onChange={(ev) => {
-                  setLotteryCampInterest(ev.target.value as LotteryInterest | '');
-                  clearLotteryError();
-                }}
-                disabled={lotteryStatus === 'loading'}
-                aria-invalid={lotteryStatus === 'error' && lotteryErrorKind === 'invalid_form'}
-                className={lotterySelectClass}
-              >
-                <option value="">{t('lottery.interestPlaceholder')}</option>
-                {LOTTERY_INTERESTS.map((key) => (
-                  <option key={key} value={key}>
-                    {t(`lottery.interests.${key}`)}
-                  </option>
-                ))}
-              </select>
-            </div>
-            {lotteryStatus === 'error' && lotteryErrorKind ? (
-              <p className="text-sm text-red-600" role="alert">
-                {lotteryErrorKind === 'invalid_email'
-                  ? t('lottery.errorInvalidEmail')
-                  : lotteryErrorKind === 'invalid_form'
-                    ? lotteryErrorDetail ?? t('lottery.errorInvalidForm')
-                    : lotteryErrorDetail ?? t('lottery.errorGeneric')}
-              </p>
-            ) : null}
-            <Button
-              type="submit"
-              disabled={lotteryStatus === 'loading'}
-              className="h-12 w-full font-bold bg-[#1D9E75] hover:bg-[#178a66] text-white text-base"
-            >
-              {lotteryStatus === 'loading' ? t('lottery.submitting') : SC.guideSubmitCta}
-            </Button>
-          </form>
-        </DialogContent>
-      </Dialog>
+      {guideLeadDialogMounted ? (
+        <SummerCampGuideLeadDialog
+          open={guideModalOpen}
+          onOpenChange={handleGuideModalOpenChange}
+          copy={{
+            guideModalTitle: SC.guideModalTitle,
+            guideModalSubtitle: SC.guideModalSubtitle,
+            parentNameLabel: SC.parentNameLabel,
+            parentNamePlaceholder: SC.parentNamePlaceholder,
+            guideSubmitCta: SC.guideSubmitCta,
+          }}
+          formAriaLabel={t('guideForm.ariaLabel')}
+          lotterySelectClassName={lotterySelectClass}
+          parentName={lotteryParentName}
+          email={lotteryEmail}
+          childGrade={lotteryChildGrade}
+          campInterest={lotteryCampInterest}
+          status={lotteryStatus}
+          errorKind={lotteryErrorKind}
+          errorDetail={lotteryErrorDetail}
+          onParentNameChange={(v) => {
+            setLotteryParentName(v);
+            clearLotteryError();
+          }}
+          onEmailChange={(v) => {
+            setLotteryEmail(v);
+            clearLotteryError();
+          }}
+          onChildGradeChange={(v) => {
+            setLotteryChildGrade(v);
+            clearLotteryError();
+          }}
+          onCampInterestChange={(v) => {
+            setLotteryCampInterest(v);
+            clearLotteryError();
+          }}
+          onSubmit={handleLotterySubmit}
+        />
+      ) : null}
 
       {/* Sticky conversion bar — reserve vs guide (hidden while guide modal is open) */}
       {showStickyCta && !guideModalOpen ? (
@@ -1024,7 +968,7 @@ export default function SummerCampPage() {
             <button
               type="button"
               onClick={scrollToSlots}
-              className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#10b981] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#059669] sm:w-auto md:text-base"
+              className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#047857] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#065f46] sm:w-auto md:text-base"
             >
               {SC.finalReserveCta}
             </button>

--- a/src/app/api/summer-camp-lottery/route.ts
+++ b/src/app/api/summer-camp-lottery/route.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
 import { NextResponse } from 'next/server';
 import { CONTACT_INFO } from '@/lib/constants';
 import {
@@ -5,7 +7,7 @@ import {
   isBrevoTransactionalReady,
   sendBrevoTransactionalEmail,
 } from '@/lib/brevo';
-import { sendEmail, type SendEmailResult } from '@/lib/email';
+import { sendEmail, type EmailAttachment, type SendEmailResult } from '@/lib/email';
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
 import {
   buildCampGuidePdfUrl,
@@ -86,12 +88,38 @@ const BREVO_REPLY_TO = { email: CONTACT_INFO.email, name: 'GrowWise' } as const;
 
 const BREVO_RETRY_DELAY_MS = 450;
 
+const SUMMER_CAMP_BROCHURE_REL_PATH = path.join(
+  'public',
+  'assets',
+  'camps',
+  'SummerCampBrochure.pdf'
+);
+
+async function loadSummerCampBrochureAttachment(): Promise<EmailAttachment | null> {
+  try {
+    const abs = path.join(process.cwd(), SUMMER_CAMP_BROCHURE_REL_PATH);
+    const content = await readFile(abs);
+    return {
+      filename: 'GrowWise-Summer-Camp-Guide.pdf',
+      content,
+      contentType: 'application/pdf',
+    };
+  } catch (err) {
+    console.warn(
+      '[summer-camp-guide] Could not read brochure PDF for attachment; email will be link-only.',
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
 /** Try Brevo (with one retry — cold starts / transient 5xx); then SMTP if still failing. */
 async function sendCampTransactionalWithFallback(opts: {
   to: string;
   subject: string;
   html: string;
   text: string;
+  attachments?: EmailAttachment[];
 }): Promise<SendEmailResult> {
   if (isBrevoTransactionalReady()) {
     let lastErr: string | undefined;
@@ -122,6 +150,7 @@ async function sendCampTransactionalWithFallback(opts: {
     html: opts.html,
     text: opts.text,
     replyTo: BREVO_REPLY_TO.email,
+    ...(opts.attachments?.length ? { attachments: opts.attachments } : {}),
   });
 }
 
@@ -173,6 +202,8 @@ export async function POST(request: Request) {
     const pdfUrl = buildCampGuidePdfUrl(siteUrl);
     const reserveUrl = buildReserveSpotUrl(siteUrl, localeSeg);
     const openPixelUrl = buildEmailOpenPixelUrl(siteUrl);
+    const brochureAttachment = await loadSummerCampBrochureAttachment();
+    const guideAttachments = brochureAttachment ? [brochureAttachment] : undefined;
 
     const interestKey = campInterest as InterestKey;
     const recHtml = recommendedProgramTrackHtml(interestKey);
@@ -185,7 +216,11 @@ export async function POST(request: Request) {
       <div style="font-family: Arial, Helvetica, sans-serif; max-width: 600px; margin: 0 auto; color: #1e293b; line-height: 1.6;">
         <p style="margin: 0 0 16px;">Hi ${greetingName},</p>
         <p style="margin: 0 0 20px;">Thanks for your interest in GrowWise Summer Camps.</p>
-        <p style="margin: 0 0 12px;">Here’s your full camp guide with program details and schedules:</p>
+        <p style="margin: 0 0 12px;">${
+          brochureAttachment
+            ? 'Your full camp guide with program details and schedules is <strong>attached</strong> to this email (PDF). If the attachment does not show up, use this link:'
+            : 'Here’s your full camp guide with program details and schedules:'
+        }</p>
         <p style="margin: 0 0 20px;">
           <a href="${escapeHtml(pdfUrl)}" target="_blank" rel="noopener noreferrer" style="color: #1F396D; font-weight: bold;">👉 Camp Guide (PDF, opens in new tab)</a>
         </p>
@@ -221,7 +256,9 @@ export async function POST(request: Request) {
       '',
       'Thanks for your interest in GrowWise Summer Camps.',
       '',
-      'Here’s your full camp guide with program details and schedules:',
+      brochureAttachment
+        ? 'Your full camp guide (PDF) is attached to this email. If you do not see it, open this link:'
+        : 'Here’s your full camp guide with program details and schedules (open the link):',
       pdfUrl,
       '',
       '• AI & Coding',
@@ -264,6 +301,7 @@ export async function POST(request: Request) {
       subject: userSubject,
       html: userHtml,
       text: userText,
+      ...(guideAttachments ? { attachments: guideAttachments } : {}),
     });
 
     if (!userResult.success) {

--- a/src/components/camps/SummerCampProgramList.tsx
+++ b/src/components/camps/SummerCampProgramList.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 import { Check } from 'lucide-react';
 import type { Program } from '@/lib/summer-camp-data';
-import { trackCampView } from '@/lib/meta-pixel';
 import {
   getSummerCampProgramTrack,
   orderProgramsBySummerCampTrack,
@@ -42,18 +41,18 @@ const SummerCampProgramPickCard = memo(function SummerCampProgramPickCard({
   onSelect,
   imageSizes,
   imageWrapperClassName,
-  imagePriority,
 }: {
   program: Program;
   isSelected: boolean;
   onSelect: (program: Program) => void;
   imageSizes: string;
   imageWrapperClassName: string;
-  imagePriority: boolean;
 }) {
   const t = useTranslations('summerCamp');
   const handleClick = useCallback(() => {
-    trackCampView(program.title, program.category);
+    void import('@/lib/meta-pixel').then(({ trackCampView }) =>
+      trackCampView(program.title, program.category)
+    );
     onSelect(program);
   }, [onSelect, program]);
 
@@ -76,8 +75,8 @@ const SummerCampProgramPickCard = memo(function SummerCampProgramPickCard({
           alt={`${program.title}: ${program.description}`}
           fill
           sizes={imageSizes}
-          quality={75}
-          priority={imagePriority}
+          quality={70}
+          decoding="async"
           className="object-cover transition-transform duration-500 min-[769px]:group-hover:scale-105"
           draggable={false}
           unoptimized={/^https?:\/\//i.test(program.image)}
@@ -122,11 +121,6 @@ export const ProgramList = memo(function ProgramList({
   const list = programs ?? [];
   const ordered = useMemo(() => orderProgramsBySummerCampTrack(list), [list]);
   const groups = useMemo(() => groupProgramsByTrack(ordered), [ordered]);
-  const globalIndexById = useMemo(() => {
-    const m = new Map<string, number>();
-    ordered.forEach((p, i) => m.set(p.id, i));
-    return m;
-  }, [ordered]);
 
   const sectionHeading = (track: SummerCampProgramTrack | 'unknown') => {
     switch (track) {
@@ -152,7 +146,6 @@ export const ProgramList = memo(function ProgramList({
             <ul className="grid grid-cols-1 gap-3 list-none p-0 m-0" aria-label={sectionHeading(group.track)}>
               {group.programs.map((program) => {
                 const isSelected = selectedProgramId === program.id;
-                const gIdx = globalIndexById.get(program.id) ?? 0;
                 const seo = getSummerCampProgramSeoLink(program.id);
                 return (
                   <li
@@ -165,7 +158,6 @@ export const ProgramList = memo(function ProgramList({
                       onSelect={onSelectProgram}
                       imageSizes="(max-width:768px) 96vw, 100vw"
                       imageWrapperClassName="aspect-[650/450]"
-                      imagePriority={gIdx < 2}
                     />
                     {seo ? (
                       <Link
@@ -184,8 +176,7 @@ export const ProgramList = memo(function ProgramList({
         <p className="text-center">
           <a
             href="#lead-capture"
-            className="text-[13px] font-medium"
-            style={{ color: '#0F6E56' }}
+            className="text-[13px] font-medium text-[#065f46]"
           >
             {t('mobile.lotteryLink')}
           </a>
@@ -206,7 +197,6 @@ export const ProgramList = memo(function ProgramList({
                 const isSelected = selectedProgramId === program.id;
                 const hasOddCount = group.programs.length % 2 !== 0;
                 const isLastAndAlone = hasOddCount && idx === group.programs.length - 1;
-                const gIdx = globalIndexById.get(program.id) ?? 0;
                 const seo = getSummerCampProgramSeoLink(program.id);
                 return (
                   <li
@@ -219,7 +209,6 @@ export const ProgramList = memo(function ProgramList({
                       onSelect={onSelectProgram}
                       imageSizes="(min-width: 1024px) 24vw, (min-width: 769px) 42vw, 100vw"
                       imageWrapperClassName={isLastAndAlone ? 'h-[200px]' : 'aspect-[650/450]'}
-                      imagePriority={gIdx < 2}
                     />
                     {seo ? (
                       <Link

--- a/src/components/camps/SummerCampTrustBlock.tsx
+++ b/src/components/camps/SummerCampTrustBlock.tsx
@@ -46,15 +46,17 @@ export function SummerCampTrustBlock({
               key={`trust-review-${index}`}
               className="flex h-full flex-col rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm md:p-6"
             >
-              <span className="text-base leading-none text-amber-500" aria-hidden="true">
-                ★★★★★
-              </span>
-              <p className="mt-3 flex-1 text-sm font-normal leading-relaxed text-slate-800 md:text-[15px]">
-                &ldquo;{review.quote}&rdquo;
-              </p>
-              <p className="mt-4 text-xs font-medium leading-snug text-slate-600 md:text-[13px]">
-                {review.byline}
-              </p>
+              <blockquote className="m-0 flex flex-1 flex-col border-0 p-0">
+                <span className="text-base leading-none text-amber-500" aria-hidden="true">
+                  ★★★★★
+                </span>
+                <p className="mt-3 flex-1 text-sm font-normal leading-relaxed text-slate-800 md:text-[15px]">
+                  &ldquo;{review.quote}&rdquo;
+                </p>
+                <footer className="mt-4 text-xs font-medium leading-snug text-slate-600 md:text-[13px]">
+                  {review.byline}
+                </footer>
+              </blockquote>
             </li>
           ))}
         </ul>
@@ -77,6 +79,7 @@ export function SummerCampTrustBlock({
             href={projectsCtaHref}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`${projectsCta} (opens in new tab)`}
             className="inline-flex text-sm font-semibold text-[#1F396D] underline-offset-4 transition-colors hover:text-[#152a52] hover:underline"
           >
             {projectsCta}

--- a/src/components/camps/SummerCampUI.tsx
+++ b/src/components/camps/SummerCampUI.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/lib/summer-camp-data';
 import { useCart } from '@/components/gw/CartContext';
 import { Button } from '@/components/ui/button';
-import { X, Clock, Info, CalendarDays, CheckCircle2 } from 'lucide-react';
+import { X, Clock, Info, CalendarDays, CheckCircle2, MapPin } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -28,13 +28,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
-import { trackEnrollClick } from '@/lib/meta-pixel';
 import { createLocaleUrl } from '@/components/layout/Header/utils';
 import {
   getRoboticsFullDaySeoLink,
   getSummerCampProgramSeoLink,
   summerCampSeoMessagePath,
 } from '@/lib/summer-camp-seo-links';
+import { formatAdvMathWeekSlotHeading } from '@/lib/adv-math-week-sessions';
+import {
+  formatCampWeekSlotHeading,
+  formatOlympiadTier2SlotHeading,
+  SUMMER_CAMP_JULY4_NOTE,
+  SUMMER_CAMP_SEASON_RANGE_TEXT,
+} from '@/lib/summer-camp-week-calendar';
 
 function InfoModal({
   program,
@@ -124,6 +130,37 @@ function InfoModal({
               </div>
             </div>
 
+            {/* Camp season + format (shared calendar; delivery from program JSON) */}
+            <div className="flex flex-wrap items-center gap-4 px-5 py-3 bg-white border-b border-slate-100">
+              <div className="flex items-center gap-2 text-[#1F396D]">
+                <CalendarDays className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                <div>
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-slate-600">{t('infoModal.campDatesLabel')}</p>
+                  <p className="text-xs font-bold text-slate-900">{SUMMER_CAMP_SEASON_RANGE_TEXT}</p>
+                </div>
+              </div>
+              <div className="w-px h-8 bg-slate-200 max-[360px]:hidden" aria-hidden="true" />
+              <div className="flex items-center gap-2 text-[#1F396D]">
+                <CalendarDays className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                <div>
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-slate-600">{t('infoModal.seasonNoteLabel')}</p>
+                  <p className="text-xs font-bold text-slate-900">{SUMMER_CAMP_JULY4_NOTE}</p>
+                </div>
+              </div>
+              {details.deliverySummary ? (
+                <>
+                  <div className="w-px h-8 bg-slate-200 max-[360px]:hidden" aria-hidden="true" />
+                  <div className="flex items-center gap-2 text-[#1F396D]">
+                    <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-wider text-slate-600">{t('infoModal.deliveryLabel')}</p>
+                      <p className="text-xs font-bold text-slate-900">{details.deliverySummary}</p>
+                    </div>
+                  </div>
+                </>
+              ) : null}
+            </div>
+
             {/* What's included */}
             <div className="px-5 py-4">
               <p className="text-[10px] font-black uppercase tracking-widest text-slate-700 mb-3">
@@ -191,18 +228,18 @@ function SlotRow({
       `}
     >
       <div className="space-y-0.5">
-        <div className="font-bold text-slate-800 text-sm">{slot.label}</div>
-        <div className="text-[9px] text-slate-600 flex items-center gap-2 font-medium uppercase tracking-wider">
+        <div className="font-bold text-slate-800 text-sm leading-snug">{slot.label}</div>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[9px] font-medium uppercase tracking-wider text-slate-600">
           <span className="flex items-center gap-1">
             <span
               aria-hidden="true"
-              className={`w-1.5 h-1.5 rounded-full ${
+              className={`w-1.5 h-1.5 flex-shrink-0 rounded-full ${
                 slot.format === 'Online' ? 'bg-sky-400' : 'bg-amber-400'
               }`}
             />
             {slot.format}
           </span>
-          <span>{slot.time}</span>
+          <span className="font-semibold normal-case tracking-normal text-slate-700">{slot.time}</span>
         </div>
       </div>
       <div className="flex items-center gap-3 mt-3 sm:mt-0">
@@ -299,7 +336,9 @@ export function SlotsPanel({
 
   const handleAdd = (level: Level, slot: Slot) => {
     if (summerCampItemIds.has(slot.id)) return;
-    trackEnrollClick(program.title, slot.price);
+    void import('@/lib/meta-pixel').then(({ trackEnrollClick }) =>
+      trackEnrollClick(program.title, slot.price)
+    );
     addItem(toGlobalCartItem(program, level, slot));
   };
 
@@ -332,15 +371,15 @@ export function SlotsPanel({
     const priceByProgramAndFormat = level.priceByProgramAndFormat;
     const price =
       (priceByProgramAndFormat?.[advMathProgram]?.[format] ?? level.slots[0]?.price) ?? 0;
-    return level.slots.map((s) => ({
+    return level.slots.map((s, i) => ({
       ...s,
       id: `${s.id}-${advMathMode}-${advMathProgram}`,
-      label: `${s.label} — ${programLabels[advMathProgram]}, ${modeLabels[advMathMode]}`,
+      label: `${formatAdvMathWeekSlotHeading(advMathProgram, i)} — ${programLabels[advMathProgram]}`,
       format,
       time: timeMap[advMathMode] ?? '9:00 AM - 12:00 PM',
       price,
     }));
-  }, [isAdvMath, program, advMathMode, advMathProgram, programLabels, modeLabels]);
+  }, [isAdvMath, program, advMathMode, advMathProgram, programLabels]);
 
   const aiEntrepreneurSlots: Slot[] = useMemo(() => {
     if (!isAiEntrepreneur || !program.levels[0]) return [];
@@ -354,12 +393,12 @@ export function SlotsPanel({
     return level.slots.map((s) => ({
       ...s,
       id: `${s.id}-${aiEntrepreneurMode}`,
-      label: `${s.label} — ${modeLabels[aiEntrepreneurMode]}`,
+      label: s.label,
       format,
       time: timeMap[aiEntrepreneurMode] ?? '9:00 AM - 12:00 PM',
       price,
     }));
-  }, [isAiEntrepreneur, program, aiEntrepreneurMode, modeLabels]);
+  }, [isAiEntrepreneur, program, aiEntrepreneurMode]);
 
   const scratchSlots: Slot[] = useMemo(() => {
     if (!isScratch || !program.levels[0]) return [];
@@ -373,12 +412,12 @@ export function SlotsPanel({
     return level.slots.map((s) => ({
       ...s,
       id: `${s.id}-${scratchMode}`,
-      label: `${s.label} — ${modeLabels[scratchMode]}`,
+      label: s.label,
       format,
       time: timeMap[scratchMode] ?? '9:00 AM - 12:00 PM',
       price,
     }));
-  }, [isScratch, program, scratchMode, modeLabels]);
+  }, [isScratch, program, scratchMode]);
 
   const robloxSlots: Slot[] = useMemo(() => {
     if (!isRoblox || !program.levels[0]) return [];
@@ -392,12 +431,12 @@ export function SlotsPanel({
     return level.slots.map((s) => ({
       ...s,
       id: `${s.id}-${robloxMode}`,
-      label: `${s.label} — ${modeLabels[robloxMode]}`,
+      label: s.label,
       format,
       time: timeMap[robloxMode] ?? '9:00 AM - 12:00 PM',
       price,
     }));
-  }, [isRoblox, program, robloxMode, modeLabels]);
+  }, [isRoblox, program, robloxMode]);
 
   const olympiadTierConfig = useMemo(
     () => (olympiadTierConfigs ?? []).find((c) => c.id === olympiadTier),
@@ -411,22 +450,20 @@ export function SlotsPanel({
     const format = (formatMap[olympiadMode] ?? 'In-Person') as Slot['format'];
     const price = olympiadTierConfig.priceByFormat[format];
     return Array.from({ length: olympiadTierConfig.slotCount }).map((_, i) => {
-      const baseLabel =
+      const weekHeading =
         olympiadTierConfig.weeksPerSlot === 1
-          ? t('slotLabel.singleWeek', { week: i + 1 })
-          : t('slotLabel.weekRange', {
-              start: i * 2 + 1,
-              end: i * 2 + 2,
-            });
+          ? formatCampWeekSlotHeading(i)
+          : formatOlympiadTier2SlotHeading(i);
+      const tierName = tierLabels[olympiadTierConfig.id].name;
       return {
         id: `${olympiadTierConfig.slotId(i)}-${olympiadMode}`,
-        label: `${baseLabel} — ${tierLabels[olympiadTierConfig.id].name}, ${modeLabels[olympiadMode]}`,
+        label: `${weekHeading} — ${tierName}`,
         time: timeMap[olympiadMode] ?? '9:00 AM - 12:00 PM',
         format,
         price,
       };
     });
-  }, [isMathOlympiad, olympiadTierConfig, olympiadMode, t, tierLabels, modeLabels]);
+  }, [isMathOlympiad, olympiadTierConfig, olympiadMode, tierLabels]);
 
   return (
     <div

--- a/src/components/camps/__tests__/summer-camp-data.test.ts
+++ b/src/components/camps/__tests__/summer-camp-data.test.ts
@@ -191,6 +191,20 @@ describe('hydrateSummerCampData (programs)', () => {
     expect(adv!.category).toBe('Half-Day Camps');
   });
 
+  it('hydrated slots use Week N (date range) headings from expandSlotTemplate', () => {
+    const adv = SUMMER_CAMP_PROGRAMS.find((p) => p.id === 'adv-math')!;
+    const slots = adv.levels[0]?.slots ?? [];
+    expect(slots[0]?.label).toBe('Week 1 (Jun 8–12, 2026)');
+    expect(slots[7]?.label).toBe('Week 8 (Jul 27–31, 2026)');
+  });
+
+  it('every program details includes deliverySummary for the info modal', () => {
+    SUMMER_CAMP_PROGRAMS.forEach((p) => {
+      expect(typeof p.details.deliverySummary).toBe('string');
+      expect((p.details.deliverySummary as string).length).toBeGreaterThan(3);
+    });
+  });
+
   it('math olympiad program exists and is in Half-Day Camps', () => {
     const olympiad = SUMMER_CAMP_PROGRAMS.find((p) => p.id === 'math-olympiad');
     expect(olympiad).toBeDefined();

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -723,7 +723,10 @@
       "removeItem": "Remove item"
     },
     "infoModal": {
-      "detailsUnavailable": "Details are not available for this program."
+      "detailsUnavailable": "Details are not available for this program.",
+      "campDatesLabel": "Camp dates",
+      "seasonNoteLabel": "Calendar",
+      "deliveryLabel": "Format"
     },
     "filter": {
       "allCamps": "All Camps",

--- a/src/i18n/messages/summer-camp-canonical-en.json
+++ b/src/i18n/messages/summer-camp-canonical-en.json
@@ -1,0 +1,70 @@
+{
+  "hero": {
+    "h1": "This summer, your child builds something real.",
+    "subhead": "Coding, AI, Robotics, Game Dev & Math Camps · Grades 1–12 · Dublin CA · Limited seats",
+    "primaryCta": "Reserve a Spot →",
+    "secondaryCta": "Get Camp Guide (PDF, opens in new tab) →",
+    "brochurePdf": "/assets/camps/SummerCampBrochure.pdf",
+    "trustMicro": "98% parent satisfaction · Max 8 students per class · Expert instructors",
+    "urgencyLine": "15% early-bird ends April 30 · Limited seats per week",
+    "downloadBrochure": "View 2026 brochure PDF (new tab)",
+    "earlyBirdPromoBefore": "15% off for early bird on any course through April 30 — Use code: "
+  },
+  "conversion": {
+    "programGroupsHeading": "Start with one track",
+    "programGroupsSub": "Same programs as in the booking grid above—grouped by track with quick links to each camp page.",
+    "exploreProgramCta": "Explore Program →",
+    "programGroups": [
+      {
+        "title": "Academic Camp",
+        "outcome": "Math Olympiad (AMC8 / MOEMS) and High School Math—structured intensives that match how we run camps year-round.",
+        "ages": "Grades 3–12"
+      },
+      {
+        "title": "AI & Game Development",
+        "outcome": "AI coding, app development, Roblox, Scratch, and robotics-style builds—project-based camps led by expert instructors.",
+        "ages": "Grades 3–12"
+      },
+      {
+        "title": "Creative Writing",
+        "outcome": "Young Authors—craft stories and publish-ready pieces in a small, supportive cohort.",
+        "ages": "Grades 3–12"
+      }
+    ],
+    "trustBlockHeading": "Real Results Parents Trust",
+    "trustGoogleRatingLine": "Rated 4.9⭐ on Google · 40+ reviews",
+    "trustProofStrip": "325+ students enrolled · 98% parent satisfaction · 40+ student projects showcased",
+    "trustBullets": [
+      "Max 8 students per class — personalized attention",
+      "Experienced instructors in coding, math & robotics",
+      "Serving Dublin, Pleasanton, San Ramon & Tri-Valley families"
+    ],
+    "trustReviews": [
+      {
+        "quote": "GrowWise has been such a wonderful experience for my daughter. Her tutor has been incredibly patient, encouraging, and attentive to her individual learning needs. Since starting with GrowWise, I’ve noticed a big improvement in her confidence, focus, and overall understanding of subjects that used to be challenging for her. The lessons are engaging and tailored to her pace, which has made learning enjoyable instead of stressful. I’m truly grateful for the positive impact GrowWise has had on her academic growth and motivation.",
+        "byline": "— Parent · 5★ Google review"
+      },
+      {
+        "quote": "My son and I had a very positive experience with Growwise recently. My son attended the half-day python coding camp (Level 1 & 2), which was his first formal exposure to programming. Thanks to the small class size and the teacher's personalized approach, he was able to grasp the fundamentals of python and enjoyed working on the assignments and demo projects such as the Hangman game. The teacher provided prompt feedback after each session and offered helpful suggestions for future learning opportunities. I strongly recommend this program!",
+        "byline": "— Roger Jiang · Google review"
+      },
+      {
+        "quote": "My daughter joined Growwise to begin learning the basics of coding, starting with Roblox development. She had a fantastic experience throughout the program! The classes were engaging, and the teacher did a great job keeping the students interested and motivated. It was wonderful to see her enjoying herself while learning something so valuable.",
+        "byline": "— Parent · Google review"
+      }
+    ],
+    "trustProjectsCta": "See Student Projects →",
+    "trustProjectsUrl": "https://thegrowwise.com/nextgen-hub/",
+    "guideModalTitle": "Get your camp guide + 15% off",
+    "guideModalSubtitle": "Tell us a bit about your child—we’ll email the PDF and early-bird details.",
+    "parentNameLabel": "Parent name",
+    "parentNamePlaceholder": "Your full name",
+    "guideSubmitCta": "Get Guide + 15% Off →",
+    "finalHeading": "Still not sure which summer camp is right for your child?",
+    "finalSubtext": "Limited seats per batch · 15% early-bird ends April 30",
+    "finalReserveCta": "Reserve a Spot →",
+    "finalGuidePdfCta": "Get guide + 15% off (by email) →",
+    "bookingSectionTitle": "Choose your camp & reserve a week",
+    "bookingSectionSub": "Pick a program, then select your week and checkout."
+  }
+}

--- a/src/lib/adv-math-week-sessions.test.ts
+++ b/src/lib/adv-math-week-sessions.test.ts
@@ -1,0 +1,36 @@
+import {
+  ADV_MATH_ALGEBRA_WEEK_SESSIONS,
+  ADV_MATH_PRECAL_WEEK_SESSIONS,
+  formatAdvMathWeekSessions,
+  formatAdvMathWeekSlotHeading,
+  getAdvMathSlotDateLabel,
+} from '@/lib/adv-math-week-sessions';
+
+describe('adv-math-week-sessions', () => {
+  it('has eight weeks for each track', () => {
+    expect(ADV_MATH_ALGEBRA_WEEK_SESSIONS).toHaveLength(8);
+    expect(ADV_MATH_PRECAL_WEEK_SESSIONS).toHaveLength(8);
+  });
+
+  it('formats same-month algebra week 1', () => {
+    expect(formatAdvMathWeekSessions(ADV_MATH_ALGEBRA_WEEK_SESSIONS[0]!)).toBe('Jun 8, 10, 12');
+  });
+
+  it('formats algebra week spanning June–July', () => {
+    expect(formatAdvMathWeekSessions(ADV_MATH_ALGEBRA_WEEK_SESSIONS[3]!)).toBe('Jun 29, Jul 1, 3');
+  });
+
+  it('formats precal week 1', () => {
+    expect(formatAdvMathWeekSessions(ADV_MATH_PRECAL_WEEK_SESSIONS[0]!)).toBe('Jun 9, 10, 11');
+  });
+
+  it('getAdvMathSlotDateLabel matches week index', () => {
+    expect(getAdvMathSlotDateLabel('algebra', 7)).toBe('Jul 27, 29, 31');
+    expect(getAdvMathSlotDateLabel('precalculus', 7)).toBe('Jul 28, 29, 30');
+  });
+
+  it('formatAdvMathWeekSlotHeading matches camp-wide Week N (…) pattern', () => {
+    expect(formatAdvMathWeekSlotHeading('algebra', 0)).toBe('Week 1 (Jun 8, 10, 12)');
+    expect(formatAdvMathWeekSlotHeading('precalculus', 0)).toBe('Week 1 (Jun 9, 10, 11)');
+  });
+});

--- a/src/lib/adv-math-week-sessions.ts
+++ b/src/lib/adv-math-week-sessions.ts
@@ -1,0 +1,114 @@
+/**
+ * Advanced Math (summer): per-week session dates by track.
+ * Algebra II: Mon / Wed / Fri. Precalculus: Tue / Wed / Thu.
+ * Source: 2026 camp schedule (8 weeks).
+ */
+
+/** Matches `AdvMathProgramKey` in summer-camp-data (kept local to avoid a runtime import cycle). */
+export type AdvMathSessionProgram = 'algebra' | 'precalculus';
+
+/** ISO date (YYYY-MM-DD) for each of the three sessions in that enrollment week. */
+export type AdvMathWeekSessions = readonly [string, string, string];
+
+/** Summer Adv Algebra 2 — Mon/Wed/Fri pattern per week. */
+export const ADV_MATH_ALGEBRA_WEEK_SESSIONS: readonly AdvMathWeekSessions[] = [
+  ['2026-06-08', '2026-06-10', '2026-06-12'],
+  ['2026-06-15', '2026-06-17', '2026-06-18'],
+  ['2026-06-22', '2026-06-24', '2026-06-26'],
+  ['2026-06-29', '2026-07-01', '2026-07-03'],
+  ['2026-07-06', '2026-07-08', '2026-07-10'],
+  ['2026-07-13', '2026-07-15', '2026-07-17'],
+  ['2026-07-20', '2026-07-22', '2026-07-24'],
+  ['2026-07-27', '2026-07-29', '2026-07-31'],
+] as const;
+
+/** Summer PreCal — Tue/Wed/Thu pattern per week. */
+export const ADV_MATH_PRECAL_WEEK_SESSIONS: readonly AdvMathWeekSessions[] = [
+  ['2026-06-09', '2026-06-10', '2026-06-11'],
+  ['2026-06-16', '2026-06-17', '2026-06-18'],
+  ['2026-06-23', '2026-06-24', '2026-06-25'],
+  ['2026-06-30', '2026-07-01', '2026-07-02'],
+  ['2026-07-07', '2026-07-08', '2026-07-09'],
+  ['2026-07-14', '2026-07-15', '2026-07-16'],
+  ['2026-07-21', '2026-07-22', '2026-07-23'],
+  ['2026-07-28', '2026-07-29', '2026-07-30'],
+] as const;
+
+const MONTH_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+
+function parseIso(iso: string): { month: number; day: number } {
+  const parts = iso.split('-');
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  if (!month || !day || month < 1 || month > 12) {
+    throw new Error(`Invalid ISO date: ${iso}`);
+  }
+  return { month, day };
+}
+
+/** e.g. "Jun 8" */
+function monthDay(iso: string): string {
+  const { month, day } = parseIso(iso);
+  return `${MONTH_SHORT[month - 1]} ${day}`;
+}
+
+/**
+ * Compact label: same month → "Jun 8, 10, 12"; mixed months → "Jun 30, Jul 1, 2".
+ */
+export function formatAdvMathWeekSessions(week: AdvMathWeekSessions): string {
+  const [a, b, c] = week;
+  const ma = parseIso(a).month;
+  const mb = parseIso(b).month;
+  const mc = parseIso(c).month;
+  const da = parseIso(a).day;
+  const db = parseIso(b).day;
+  const dc = parseIso(c).day;
+
+  if (ma === mb && mb === mc) {
+    return `${MONTH_SHORT[ma - 1]} ${da}, ${db}, ${dc}`;
+  }
+  /* e.g. Jun 29 + Jul 1 + Jul 3 → "Jun 29, Jul 1, 3" */
+  if (mb === mc && ma !== mb) {
+    return `${MONTH_SHORT[ma - 1]} ${da}, ${MONTH_SHORT[mb - 1]} ${db}, ${dc}`;
+  }
+  if (ma === mb) {
+    return `${MONTH_SHORT[ma - 1]} ${da}, ${db}, ${MONTH_SHORT[mc - 1]} ${dc}`;
+  }
+  return `${monthDay(a)}, ${monthDay(b)}, ${monthDay(c)}`;
+}
+
+export function getAdvMathWeekSessions(
+  program: AdvMathSessionProgram,
+  weekIndex0: number
+): AdvMathWeekSessions | undefined {
+  const rows =
+    program === 'algebra' ? ADV_MATH_ALGEBRA_WEEK_SESSIONS : ADV_MATH_PRECAL_WEEK_SESSIONS;
+  return rows[weekIndex0];
+}
+
+/** Session dates only (no "Week N" wrapper), e.g. `Jun 8, 10, 12`. */
+export function getAdvMathSlotDateLabel(program: AdvMathSessionProgram, weekIndex0: number): string {
+  const week = getAdvMathWeekSessions(program, weekIndex0);
+  if (!week) return `Week ${weekIndex0 + 1}`;
+  return formatAdvMathWeekSessions(week);
+}
+
+/** Same pattern as other camps: `Week 1 (Jun 8, 10, 12) — …` */
+export function formatAdvMathWeekSlotHeading(program: AdvMathSessionProgram, weekIndex0: number): string {
+  const inner = getAdvMathSlotDateLabel(program, weekIndex0);
+  if (/^Week\s+\d+$/.test(inner)) return inner;
+  return `Week ${weekIndex0 + 1} (${inner})`;
+}

--- a/src/lib/brevo.ts
+++ b/src/lib/brevo.ts
@@ -4,7 +4,7 @@
  * BREVO_LIST_LOTTERY (numeric list id — summer camp guide leads + Meta Lead Ads upsert; legacy env name).
  */
 
-import type { SendEmailResult } from '@/lib/email';
+import type { EmailAttachment, SendEmailResult } from '@/lib/email';
 import type { NormalizedMetaLead } from '@/lib/meta-lead';
 
 const BREVO_API_BASE = 'https://api.brevo.com/v3';
@@ -58,6 +58,8 @@ export interface BrevoTransactionalEmailOptions {
   html: string;
   text: string;
   replyTo?: { email: string; name?: string };
+  /** Brevo expects base64 `content` per attachment (see POST /v3/smtp/email). */
+  attachments?: EmailAttachment[];
 }
 
 /** POST /v3/smtp/email — same logical inputs as Nodemailer send (html/text), mapped to Brevo field names. */
@@ -91,6 +93,14 @@ export async function sendBrevoTransactionalEmail(
         htmlContent: options.html,
         textContent: options.text,
         ...(options.replyTo ? { replyTo: options.replyTo } : {}),
+        ...(options.attachments?.length
+          ? {
+              attachment: options.attachments.map((a) => ({
+                name: a.filename,
+                content: a.content.toString('base64'),
+              })),
+            }
+          : {}),
       }),
     });
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -5,6 +5,12 @@
 
 import nodemailer from 'nodemailer';
 
+export type EmailAttachment = {
+  filename: string;
+  content: Buffer;
+  contentType?: string;
+};
+
 export interface SendEmailOptions {
   to: string | string[];
   subject: string;
@@ -12,6 +18,8 @@ export interface SendEmailOptions {
   text: string;
   /** Optional Reply-To header (e.g. connect@thegrowwise.com). */
   replyTo?: string;
+  /** Optional files (e.g. camp brochure PDF). */
+  attachments?: EmailAttachment[];
 }
 
 export interface SendEmailResult {
@@ -42,7 +50,7 @@ function getTransporter(): nodemailer.Transporter | null {
 }
 
 export async function sendEmail(options: SendEmailOptions): Promise<SendEmailResult> {
-  const { to, subject, html, text, replyTo } = options;
+  const { to, subject, html, text, replyTo, attachments } = options;
   const fromEmail = process.env.FROM_EMAIL;
   const fromName = process.env.FROM_NAME ?? 'GrowWise';
 
@@ -65,6 +73,15 @@ export async function sendEmail(options: SendEmailOptions): Promise<SendEmailRes
       text,
       html,
       ...(replyTo ? { replyTo } : {}),
+      ...(attachments?.length
+        ? {
+            attachments: attachments.map((a) => ({
+              filename: a.filename,
+              content: a.content,
+              contentType: a.contentType ?? 'application/octet-stream',
+            })),
+          }
+        : {}),
     });
     return { success: true, messageId: result.messageId };
   } catch (err) {

--- a/src/lib/summer-camp-data.ts
+++ b/src/lib/summer-camp-data.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import { Calculator, Brain, Gamepad2, Bot, Code2, Lightbulb, PenTool } from 'lucide-react';
 import enProgramsJson from '../../public/api/mock/en/summer-camp-programs.json';
+import { formatCampWeekSlotHeading } from '@/lib/summer-camp-week-calendar';
 
 export type Slot = {
   id: string;
@@ -32,6 +33,8 @@ export type ProgramDetails = {
   /** When set, used as the label instead of "Daily hours" (e.g. "Session hours"). */
   hoursLabel?: string;
   includes: string[];
+  /** Shown in Program Details modal (e.g. in-person only vs in-person or online). */
+  deliverySummary?: string;
 };
 
 export type Program = {
@@ -174,7 +177,7 @@ function expandSlotTemplate(template: SlotTemplate): Slot[] {
   const price = firstProgramPrices?.[template.defaultFormat] ?? 0;
   return Array.from({ length: template.count }).map((_, i) => ({
     id: `${template.slotIdPrefix}-w${i + 1}`,
-    label: `Week ${i + 1}`,
+    label: formatCampWeekSlotHeading(i),
     time,
     format: template.defaultFormat,
     price,

--- a/src/lib/summer-camp-week-calendar.test.ts
+++ b/src/lib/summer-camp-week-calendar.test.ts
@@ -1,0 +1,58 @@
+import {
+  formatCampWeekSlotHeading,
+  formatOlympiadTier2SlotHeading,
+  getMathOlympiadTier2SlotLabel,
+  getSummerCampWeekLabel,
+  SUMMER_CAMP_EVENT_END_ISO,
+  SUMMER_CAMP_EVENT_START_ISO,
+  SUMMER_CAMP_JULY4_NOTE,
+  SUMMER_CAMP_SEASON_RANGE_TEXT,
+  SUMMER_CAMP_WEEK_COUNT,
+  SUMMER_CAMP_WEEK_LABELS_2026,
+} from '@/lib/summer-camp-week-calendar';
+
+describe('summer-camp-week-calendar', () => {
+  it('exposes eight week labels for 2026', () => {
+    expect(SUMMER_CAMP_WEEK_COUNT).toBe(8);
+    expect(SUMMER_CAMP_WEEK_LABELS_2026).toHaveLength(8);
+  });
+
+  it('first week is Jun 8–12 and last is Jul 27–31', () => {
+    expect(SUMMER_CAMP_WEEK_LABELS_2026[0]).toBe('Jun 8–12, 2026');
+    expect(SUMMER_CAMP_WEEK_LABELS_2026[7]).toBe('Jul 27–31, 2026');
+  });
+
+  it('getSummerCampWeekLabel falls back beyond range', () => {
+    expect(getSummerCampWeekLabel(8)).toBe('Week 9');
+  });
+
+  it('tier 2 olympiad spans four two-week slots', () => {
+    expect(getMathOlympiadTier2SlotLabel(0)).toBe('Jun 8 – Jun 19, 2026');
+    expect(getMathOlympiadTier2SlotLabel(3)).toBe('Jul 20 – Jul 31, 2026');
+  });
+
+  it('tier 2 label falls back for out-of-range index', () => {
+    expect(getMathOlympiadTier2SlotLabel(4)).toBe('Weeks 9–10');
+  });
+
+  it('JSON-LD ISO bounds match June 8 and July 31 2026 PT', () => {
+    expect(SUMMER_CAMP_EVENT_START_ISO).toContain('2026-06-08');
+    expect(SUMMER_CAMP_EVENT_END_ISO).toContain('2026-07-31');
+  });
+
+  it('season copy strings are non-empty', () => {
+    expect(SUMMER_CAMP_SEASON_RANGE_TEXT.length).toBeGreaterThan(10);
+    expect(SUMMER_CAMP_JULY4_NOTE.length).toBeGreaterThan(3);
+  });
+
+  it('formatCampWeekSlotHeading matches Week N (dates) pattern', () => {
+    expect(formatCampWeekSlotHeading(0)).toBe('Week 1 (Jun 8–12, 2026)');
+    expect(formatCampWeekSlotHeading(7)).toBe('Week 8 (Jul 27–31, 2026)');
+  });
+
+  it('formatOlympiadTier2SlotHeading wraps tier-2 spans', () => {
+    expect(formatOlympiadTier2SlotHeading(0)).toBe(
+      `Weeks 1-2 (${getMathOlympiadTier2SlotLabel(0)})`
+    );
+  });
+});

--- a/src/lib/summer-camp-week-calendar.ts
+++ b/src/lib/summer-camp-week-calendar.ts
@@ -1,0 +1,67 @@
+/**
+ * Single source of truth for 2026 summer camp calendar buckets (Mon–Fri weeks).
+ * Season: June 8 (Mon) through July 31 (Fri), 2026 — eight full weeks.
+ */
+
+/** Human-readable season span for modal / marketing (matches week list). */
+export const SUMMER_CAMP_SEASON_RANGE_TEXT = 'June 8 – July 31, 2026';
+
+/** Short note for parents (July 4, 2026 is a Saturday; still stated for clarity). */
+export const SUMMER_CAMP_JULY4_NOTE = 'No camp July 4';
+
+/** ISO-8601 with Pacific offset for Event JSON-LD. */
+export const SUMMER_CAMP_EVENT_START_ISO = '2026-06-08T09:00:00-08:00';
+
+export const SUMMER_CAMP_EVENT_END_ISO = '2026-07-31T17:00:00-08:00';
+
+/**
+ * Eight Monday–Friday camp weeks, fixed labels (avoids TZ bugs from Date parsing).
+ */
+export const SUMMER_CAMP_WEEK_LABELS_2026 = [
+  'Jun 8–12, 2026',
+  'Jun 15–19, 2026',
+  'Jun 22–26, 2026',
+  'Jun 29 – Jul 3, 2026',
+  'Jul 6–10, 2026',
+  'Jul 13–17, 2026',
+  'Jul 20–24, 2026',
+  'Jul 27–31, 2026',
+] as const;
+
+export const SUMMER_CAMP_WEEK_COUNT = SUMMER_CAMP_WEEK_LABELS_2026.length;
+
+export function getSummerCampWeekLabel(weekIndex0: number): string {
+  const label = SUMMER_CAMP_WEEK_LABELS_2026[weekIndex0];
+  if (label) return label;
+  return `Week ${weekIndex0 + 1}`;
+}
+
+/** Standard slot line: `Week 1 (Jun 8–12, 2026)` — used across camp programs. */
+export function formatCampWeekSlotHeading(weekIndex0: number): string {
+  const dates = getSummerCampWeekLabel(weekIndex0);
+  if (/^Week\s+\d+$/.test(dates)) return dates;
+  return `Week ${weekIndex0 + 1} (${dates})`;
+}
+
+/** Math Olympiad Tier 2: `Weeks 1-2 (Jun 8 – Jun 19, 2026)` */
+export function formatOlympiadTier2SlotHeading(slotIndex0: number): string {
+  const dates = getMathOlympiadTier2SlotLabel(slotIndex0);
+  if (/^Weeks\s/.test(dates)) return dates;
+  const start = slotIndex0 * 2 + 1;
+  const end = slotIndex0 * 2 + 2;
+  return `Weeks ${start}-${end} (${dates})`;
+}
+
+/** Math Olympiad Tier 2: each slot spans two consecutive calendar weeks. */
+const MATH_OLYMPIAD_TIER2_SLOT_LABELS = [
+  'Jun 8 – Jun 19, 2026',
+  'Jun 22 – Jul 3, 2026',
+  'Jul 6 – Jul 17, 2026',
+  'Jul 20 – Jul 31, 2026',
+] as const;
+
+export function getMathOlympiadTier2SlotLabel(slotIndex0: number): string {
+  const label = MATH_OLYMPIAD_TIER2_SLOT_LABELS[slotIndex0];
+  if (label) return label;
+  return `Weeks ${slotIndex0 * 2 + 1}–${slotIndex0 * 2 + 2}`;
+}


### PR DESCRIPTION
## Summary
This PR delivers **Summer Camp 2026** work tracked under [GWA-171](https://thegrowwise-school.atlassian.net/browse/GWA-171): camp season dates across UI and JSON-LD, compact hero and mobile CTA, guide email with brochure PDF, and **performance / accessibility** improvements aligned with Lighthouse findings.

## What changed
- **Dates & calendar:** `summer-camp-week-calendar.ts`, slot labels, Math Olympiad tier labels, Advanced Math per-track week labels (`adv-math-week-sessions.ts`) + tests.
- **Data & API:** Program details and mock JSON; `/api/summer-camp-lottery` attaches `SummerCampBrochure.pdf` when present; email/Brevo wiring.
- **Summer page:** Slim `summer-camp-canonical-en.json` for hero/conversion copy; hero image tuning; mobile deferrals for FAQ and SlotsPanel chunk; dynamic Meta Pixel; **lazy** `SummerCampGuideLeadDialog` (code-split Radix dialog).
- **Program list / slots / trust:** No competing LCP `priority` on cards, dynamic pixel tracking, trust `blockquote`/footer, contrast-safe greens and text.
- **JSON-LD:** `layout.tsx` — Event dates from calendar, breadcrumb to `/camps`, offers without misleading fixed price, FAQ from `summer-camp-faq.json` only.
- **Config & docs:** `next.config` `images.qualities` includes 70; `docs/summer-camp-2026-status.md` (single status + Lighthouse snapshot); `npm run lighthouse:summer`.

## How to test
- `npm test` — 184 tests
- `npm run build`
- Manual: `/camps/summer` — hero, filters, program cards, slots, guide modal, deep link `#lead-capture`

## Lighthouse
Re-run after `next start`: `PORT=<port> npm run lighthouse:summer` (updates snapshot in `docs/summer-camp-2026-status.md`). Dev server (`next dev`) scores are not representative of production.

Made with [Cursor](https://cursor.com)