### PR TITLE
Book assessment, thank-you pages, header z-index, SEO & JSON-LD

### DIFF
--- a/e2e/specs/book-assessment.spec.ts
+++ b/e2e/specs/book-assessment.spec.ts
@@ -44,14 +44,18 @@ test.describe('Book assessment form', () => {
     await page.getByTestId('assessment-type-trigger').click();
     await page.getByRole('option', { name: /Math Skills Assessment/i }).click();
 
-    // Mode
+    // Mode: choose online, then in-person to ensure switching works
     await page.getByTestId('assessment-mode-online').click();
+    await page.getByTestId('assessment-mode-in-person').click();
 
-    // Schedule
-    await page.getByTestId('assessment-schedule-trigger').click();
-    await page
-      .getByRole('option', { name: /Weekdays After School/i })
-      .click();
+    // Preferred days + time, then how you heard
+    await page.getByTestId('assessment-schedule-day-trigger').click();
+    await page.getByRole('option', { name: /Monday.*Friday/i }).click();
+    await page.getByTestId('assessment-schedule-time-trigger').click();
+    await page.getByRole('option', { name: /3:00.*7:00.*pm/i }).click();
+
+    await page.getByTestId('hear-about-trigger').click();
+    await page.getByRole('option', { name: /Google/i }).click();
 
     // Submit form (consent defaults to checked on this page)
     const submitBtn = page.getByTestId('assessment-submit');
@@ -67,13 +71,12 @@ test.describe('Book assessment form', () => {
       { timeout: 20000 }
     );
 
-    // Success view (page resets form after 5s, so assert promptly)
-    await expect(
-      page.getByTestId('assessment-success'),
-    ).toBeVisible({ timeout: 20000 });
-    await expect(
-      page.getByText(/free assessment booking request/i),
-    ).toBeVisible();
+    const successPath = localePath('/book-assessment/thank-you');
+    await expect(page).toHaveURL(new RegExp(`${successPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\?.*)?$`), {
+      timeout: 20000,
+    });
+    await expect(page.getByTestId('form-thank-you')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByRole('heading', { level: 1, name: /thank you for your request/i })).toBeVisible();
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack",
-    "dev:webpack": "next dev --webpack",
-    "dev:turbo": "next dev --turbo",
+    "dev": "lsof -ti:3000 | xargs kill -9 2>/dev/null; next dev --webpack",
+    "dev:webpack": "lsof -ti:3000 | xargs kill -9 2>/dev/null; next dev --webpack",
+    "dev:turbo": "lsof -ti:3000 | xargs kill -9 2>/dev/null; next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "eslint src",

--- a/src/app/[locale]/book-assessment/layout.tsx
+++ b/src/app/[locale]/book-assessment/layout.tsx
@@ -21,33 +21,42 @@ export default async function BookAssessmentLayout({
   const baseUrl = getCanonicalSiteUrl()
 
   const serviceSchema = {
-    "@context": "https://schema.org",
-    "@type": "Service",
-    "name": "Free Student Assessment — GrowWise Dublin CA",
-    "description": "Book a free 60-minute student assessment at GrowWise in Dublin, CA. Our education experts evaluate your child's current level in Math, English, or STEAM and recommend the right program.",
-    "provider": {
-      "@type": "EducationalOrganization",
-      "name": "GrowWise",
-      "url": baseUrl,
-      "telephone": CONTACT_INFO.phone,
-      "address": {
-        "@type": "PostalAddress",
-        "streetAddress": CONTACT_INFO.street,
-        "addressLocality": "Dublin",
-        "addressRegion": "CA",
-        "postalCode": CONTACT_INFO.zipCode,
-        "addressCountry": "US",
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    '@id': absoluteSiteUrl('/book-assessment#service', locale, baseUrl),
+    name: 'Free Academic Assessment',
+    description:
+      "Book a free academic assessment at GrowWise in Dublin, CA. We evaluate your child's current level in Math, English, or STEAM and recommend the right next step.",
+    serviceType: 'Academic Assessment',
+    provider: {
+      '@type': 'EducationalOrganization',
+      name: 'GrowWise',
+      url: baseUrl,
+      telephone: CONTACT_INFO.phone,
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: CONTACT_INFO.street,
+        addressLocality: 'Dublin',
+        addressRegion: 'CA',
+        postalCode: CONTACT_INFO.zipCode,
+        addressCountry: 'US',
       },
     },
-    "serviceType": "Educational Assessment",
-    "areaServed": ["Dublin", "Pleasanton", "San Ramon", "Livermore"],
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD",
-      "description": "Complimentary 60-minute placement assessment",
+    areaServed: [
+      { '@type': 'City', name: 'Dublin' },
+      { '@type': 'City', name: 'Pleasanton' },
+      { '@type': 'City', name: 'San Ramon' },
+      { '@type': 'City', name: 'Livermore' },
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+      url: absoluteSiteUrl('/book-assessment', locale, baseUrl),
+      description: 'Complimentary academic assessment',
     },
-    "url": absoluteSiteUrl('/book-assessment', locale, baseUrl),
+    url: absoluteSiteUrl('/book-assessment', locale, baseUrl),
   }
 
   return (

--- a/src/app/[locale]/book-assessment/page.tsx
+++ b/src/app/[locale]/book-assessment/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useLocale } from 'next-intl';
 import { Card, CardContent } from '@/components/ui/card';
@@ -8,10 +8,8 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {
   AlertDialog,
@@ -20,7 +18,7 @@ import {
   AlertDialogTitle,
   AlertDialogDescription,
 } from '@/components/ui/alert-dialog';
-import { BookOpen, BookMarked, CheckCircle, Clock, Users, Award, TrendingUp, Brain, FileText, PenTool, Sparkles, Eye, ChevronRight, Lightbulb, Trophy, Star, Shield, ArrowRight, Calendar, Target, GraduationCap, User, Mail, Phone as PhoneIcon, MessageSquare, Send, ThumbsUp, Globe, Video, CheckSquare, Calculator, X, AlertCircle } from 'lucide-react';
+import { BookOpen, BookMarked, CheckCircle, Clock, Users, Award, TrendingUp, Brain, FileText, Sparkles, Eye, ChevronRight, Lightbulb, Trophy, Star, Shield, ArrowRight, Calendar, Target, GraduationCap, User, Mail, Phone as PhoneIcon, Send, Globe, Video, Calculator, X, AlertCircle, Megaphone } from 'lucide-react';
 import CountryCodeSelector from '@/components/CountryCodeSelector';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 import { useRouter } from 'next/navigation';
@@ -38,11 +36,11 @@ interface FormData {
   phone: string;
   studentName: string;
   grade: string;
-  subjects: string[];
   assessmentType: string;
   mode: string;
-  schedule: string;
-  notes: string;
+  scheduleDay: string;
+  scheduleTime: string;
+  hearAboutUs: string;
 }
 
 export default function BookAssessmentPage() {
@@ -50,7 +48,6 @@ export default function BookAssessmentPage() {
   const locale = useLocale();
   const router = useRouter();
   const [scrollY, setScrollY] = useState(0);
-  const [isSubmitted, setIsSubmitted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [phoneError, setPhoneError] = useState<string | null>(null);
@@ -60,19 +57,24 @@ export default function BookAssessmentPage() {
 
   // Default consent to true so users (and automated tests) are not blocked if they miss this single checkbox.
   const [agreeToCommunications, setAgreeToCommunications] = useState(true);
-  const [formData, setFormData] = useState<FormData>({
-    parentName: '',
-    email: '',
-    countryCode: '+1',
-    phone: '',
-    studentName: '',
-    grade: '',
-    subjects: [],
-    assessmentType: '',
-    mode: '',
-    schedule: '',
-    notes: ''
-  });
+  const initialFormData = useMemo<FormData>(
+    () => ({
+      parentName: '',
+      email: '',
+      countryCode: '+1',
+      phone: '',
+      studentName: '',
+      grade: '',
+      assessmentType: '',
+      mode: '',
+      scheduleDay: '',
+      scheduleTime: '',
+      hearAboutUs: '',
+    }),
+    []
+  );
+
+  const [formData, setFormData] = useState<FormData>(initialFormData);
 
   useEffect(() => {
     const handleScroll = () => setScrollY(window.scrollY);
@@ -85,22 +87,45 @@ export default function BookAssessmentPage() {
     'Grade 6', 'Grade 7', 'Grade 8', 'Grade 9', 'Grade 10', 'Grade 11', 'Grade 12'
   ];
 
-  // Move availableSubjects outside component or use useMemo to prevent recreation
-  const availableSubjects = useMemo(() => [
-    { value: 'Math', icon: '📐' },
-    { value: 'English', icon: '📚' },
-    { value: 'SAT/ACT', icon: '🎯' }
-  ], []);
+  const scheduleDayOptions = useMemo(
+    () => [
+      { value: 'weekdays', label: 'Monday – Friday' },
+      { value: 'sunday', label: 'Sunday' },
+      { value: 'either-day', label: 'Either / flexible' },
+    ],
+    []
+  );
 
-  const scheduleOptions = [
-    'Weekdays Morning', 'Weekdays After School', 'Weekends Morning', 'Weekends Afternoon'
-  ];
+  const scheduleTimeOptions = useMemo(
+    () => [
+      { value: '3-7', label: '3:00 – 7:00 pm' },
+      { value: '11-1', label: '11:00 am – 1:00 pm' },
+      { value: 'either-time', label: 'Either / flexible' },
+    ],
+    []
+  );
 
-  const assessmentTypes = [
-    { value: 'English Reading Assessment', icon: '📚', label: 'English Reading Assessment' },
-    { value: 'Math Skills Assessment', icon: '📐', label: 'Math Skills Assessment' },
-    { value: 'Complete Academic Assessment', icon: '🎓', label: '(English + Maths) Complete Academic Assessment' }
-  ];
+  const hearAboutOptions = useMemo(
+    () => [
+      { value: 'google', label: 'Google / web search' },
+      { value: 'social', label: 'Social media' },
+      { value: 'referral', label: 'Friend or family referral' },
+      { value: 'school', label: 'School or community' },
+      { value: 'walkin', label: 'Walk-in or drove by' },
+      { value: 'other', label: 'Other' },
+    ],
+    []
+  );
+
+  const assessmentTypes = useMemo(
+    () => [
+      { value: 'English Reading Assessment', icon: '📚', label: 'English Reading Assessment' },
+      { value: 'Math Skills Assessment', icon: '📐', label: 'Math Skills Assessment' },
+      { value: 'SAT/ACT', icon: '🎯', label: 'SAT/ACT' },
+      { value: 'Complete Academic Assessment', icon: '🎓', label: 'Complete academic (English + Math)' },
+    ],
+    []
+  );
 
   const handleInputChange = (field: keyof FormData, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -134,27 +159,6 @@ export default function BookAssessmentPage() {
       setPhoneError(result.errorMessage);
     }
   };
-
-  // Use ref to store handlers to prevent recreation
-  const handlersRef = useRef<Record<string, (checked: boolean | 'indeterminate') => void>>({});
-
-  // Initialize handlers only once
-  if (Object.keys(handlersRef.current).length === 0) {
-    availableSubjects.forEach(subject => {
-      handlersRef.current[subject.value] = (checked: boolean | 'indeterminate') => {
-        const isChecked = checked === true;
-        setFormData(prev => {
-          const currentSubjects = Array.isArray(prev.subjects) ? prev.subjects : [];
-          return {
-            ...prev,
-            subjects: isChecked
-              ? [...currentSubjects, subject.value]
-              : currentSubjects.filter(s => s !== subject.value)
-          };
-        });
-      };
-    });
-  }
 
   // Validate all form fields
   const validateForm = useCallback((): { isValid: boolean; errors: Record<string, string> } => {
@@ -199,9 +203,15 @@ export default function BookAssessmentPage() {
       errors.mode = 'Please select a mode (Online or In-Person)';
     }
 
-    // Validate schedule
-    if (!formData.schedule.trim()) {
-      errors.schedule = 'Please select a preferred schedule';
+    if (!formData.scheduleDay.trim()) {
+      errors.scheduleDay = 'Select preferred days';
+    }
+    if (!formData.scheduleTime.trim()) {
+      errors.scheduleTime = 'Select preferred time';
+    }
+
+    if (!formData.hearAboutUs.trim()) {
+      errors.hearAboutUs = 'Please tell us how you heard about us';
     }
 
     // Validate communication consent
@@ -213,7 +223,7 @@ export default function BookAssessmentPage() {
     setPhoneError(errors.phone || null);
 
     return { isValid: Object.keys(errors).length === 0, errors };
-  }, [formData, agreeToCommunications]);
+  }, [formData, agreeToCommunications, t]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -239,7 +249,9 @@ export default function BookAssessmentPage() {
             grade: 'grade',
             assessmentType: 'assessmentType',
             mode: 'mode',
-            schedule: 'schedule',
+            scheduleDay: 'schedule-day',
+            scheduleTime: 'schedule-time',
+            hearAboutUs: 'hearAboutUs',
             agreeToCommunications: 'agreeToCommunications'
           };
           const inputId = fieldIdMap[firstErrorId] || firstErrorId;
@@ -263,6 +275,12 @@ export default function BookAssessmentPage() {
     try {
       const recaptchaToken = await getRecaptchaToken('assessment_submit');
 
+      const dayLabel =
+        scheduleDayOptions.find((d) => d.value === formData.scheduleDay)?.label ?? formData.scheduleDay;
+      const timeLabel =
+        scheduleTimeOptions.find((t) => t.value === formData.scheduleTime)?.label ?? formData.scheduleTime;
+      const scheduleCombined = `${dayLabel} · ${timeLabel}`;
+
       const assessmentData = {
         parentName: formData.parentName,
         email: formData.email,
@@ -270,11 +288,12 @@ export default function BookAssessmentPage() {
         phone: phoneValidation.e164 || formData.phone, // Use E.164 format if available
         studentName: formData.studentName,
         grade: formData.grade,
-        subjects: formData.subjects,
+        subjects: [],
         assessmentType: formData.assessmentType,
         mode: formData.mode,
-        schedule: formData.schedule,
-        notes: formData.notes,
+        schedule: scheduleCombined,
+        hearAboutUs: hearAboutOptions.find((h) => h.value === formData.hearAboutUs)?.label ?? formData.hearAboutUs,
+        notes: '',
         agreeToCommunications,
         recaptchaToken: recaptchaToken || undefined,
       };
@@ -296,26 +315,8 @@ export default function BookAssessmentPage() {
       }
 
       if (result.success) {
-        setIsSubmitted(true);
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-        // Reset form after success
-        setTimeout(() => {
-          setFormData({
-            parentName: '',
-            email: '',
-            countryCode: '+1',
-            phone: '',
-            studentName: '',
-            grade: '',
-            subjects: [],
-            assessmentType: '',
-            mode: '',
-            schedule: '',
-            notes: ''
-          });
-          setAgreeToCommunications(false);
-          setIsSubmitted(false);
-        }, 5000);
+        router.replace(publicPath('/book-assessment/thank-you', locale));
+        return;
       } else {
         setErrorMessage(result.error || 'Failed to submit assessment booking');
       }
@@ -325,7 +326,16 @@ export default function BookAssessmentPage() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [formData]);
+  }, [
+    formData,
+    agreeToCommunications,
+    validateForm,
+    router,
+    locale,
+    hearAboutOptions,
+    scheduleDayOptions,
+    scheduleTimeOptions,
+  ]);
 
   const assessmentFeatures = [
     { icon: FileText, title: 'Detailed Report', description: 'Comprehensive analysis of strengths and growth areas', color: 'from-blue-500 to-blue-600', stats: '15+ Pages' },
@@ -336,7 +346,7 @@ export default function BookAssessmentPage() {
 
   // const processSteps = [
   //   { number: '1', title: 'Book Your Assessment', description: 'Choose your package and schedule a convenient time', icon: Calendar, color: 'from-[#1F396D] to-[#29335C]' },
-  //   { number: '2', title: 'Take the Assessment', description: 'Complete the evaluation with our expert teachers', icon: PenTool, color: 'from-[#F16112] to-[#F1894F]' },
+  //   { number: '2', title: 'Take the Assessment', description: 'Complete the evaluation with our expert teachers', icon: FileText, color: 'from-[#F16112] to-[#F1894F]' },
   //   { number: '3', title: 'Receive Your Report', description: 'Get detailed insights within 48 hours', icon: FileText, color: 'from-[#1F396D] to-[#F16112]' },
   //   { number: '4', title: 'Plan Your Path', description: 'Schedule a consultation to discuss next steps', icon: Lightbulb, color: 'from-[#F1894F] to-[#1F396D]' }
   // ];
@@ -359,9 +369,6 @@ export default function BookAssessmentPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-50" suppressHydrationWarning>
-      <h1 className="sr-only">Book Free Grades 1-12 Assessment | GrowWise Dublin, CA</h1>
-
-
       {/* <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
@@ -434,19 +441,27 @@ export default function BookAssessmentPage() {
           <div className="absolute top-20 left-10 w-96 h-96 bg-gradient-to-br from-[#1F396D]/10 to-transparent rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-10 w-[500px] h-[500px] bg-gradient-to-br from-[#F16112]/10 to-transparent rounded-full blur-3xl"></div>
         </div>
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative">
           <div className="text-center mb-12">
             <Badge className="mb-6 bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white border-0 px-8 py-3 shadow-lg">
               <Sparkles className="w-5 h-5 mr-2" />
               100% Free - No Credit Card Required
             </Badge>
-            <h2 className="text-gray-900 mb-4">Book Your <span className="bg-gradient-to-r from-[#F16112] to-[#F1894F] bg-clip-text text-transparent">Free Assessment</span></h2>
+            <h1
+              id="book-assessment-hero-h1"
+              className="text-3xl sm:text-4xl font-semibold tracking-tight text-balance text-gray-900 mb-4"
+            >
+              Book Your{' '}
+              <span className="bg-gradient-to-r from-[#F16112] to-[#F1894F] bg-clip-text text-transparent">
+                Free Academic Assessment
+              </span>{' '}
+              Today
+            </h1>
             <p className="text-gray-600 max-w-2xl mx-auto text-lg">Fill out the form below and our academic advisors will contact you within 24 hours</p>
           </div>
           <div suppressHydrationWarning>
             <Card className="bg-white/95 backdrop-blur-xl border-2 border-white/60 shadow-2xl rounded-xl md:rounded-3xl overflow-hidden" suppressHydrationWarning>
               <CardContent className="p-4 sm:p-6 md:p-8 lg:p-10 pt-4 sm:pt-6 md:pt-8 lg:pt-10" suppressHydrationWarning>
-                {!isSubmitted ? (
                   <form onSubmit={handleSubmit} className="space-y-6 md:space-y-8" suppressHydrationWarning noValidate>
                     <div className="space-y-4 md:space-y-6 p-4 sm:p-6 md:p-8 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10">
                       <div className="flex items-center gap-2 sm:gap-3 pb-3 md:pb-4 border-b-2 border-[#1F396D]/20">
@@ -532,109 +547,161 @@ export default function BookAssessmentPage() {
                       </div>
                     </div>
 
-                    <div className="space-y-4 md:space-y-6 p-4 sm:p-6 md:p-8 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10">
-                      <div className="flex items-center gap-2 sm:gap-3 pb-3 md:pb-4 border-b-2 border-[#1F396D]/20">
+                    <div className="space-y-4 md:space-y-5 p-4 sm:p-6 md:p-8 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10">
+                      <div className="flex items-center gap-2 sm:gap-3 pb-2 border-b-2 border-[#1F396D]/20">
                         <div className="p-2 sm:p-3 bg-gradient-to-br from-[#1F396D] to-[#F16112] rounded-lg md:rounded-xl"><BookMarked className="w-5 h-5 sm:w-6 sm:h-6 text-white" /></div>
-                        <div><h3 className="text-gray-900 text-lg sm:text-xl">Assessment Preferences</h3><p className="text-xs sm:text-sm text-gray-500">Customize your assessment experience</p></div>
+                        <div><h3 className="text-gray-900 text-lg sm:text-xl">Assessment preferences</h3><p className="text-xs sm:text-sm text-gray-500">Type, format, and availability</p></div>
                       </div>
-                      <div className="space-y-3">
-                        <Label htmlFor="assessmentType" className="text-gray-700 font-medium text-base flex items-center gap-2"><Target className="w-4 h-4 text-[#F16112]" />Assessment Type <span className="text-red-500">*</span></Label>
-                        <Select onValueChange={(value) => handleInputChange('assessmentType', value)} required>
+                      <div className="space-y-2">
+                        <span className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2"><Target className="w-4 h-4 text-[#F16112] shrink-0" />Assessment type <span className="text-red-500">*</span></span>
+                        <Select
+                          onValueChange={(value) => handleInputChange('assessmentType', value)}
+                          value={formData.assessmentType || undefined}
+                          required
+                        >
                           <SelectTrigger
                             data-testid="assessment-type-trigger"
-                            className="bg-white border-2 border-gray-300 rounded-xl hover:border-gray-400 transition-all h-14 text-base"
+                            id="assessmentType"
+                            className="bg-white border-2 border-gray-300 rounded-xl hover:border-gray-400 transition-all h-12 sm:h-14 text-sm sm:text-base"
                           >
-                            <SelectValue placeholder="Select assessment type" />
+                            <SelectValue placeholder="Select type" />
                           </SelectTrigger>
-                          <SelectContent className="bg-white/95 backdrop-blur-xl border-2 border-white/60 rounded-xl shadow-2xl">
+                          <SelectContent className="bg-white/95 backdrop-blur-xl border-2 border-white/60 rounded-xl shadow-2xl max-h-72">
                             {assessmentTypes.map((type) => (
-                              <SelectItem key={type.value} value={type.value} className="hover:bg-[#F16112]/10 py-4 text-base">
-                                <div className="flex items-center w-full gap-4">
-                                  <span className="flex items-center gap-2">
-                                    <span>{type.icon}</span>
-                                    {type.label ?? type.value}
-                                  </span>
-                                </div>
+                              <SelectItem key={type.value} value={type.value} className="hover:bg-[#F16112]/10 py-3 text-sm sm:text-base">
+                                <span className="flex items-center gap-2">
+                                  <span>{type.icon}</span>
+                                  {type.label}
+                                </span>
                               </SelectItem>
                             ))}
                           </SelectContent>
                         </Select>
                       </div>
-                      <div>
-                        <Label className="text-gray-700 font-medium mb-3 md:mb-4 block flex items-center gap-2 text-sm sm:text-base"><CheckSquare className="w-4 h-4 text-[#F16112]" />Areas of Focus <span className="text-red-500">*</span></Label>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
-                          {availableSubjects.map((subject) => {
-                            const isSelected = Array.isArray(formData.subjects) && formData.subjects.includes(subject.value);
-
-                            return (
-                              <div
-                                key={subject.value}
-                                className={cn(
-                                  "flex items-center space-x-2 sm:space-x-3 p-3 sm:p-4 bg-white rounded-lg md:rounded-xl border-2 transition-all cursor-pointer",
-                                  isSelected
-                                    ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5 shadow-md'
-                                    : 'border-gray-300 hover:border-[#F16112]/30 hover:shadow-sm'
-                                )}
-                              >
-                                <Checkbox
-                                  id={subject.value}
-                                  checked={isSelected}
-                                  onCheckedChange={handlersRef.current[subject.value]}
-                                  className="border-2 border-gray-400 data-[state=checked]:bg-[#F16112] data-[state=checked]:border-[#F16112] w-5 h-5 flex-shrink-0"
-                                  suppressHydrationWarning
-                                />
-                                <Label
-                                  htmlFor={subject.value}
-                                  className="cursor-pointer text-gray-700 font-medium flex-1 flex items-center gap-2"
-                                >
-                                  <span>{subject.icon}</span>{subject.value}
-                                </Label>
-                              </div>
-                            );
-                          })}
-                        </div>
+                      <div className="space-y-2">
+                        <span className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2" id="mode-label"><Globe className="w-4 h-4 text-[#1F396D] shrink-0" />Preferred format <span className="text-red-500">*</span></span>
+                        <RadioGroup
+                          value={formData.mode}
+                          onValueChange={(value) => handleInputChange('mode', value)}
+                          className="flex flex-col gap-2.5"
+                          aria-labelledby="mode-label"
+                        >
+                          <label
+                            data-testid="assessment-mode-in-person"
+                            className={cn(
+                              'flex w-full items-center gap-3 p-3 sm:p-3.5 rounded-lg md:rounded-xl border-2 transition-colors cursor-pointer',
+                              formData.mode === 'in-person'
+                                ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5'
+                                : 'border-gray-200 bg-white hover:border-[#F16112]/30'
+                            )}
+                          >
+                            <RadioGroupItem value="in-person" id="assessment-mode-in-person-input" className="border-2 border-gray-400 text-[#F16112] shrink-0" />
+                            <span className="text-gray-800 text-sm sm:text-base font-medium">In-person at {CONTACT_INFO.city}</span>
+                          </label>
+                          <label
+                            data-testid="assessment-mode-online"
+                            className={cn(
+                              'flex w-full items-center gap-3 p-3 sm:p-3.5 rounded-lg md:rounded-xl border-2 transition-colors cursor-pointer',
+                              formData.mode === 'online'
+                                ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5'
+                                : 'border-gray-200 bg-white hover:border-[#F16112]/30'
+                            )}
+                          >
+                            <RadioGroupItem value="online" id="assessment-mode-online-input" className="border-2 border-gray-400 text-[#F16112] shrink-0" />
+                            <span className="text-gray-800 text-sm sm:text-base font-medium inline-flex items-center gap-2"><Video className="w-4 h-4 opacity-80" />Online (virtual)</span>
+                          </label>
+                        </RadioGroup>
                       </div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                        <div className="space-y-3 md:space-y-4">
-                          <Label className="text-gray-700 font-medium flex items-center gap-2 text-sm sm:text-base"><Globe className="w-4 h-4 text-[#1F396D]" />Preferred Mode <span className="text-red-500">*</span></Label>
-                          <RadioGroup value={formData.mode} onValueChange={(value) => handleInputChange('mode', value)} className="flex flex-col gap-3 md:gap-4">
-                            <div data-testid="assessment-mode-in-person" onClick={() => handleInputChange('mode', 'in-person')} className={cn("flex items-center space-x-3 sm:space-x-4 p-3 sm:p-4 bg-white rounded-lg md:rounded-xl border-2 transition-all cursor-pointer", formData.mode === 'in-person' ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5 shadow-md' : 'border-gray-300 hover:border-[#F16112]/30 hover:shadow-sm')}>
-                              <RadioGroupItem value="in-person" id="in-person" className="border-2 border-gray-400 text-[#F16112] w-5 h-5" />
-                              <Label htmlFor="in-person" className="cursor-pointer text-gray-700 font-medium text-sm sm:text-base flex-1">In-person at {CONTACT_INFO.city}</Label>
+                      <div className="space-y-3 sm:space-y-4">
+                        <div>
+                          <span
+                            className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2 mb-2"
+                            id="availability-label"
+                          >
+                            <Calendar className="w-4 h-4 text-[#F16112] shrink-0" />
+                            Preferred availability <span className="text-red-500">*</span>
+                          </span>
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+                            <div className="space-y-2">
+                              <Label htmlFor="schedule-day" className="text-gray-600 text-xs sm:text-sm">
+                                Days
+                              </Label>
+                              <Select
+                                onValueChange={(value) => handleInputChange('scheduleDay', value)}
+                                value={formData.scheduleDay || undefined}
+                                required
+                              >
+                                <SelectTrigger
+                                  data-testid="assessment-schedule-day-trigger"
+                                  id="schedule-day"
+                                  className="bg-white border-2 border-gray-300 rounded-lg md:rounded-xl h-12 md:h-14 text-sm sm:text-base"
+                                  aria-labelledby="availability-label"
+                                >
+                                  <SelectValue placeholder="Select days" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {scheduleDayOptions.map((opt) => (
+                                    <SelectItem key={opt.value} value={opt.value} className="text-sm sm:text-base">
+                                      {opt.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
                             </div>
-                            <div data-testid="assessment-mode-online" onClick={() => handleInputChange('mode', 'online')} className={cn("flex items-center space-x-3 sm:space-x-4 p-3 sm:p-4 bg-white rounded-lg md:rounded-xl border-2 transition-all cursor-pointer", formData.mode === 'online' ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5 shadow-md' : 'border-gray-300 hover:border-[#F16112]/30 hover:shadow-sm')}>
-                              <RadioGroupItem value="online" id="online" className="border-2 border-gray-400 text-[#F16112] w-5 h-5" />
-                              <Label htmlFor="online" className="cursor-pointer text-gray-700 font-medium text-sm sm:text-base flex-1 flex items-center gap-2"><Video className="w-4 h-4" />Online (Virtual)</Label>
+                            <div className="space-y-2">
+                              <Label htmlFor="schedule-time" className="text-gray-600 text-xs sm:text-sm">
+                                Time
+                              </Label>
+                              <Select
+                                onValueChange={(value) => handleInputChange('scheduleTime', value)}
+                                value={formData.scheduleTime || undefined}
+                                required
+                              >
+                                <SelectTrigger
+                                  data-testid="assessment-schedule-time-trigger"
+                                  id="schedule-time"
+                                  className="bg-white border-2 border-gray-300 rounded-lg md:rounded-xl h-12 md:h-14 text-sm sm:text-base"
+                                  aria-labelledby="availability-label"
+                                >
+                                  <SelectValue placeholder="Select time" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {scheduleTimeOptions.map((opt) => (
+                                    <SelectItem key={opt.value} value={opt.value} className="text-sm sm:text-base">
+                                      {opt.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
                             </div>
-                          </RadioGroup>
+                          </div>
                         </div>
                         <div className="space-y-2">
-                          <Label htmlFor="schedule" className="text-gray-700 font-medium flex items-center gap-2 text-sm sm:text-base"><Calendar className="w-4 h-4 text-[#F16112]" />Preferred Schedule <span className="text-red-500">*</span></Label>
-                          <Select onValueChange={(value) => handleInputChange('schedule', value)} required>
+                          <Label htmlFor="hearAboutUs" className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2">
+                            <Megaphone className="w-4 h-4 text-[#F16112] shrink-0" />
+                            How did you hear about us? <span className="text-red-500">*</span>
+                          </Label>
+                          <Select
+                            onValueChange={(value) => handleInputChange('hearAboutUs', value)}
+                            value={formData.hearAboutUs || undefined}
+                            required
+                          >
                             <SelectTrigger
-                              data-testid="assessment-schedule-trigger"
-                              className="bg-white border-2 border-gray-300 rounded-lg md:rounded-xl hover:border-gray-400 transition-all h-12 md:h-14 text-sm sm:text-base"
+                              data-testid="hear-about-trigger"
+                              id="hearAboutUs"
+                              className="bg-white border-2 border-gray-300 rounded-lg md:rounded-xl h-12 md:h-14 text-sm sm:text-base w-full"
                             >
-                              <SelectValue placeholder="Select preferred time" />
+                              <SelectValue placeholder="Select one" />
                             </SelectTrigger>
-                            <SelectContent className="bg-white/95 backdrop-blur-xl border-2 border-white/60 rounded-xl shadow-2xl">
-                              {scheduleOptions.map((option) => (
-                                <SelectItem key={option} value={option} className="hover:bg-[#F16112]/10 py-3">{option}</SelectItem>
+                            <SelectContent>
+                              {hearAboutOptions.map((opt) => (
+                                <SelectItem key={opt.value} value={opt.value} className="text-sm sm:text-base">
+                                  {opt.label}
+                                </SelectItem>
                               ))}
                             </SelectContent>
                           </Select>
                         </div>
-                      </div>
-                    </div>
-
-                    <div className="space-y-4 md:space-y-6 p-4 sm:p-6 md:p-8 bg-gradient-to-br from-blue-50 to-blue-100/50 rounded-xl md:rounded-2xl border-2 border-blue-200/50">
-                      <div className="flex items-center gap-2 sm:gap-3 pb-3 md:pb-4 border-b-2 border-blue-300/50">
-                        <div className="p-2 sm:p-3 bg-blue-500 rounded-lg md:rounded-xl"><MessageSquare className="w-5 h-5 sm:w-6 sm:h-6 text-white" /></div>
-                        <div><h3 className="text-gray-900 text-lg sm:text-xl">Additional Information</h3><p className="text-xs sm:text-sm text-gray-600">Any special requirements or questions?</p></div>
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="notes" className="text-gray-700 font-medium flex items-center gap-2 text-sm sm:text-base"><PenTool className="w-4 h-4 text-blue-600" />Special Requirements or Questions (Optional)</Label>
-                        <Textarea id="notes" value={formData.notes} onChange={(e) => handleInputChange('notes', e.target.value)} onFocus={() => setFocusedField('notes')} onBlur={() => setFocusedField(null)} className={cn("bg-white border-2 rounded-lg md:rounded-xl transition-all min-h-[100px] sm:min-h-[140px] resize-none text-sm sm:text-base", focusedField === 'notes' ? 'border-blue-500 shadow-md ring-2 ring-blue-500/10' : 'border-gray-300 hover:border-gray-400')} placeholder="Let us know if you have any specific concerns or questions about the assessment..." />
                       </div>
                     </div>
 
@@ -708,10 +775,22 @@ export default function BookAssessmentPage() {
                                   <span><strong>Mode:</strong> {formErrors.mode}</span>
                                 </li>
                               )}
-                              {formErrors.schedule && (
+                              {formErrors.scheduleDay && (
                                 <li className="flex items-center gap-2">
                                   <X className="w-4 h-4" />
-                                  <span><strong>Schedule:</strong> {formErrors.schedule}</span>
+                                  <span><strong>Days:</strong> {formErrors.scheduleDay}</span>
+                                </li>
+                              )}
+                              {formErrors.scheduleTime && (
+                                <li className="flex items-center gap-2">
+                                  <X className="w-4 h-4" />
+                                  <span><strong>Time:</strong> {formErrors.scheduleTime}</span>
+                                </li>
+                              )}
+                              {formErrors.hearAboutUs && (
+                                <li className="flex items-center gap-2">
+                                  <X className="w-4 h-4" />
+                                  <span><strong>How you heard about us:</strong> {formErrors.hearAboutUs}</span>
                                 </li>
                               )}
                               {formErrors.agreeToCommunications && (
@@ -772,34 +851,6 @@ export default function BookAssessmentPage() {
                       )}
                     </div>
                   </form>
-                ) : (
-                  <div className="text-center py-20" data-testid="assessment-success">
-                    <div className="w-28 h-28 bg-gradient-to-r from-green-500 to-green-600 rounded-full flex items-center justify-center mx-auto mb-8 shadow-2xl"><CheckCircle className="w-14 h-14 text-white" /></div>
-                    <p className="text-green-700 font-semibold mb-2">Submission completed successfully.</p>
-                    <h3 className="text-gray-900 mb-6 text-4xl">🎉 Thank You for Your Request!</h3>
-                    <p className="text-gray-600 max-w-lg mx-auto mb-10 text-xl leading-relaxed">We've received your free assessment booking request. Our team will contact you within 24 hours to confirm your appointment.</p>
-                    <div className="space-y-4">
-                      <div className="flex flex-wrap justify-center gap-4">
-                        <Button onClick={() => setIsSubmitted(false)} className="bg-gradient-to-r from-[#F16112] to-[#F1894F] hover:from-[#d54f0a] hover:to-[#F16112] text-white px-10 py-7 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"><Calendar className="w-6 h-6 mr-2" />Book Another Assessment</Button>
-                      </div>
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12 max-w-3xl mx-auto">
-                        {[
-                          { icon: Clock, text: '24-hour response guaranteed' },
-                          { icon: Shield, text: 'Your data is secure' },
-                          { icon: ThumbsUp, text: 'Welcome to GrowWise!' }
-                        ].map((item, idx) => {
-                          const IconComponent = item.icon as any;
-                          return (
-                            <div key={idx} className="flex flex-col items-center gap-3">
-                              <div className="p-3 bg-gradient-to-br from-green-100 to-green-200 rounded-xl"><IconComponent className="w-6 h-6 text-green-700" /></div>
-                              <p className="text-sm text-gray-600 font-medium">{item.text}</p>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                )}
               </CardContent>
             </Card>
           </div>

--- a/src/app/[locale]/book-assessment/thank-you/layout.tsx
+++ b/src/app/[locale]/book-assessment/thank-you/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { FormThankYouJsonLd } from '@/components/form-thank-you/FormThankYouJsonLd';
+import { buildFormThankYouMetadata } from '@/lib/seo/formThankYouMetadata';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return buildFormThankYouMetadata('book-assessment', '/book-assessment/thank-you', locale);
+}
+
+export default async function BookAssessmentThankYouLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <FormThankYouJsonLd
+        formId="book-assessment"
+        locale={locale}
+        publicPagePath="/book-assessment/thank-you"
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/[locale]/book-assessment/thank-you/page.tsx
+++ b/src/app/[locale]/book-assessment/thank-you/page.tsx
@@ -1,0 +1,12 @@
+import { getFormThankYouContent } from '@/data/form-thank-you/getFormThankYouContent';
+import { FormThankYouView } from '@/components/form-thank-you/FormThankYouView';
+
+export default async function BookAssessmentThankYouPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const content = getFormThankYouContent('book-assessment', locale);
+  return <FormThankYouView content={content} locale={locale} />;
+}

--- a/src/app/[locale]/camps/summer/layout.tsx
+++ b/src/app/[locale]/camps/summer/layout.tsx
@@ -1,6 +1,17 @@
+/**
+ * Summer camp hub JSON-LD: Event, BreadcrumbList, FAQPage, WebPage, ItemList (programs with detail URLs).
+ * Site-wide `EducationalOrganization` + `LocalBusiness` live in `[locale]/layout.tsx` only — do not paste
+ * duplicate org/course/FAQ blocks from third-party snippets (domain, season, and FAQ must match this app).
+ */
 import { Metadata } from 'next';
 import { generateMetadataFromPath } from '@/lib/seo/metadata';
-import { generateEventSchema, generateBreadcrumbSchema, generateFAQPageSchema } from '@/lib/seo/structuredData';
+import {
+  generateEventSchema,
+  generateBreadcrumbSchema,
+  generateFAQPageSchema,
+  generateItemListSchema,
+  generateWebPageJsonLd,
+} from '@/lib/seo/structuredData';
 import { CONTACT_INFO } from '@/lib/constants';
 import { absoluteSiteUrl } from '@/lib/publicPath';
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
@@ -8,6 +19,8 @@ import {
   SUMMER_CAMP_EVENT_END_ISO,
   SUMMER_CAMP_EVENT_START_ISO,
 } from '@/lib/summer-camp-week-calendar';
+import { getDefaultSummerCampData, getMinimumPublishedSummerCampPriceUsd } from '@/lib/summer-camp-data';
+import { getSummerCampProgramSeoLink } from '@/lib/summer-camp-seo-links';
 import summerCampFaqData from '../../../../../public/api/mock/en/summer-camp-faq.json';
 
 export async function generateMetadata({
@@ -34,11 +47,13 @@ export default async function SummerCampLayout({
 }) {
   const { locale } = await params;
   const baseUrl = getCanonicalSiteUrl();
+  const minCampPriceUsd = getMinimumPublishedSummerCampPriceUsd();
+  const summerEventDescription =
+    'Enrollment open for GrowWise Summer Camp 2026! Accredited courses in Math, Coding, Robotics, and more. Half-day and full-day camps. Small cohorts. Dublin, CA.';
 
   const eventSchema = generateEventSchema({
     name: 'Summer Camp 2026 - Math, Coding & Robotics',
-    description:
-      'Enrollment open for GrowWise Summer Camp 2026! Accredited courses in Math, Coding, Robotics, and more. Half-day and full-day camps. Small cohorts. Dublin, CA.',
+    description: summerEventDescription,
     startDate: SUMMER_CAMP_EVENT_START_ISO,
     endDate: SUMMER_CAMP_EVENT_END_ISO,
     location: {
@@ -56,8 +71,9 @@ export default async function SummerCampLayout({
       url: baseUrl,
     },
     image: `${baseUrl}/assets/growwise-logo.png`,
-    // No fixed price: programs use multiple tiers; misleading Offer.price hurts trust signals.
+    // price = lowest published option; program/week/format prices vary on the page.
     offers: {
+      price: String(minCampPriceUsd),
       priceCurrency: 'USD',
       availability: 'https://schema.org/InStock',
       url: absoluteSiteUrl('/camps/summer', locale, baseUrl),
@@ -74,6 +90,29 @@ export default async function SummerCampLayout({
 
   const faqSchema = generateFAQPageSchema(summerCampFaqData.faqs);
 
+  const pageUrl = absoluteSiteUrl('/camps/summer', locale, baseUrl);
+  const webPageSchema = generateWebPageJsonLd({
+    name: 'Summer Camp 2026 - Math, Coding & Robotics | GrowWise',
+    description: summerEventDescription,
+    url: pageUrl,
+  });
+
+  const programLinks: Array<{ name: string; url: string }> = [];
+  const seenUrls = new Set<string>();
+  for (const p of getDefaultSummerCampData().programs) {
+    const link = getSummerCampProgramSeoLink(p.id);
+    if (!link) continue;
+    const itemUrl = absoluteSiteUrl(`/camps/${link.slug}`, locale, baseUrl);
+    if (seenUrls.has(itemUrl)) continue;
+    seenUrls.add(itemUrl);
+    programLinks.push({ name: p.title, url: itemUrl });
+  }
+  programLinks.sort((a, b) => a.name.localeCompare(b.name, 'en'));
+  const programItemListSchema =
+    programLinks.length > 0
+      ? generateItemListSchema('Summer camp programs (Dublin, CA)', programLinks)
+      : null;
+
   return (
     <>
       <script
@@ -88,6 +127,16 @@ export default async function SummerCampLayout({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageSchema) }}
+      />
+      {programItemListSchema && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(programItemListSchema) }}
+        />
+      )}
       {children}
     </>
   );

--- a/src/app/[locale]/contact/thank-you/layout.tsx
+++ b/src/app/[locale]/contact/thank-you/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { FormThankYouJsonLd } from '@/components/form-thank-you/FormThankYouJsonLd';
+import { buildFormThankYouMetadata } from '@/lib/seo/formThankYouMetadata';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return buildFormThankYouMetadata('contact', '/contact/thank-you', locale);
+}
+
+export default async function ContactThankYouLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <FormThankYouJsonLd
+        formId="contact"
+        locale={locale}
+        publicPagePath="/contact/thank-you"
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/[locale]/contact/thank-you/page.tsx
+++ b/src/app/[locale]/contact/thank-you/page.tsx
@@ -1,0 +1,8 @@
+import { getFormThankYouContent } from '@/data/form-thank-you/getFormThankYouContent';
+import { FormThankYouView } from '@/components/form-thank-you/FormThankYouView';
+
+export default async function ContactThankYouPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const content = getFormThankYouContent('contact', locale);
+  return <FormThankYouView content={content} locale={locale} />;
+}

--- a/src/app/[locale]/enroll-academic/page.tsx
+++ b/src/app/[locale]/enroll-academic/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
+import { publicPath } from "@/lib/publicPath";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -27,7 +30,8 @@ interface EnrollFormData {
 }
 
 export default function EnrollAcademicPage() {
-  const [isSubmitted, setIsSubmitted] = useState(false);
+  const router = useRouter();
+  const locale = useLocale();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [phoneError, setPhoneError] = useState<string | null>(null);
   const [formData, setFormData] = useState<EnrollFormData>({
@@ -142,7 +146,8 @@ export default function EnrollAcademicPage() {
       }
 
       if (result.success) {
-        setIsSubmitted(true);
+        router.replace(publicPath("/enroll-academic/thank-you", locale));
+        return;
       } else {
         throw new Error(result.message || 'Failed to submit enrollment');
       }
@@ -240,7 +245,6 @@ export default function EnrollAcademicPage() {
 
           <Card className="bg-white/95 backdrop-blur-xl border-2 border-white/60 shadow-xl rounded-3xl overflow-hidden">
             <CardContent className="p-6 md:p-10">
-              {!isSubmitted ? (
                 <form onSubmit={handleSubmit} className="space-y-8">
                   <div className="space-y-6 p-6 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 rounded-2xl border-2 border-[#1F396D]/10">
                     <div className="flex items-center gap-3 pb-4 border-b-2 border-[#1F396D]/20">
@@ -360,23 +364,6 @@ export default function EnrollAcademicPage() {
                     </Button>
                   </div>
                 </form>
-              ) : (
-                <div className="text-center py-16">
-                  <div className="w-24 h-24 bg-gradient-to-r from-green-500 to-green-600 rounded-full flex items-center justify-center mx-auto mb-6 text-white">
-                    <Shield className="w-10 h-10" />
-                  </div>
-                  <h3 className="text-gray-900 mb-4 text-3xl">Registration Successful!</h3>
-                  <p className="text-gray-600 max-w-lg mx-auto mb-8 text-lg">
-                    Thank you for enrolling! Our team will contact you within 24 hours to complete the process and answer any questions.
-                  </p>
-                  <div className="flex justify-center">
-                    <Button onClick={() => setIsSubmitted(false)} className="bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white px-8 py-6 rounded-xl">
-                      <GraduationCap className="w-5 h-5 mr-2" />
-                      Enroll Another Student
-                    </Button>
-                  </div>
-                </div>
-              )}
             </CardContent>
           </Card>
 

--- a/src/app/[locale]/enroll-academic/thank-you/layout.tsx
+++ b/src/app/[locale]/enroll-academic/thank-you/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { FormThankYouJsonLd } from '@/components/form-thank-you/FormThankYouJsonLd';
+import { buildFormThankYouMetadata } from '@/lib/seo/formThankYouMetadata';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return buildFormThankYouMetadata('enroll-academic', '/enroll-academic/thank-you', locale);
+}
+
+export default async function EnrollAcademicThankYouLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <FormThankYouJsonLd
+        formId="enroll-academic"
+        locale={locale}
+        publicPagePath="/enroll-academic/thank-you"
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/[locale]/enroll-academic/thank-you/page.tsx
+++ b/src/app/[locale]/enroll-academic/thank-you/page.tsx
@@ -1,0 +1,12 @@
+import { getFormThankYouContent } from '@/data/form-thank-you/getFormThankYouContent';
+import { FormThankYouView } from '@/components/form-thank-you/FormThankYouView';
+
+export default async function EnrollAcademicThankYouPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const content = getFormThankYouContent('enroll-academic', locale);
+  return <FormThankYouView content={content} locale={locale} />;
+}

--- a/src/app/[locale]/enroll/page.tsx
+++ b/src/app/[locale]/enroll/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import React, { Suspense, useState, useRef, useCallback } from 'react';
-import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useTranslations, useLocale } from 'next-intl';
+import { publicPath } from '@/lib/publicPath';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Loader2, CheckCircle, AlertCircle, User, Mail, Phone as PhoneIcon, GraduationCap, MapPin, Target, BookOpen, Code } from 'lucide-react';
+import { Loader2, AlertCircle, User, Mail, Phone as PhoneIcon, GraduationCap, MapPin, Target, BookOpen, Code } from 'lucide-react';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 import { useFormTracking, usePageTracking } from '@/lib/analytics/hooks';
 import { TrackedForm } from '@/lib/analytics/components';
@@ -16,8 +18,10 @@ import { useSearchParams } from 'next/navigation';
 import { getRecaptchaToken } from '@/lib/recaptcha';
 
 function EnrollPageInner() {
+  const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
   const t = useTranslations('enrollnow');
+  const locale = useLocale();
   const [agree, setAgree] = useState(false);
   const [programType, setProgramType] = useState<'academic' | 'steam' | undefined>(undefined);
   const [bootcamp, setBootcamp] = useState<string | undefined>(undefined);
@@ -101,26 +105,9 @@ function EnrollPageInner() {
       }
 
       if (result.success) {
-        setSubmitStatus('success');
-        // Track successful form submission
         trackFormSubmit('enrollment_form', true);
-        
-        // Reset form by clearing all state and form fields
-        setAgree(false);
-        setProgramType(undefined);
-        setBootcamp(undefined);
-        setCourse(undefined);
-        setLevel(undefined);
-        
-        // Reset form fields using ref
-        if (formRef.current) {
-          formRef.current.reset();
-        }
-        
-        // Clear success message after 5 seconds
-        setTimeout(() => {
-          setSubmitStatus('idle');
-        }, 5000);
+        router.replace(publicPath('/enroll/thank-you', locale));
+        return;
       } else {
         setSubmitStatus('error');
         setErrorMessage(result.error || 'Failed to submit enrollment');
@@ -155,17 +142,6 @@ function EnrollPageInner() {
       </section>
 
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-
-        {/* Success Message */}
-        {submitStatus === 'success' && (
-          <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg flex items-center gap-3">
-            <CheckCircle className="w-5 h-5 text-green-600" />
-            <div>
-              <h3 className="text-green-800 font-semibold">Enrollment Successful!</h3>
-              <p className="text-green-700 text-sm">Thank you for enrolling with GrowWise. We will contact you within 24 hours.</p>
-            </div>
-          </div>
-        )}
 
         {/* Error Message */}
         {submitStatus === 'error' && (

--- a/src/app/[locale]/enroll/thank-you/layout.tsx
+++ b/src/app/[locale]/enroll/thank-you/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { FormThankYouJsonLd } from '@/components/form-thank-you/FormThankYouJsonLd';
+import { buildFormThankYouMetadata } from '@/lib/seo/formThankYouMetadata';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return buildFormThankYouMetadata('enroll', '/enroll/thank-you', locale);
+}
+
+export default async function EnrollThankYouLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <FormThankYouJsonLd formId="enroll" locale={locale} publicPagePath="/enroll/thank-you" />
+      {children}
+    </>
+  );
+}

--- a/src/app/[locale]/enroll/thank-you/page.tsx
+++ b/src/app/[locale]/enroll/thank-you/page.tsx
@@ -1,0 +1,8 @@
+import { getFormThankYouContent } from '@/data/form-thank-you/getFormThankYouContent';
+import { FormThankYouView } from '@/components/form-thank-you/FormThankYouView';
+
+export default async function EnrollThankYouPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const content = getFormThankYouContent('enroll', locale);
+  return <FormThankYouView content={content} locale={locale} />;
+}

--- a/src/app/api/assessment/route.ts
+++ b/src/app/api/assessment/route.ts
@@ -24,10 +24,13 @@ interface AssessmentFormData {
   phone: string;
   studentName: string;
   grade: string;
-  subjects: string[];
+  /** @deprecated Kept for older clients; book form no longer sends focus areas. */
+  subjects?: string[];
   assessmentType: string;
   mode: string;
   schedule: string;
+  /** Free-text or select value, e.g. how the family found GrowWise. */
+  hearAboutUs?: string;
   notes?: string;
 }
 
@@ -41,12 +44,14 @@ export async function POST(request: Request) {
       phone,
       studentName,
       grade,
-      subjects,
+      subjects: subjectsRaw,
       assessmentType,
       mode,
       schedule,
+      hearAboutUs,
       notes
     }: AssessmentFormData = body;
+    const subjects = Array.isArray(subjectsRaw) ? subjectsRaw : [];
 
     // Validate required fields
     if (!parentName || !email || !phone || !studentName || !grade || !assessmentType || !mode || !schedule) {
@@ -90,10 +95,11 @@ export async function POST(request: Request) {
       phone: phone.trim(),
       studentName: studentName.trim(),
       grade: grade.trim(),
-      subjects: subjects || [],
+      subjects,
       assessmentType: assessmentType.trim(),
       mode: mode.trim(),
       schedule: schedule.trim(),
+      hearAboutUs: (typeof hearAboutUs === 'string' ? hearAboutUs : '').trim(),
       notes: notes?.trim() || '',
       timestamp: new Date().toISOString(),
       ip: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
@@ -150,6 +156,7 @@ interface AssessmentPayload {
   assessmentType: string;
   mode: string;
   schedule: string;
+  hearAboutUs: string;
   notes: string;
   timestamp: string;
   ip: string;
@@ -234,10 +241,9 @@ async function sendUserAssessmentConfirmationEmail(
 }
 
 function generateBusinessAssessmentEmailHTML(data: AssessmentPayload) {
-  const subjectsLine =
-    data.subjects.length > 0
-      ? data.subjects.map((s) => escapeHtml(s)).join(', ')
-      : 'Not specified';
+  const hearLine = data.hearAboutUs
+    ? escapeHtml(data.hearAboutUs)
+    : '—';
   const notesBlock = data.notes
     ? `<p><strong>Notes:</strong> ${escapeHtml(data.notes)}</p>`
     : '';
@@ -257,7 +263,6 @@ function generateBusinessAssessmentEmailHTML(data: AssessmentPayload) {
         <h3 style="color: #1F396D; margin-top: 0;">Student Information</h3>
         <p><strong>Student Name:</strong> ${escapeHtml(data.studentName)}</p>
         <p><strong>Grade:</strong> ${escapeHtml(data.grade)}</p>
-        <p><strong>Subjects:</strong> ${subjectsLine}</p>
       </div>
 
       <div style="background-color: #e8f4f8; padding: 20px; border-radius: 8px; margin: 20px 0;">
@@ -265,6 +270,7 @@ function generateBusinessAssessmentEmailHTML(data: AssessmentPayload) {
         <p><strong>Assessment Type:</strong> ${escapeHtml(data.assessmentType)}</p>
         <p><strong>Mode:</strong> ${escapeHtml(data.mode)}</p>
         <p><strong>Preferred Schedule:</strong> ${escapeHtml(data.schedule)}</p>
+        <p><strong>How they heard about us:</strong> ${hearLine}</p>
         ${notesBlock}
       </div>
 
@@ -301,12 +307,12 @@ Submitted: ${new Date(data.timestamp).toLocaleString()}
 Student Information:
 Student Name: ${data.studentName}
 Grade: ${data.grade}
-Subjects: ${data.subjects && data.subjects.length > 0 ? data.subjects.join(', ') : 'Not specified'}
 
 Assessment Details:
 Assessment Type: ${data.assessmentType}
 Mode: ${data.mode}
 Preferred Schedule: ${data.schedule}
+How they heard about us: ${data.hearAboutUs || '—'}
 ${data.notes ? `Notes: ${data.notes}` : ''}
 
 Next Steps:
@@ -333,6 +339,7 @@ function generateUserAssessmentConfirmationEmailHTML(data: AssessmentPayload) {
         <p><strong>Assessment Type:</strong> ${escapeHtml(data.assessmentType)}</p>
         <p><strong>Mode:</strong> ${escapeHtml(data.mode)}</p>
         <p><strong>Preferred Schedule:</strong> ${escapeHtml(data.schedule)}</p>
+        ${data.hearAboutUs ? `<p><strong>How you heard about us:</strong> ${escapeHtml(data.hearAboutUs)}</p>` : ''}
       </div>
 
       <div style="background-color: #fff; padding: 20px; border-radius: 8px; border-left: 4px solid #F16112; margin: 20px 0;">
@@ -373,6 +380,7 @@ Grade: ${data.grade}
 Assessment Type: ${data.assessmentType}
 Mode: ${data.mode}
 Preferred Schedule: ${data.schedule}
+${data.hearAboutUs ? `How you heard about us: ${data.hearAboutUs}` : ''}
 
 What Happens Next?
 - Our team will contact you within 24 hours to confirm your assessment appointment

--- a/src/app/api/testimonials/refresh/route.ts
+++ b/src/app/api/testimonials/refresh/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getBackendBaseUrlForProxy } from '@/lib/config';
 
+const PROXY_TO_BACKEND_MS = 12_000;
+
 export async function POST() {
   try {
     const base = getBackendBaseUrlForProxy();
@@ -13,11 +15,18 @@ export async function POST() {
     const res = await fetch(`${base}/api/testimonials/refresh`, {
       method: 'POST',
       cache: 'no-store',
+      signal: AbortSignal.timeout(PROXY_TO_BACKEND_MS),
     });
     const data = await res.json().catch(() => ({}));
     return NextResponse.json(data, { status: res.status });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Proxy failed';
-    return NextResponse.json({ success: false, error: message }, { status: 502 });
+    const isTimeout =
+      error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+    const message = isTimeout
+      ? 'Backend request timed out. Is the API server running?'
+      : error instanceof Error
+        ? error.message
+        : 'Proxy failed';
+    return NextResponse.json({ success: false, error: message }, { status: isTimeout ? 504 : 502 });
   }
 }

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getBackendBaseUrlForProxy } from '@/lib/config';
 
+/** Slightly above Express axios timeout to backend Google call so the proxy does not hang indefinitely. */
+const PROXY_TO_BACKEND_MS = 12_000;
+
 /**
  * Proxies GET /api/testimonials → Express backend (same-origin from the browser).
  */
@@ -18,11 +21,20 @@ export async function GET(request: Request) {
       );
     }
     const { search } = new URL(request.url);
-    const res = await fetch(`${base}/api/testimonials${search}`, { cache: 'no-store' });
+    const res = await fetch(`${base}/api/testimonials${search}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(PROXY_TO_BACKEND_MS),
+    });
     const data = await res.json().catch(() => ({}));
     return NextResponse.json(data, { status: res.status });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Proxy failed';
-    return NextResponse.json({ success: false, error: message }, { status: 502 });
+    const isTimeout =
+      error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+    const message = isTimeout
+      ? 'Backend request timed out. Is the API server running and reachable?'
+      : error instanceof Error
+        ? error.message
+        : 'Proxy failed';
+    return NextResponse.json({ success: false, error: message }, { status: isTimeout ? 504 : 502 });
   }
 }

--- a/src/app/api/testimonials/stats/route.ts
+++ b/src/app/api/testimonials/stats/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getBackendBaseUrlForProxy } from '@/lib/config';
 
+const PROXY_TO_BACKEND_MS = 12_000;
+
 export async function GET() {
   try {
     const base = getBackendBaseUrlForProxy();
@@ -10,11 +12,20 @@ export async function GET() {
         { status: 503 },
       );
     }
-    const res = await fetch(`${base}/api/testimonials/stats`, { cache: 'no-store' });
+    const res = await fetch(`${base}/api/testimonials/stats`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(PROXY_TO_BACKEND_MS),
+    });
     const data = await res.json().catch(() => ({}));
     return NextResponse.json(data, { status: res.status });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Proxy failed';
-    return NextResponse.json({ success: false, error: message }, { status: 502 });
+    const isTimeout =
+      error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+    const message = isTimeout
+      ? 'Backend request timed out. Is the API server running?'
+      : error instanceof Error
+        ? error.message
+        : 'Proxy failed';
+    return NextResponse.json({ success: false, error: message }, { status: isTimeout ? 504 : 502 });
   }
 }

--- a/src/components/FreeAssessmentModal.tsx
+++ b/src/components/FreeAssessmentModal.tsx
@@ -2,7 +2,9 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useTranslations, useLocale } from 'next-intl';
+import { publicPath } from '@/lib/publicPath';
 import { X, CheckCircle, User, GraduationCap, BookOpen, Users, MessageSquare } from 'lucide-react';
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -45,6 +47,8 @@ interface FormData {
 }
 
 const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClose }) => {
+  const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations();
   const [formData, setFormData] = useState<FormData>({
     parentName: '',
@@ -61,7 +65,6 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
     notes: ''
   });
 
-  const [isSubmitted, setIsSubmitted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const [agreeToCommunications, setAgreeToCommunications] = useState(false);
@@ -190,6 +193,7 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
       mode: formData.mode.trim(),
       schedule,
       notes: notesCombined,
+      hearAboutUs: 'Website — free assessment modal (not specified)',
     };
 
     setIsSubmitting(true);
@@ -207,7 +211,9 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
       }
 
       if (result.success) {
-        setIsSubmitted(true);
+        router.replace(publicPath('/book-assessment/thank-you', locale));
+        resetAndClose();
+        return;
       } else {
         setSubmitError(result.error || 'Failed to submit assessment booking.');
       }
@@ -233,7 +239,6 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
       preferredTime: '',
       notes: ''
     });
-    setIsSubmitted(false);
     setIsSubmitting(false);
     setSubmitError('');
     setAgreeToCommunications(false);
@@ -256,7 +261,6 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
 
             <div className="overflow-y-auto max-h-[78vh] min-h-0 custom-scrollbar">
               <CardContent className="p-8 lg:p-12">
-              {!isSubmitted ? (
                 <>
                   <div className="text-center mb-8">
                     <div className="w-16 h-16 bg-gradient-to-r from-[#F16112] to-[#F1894F] rounded-full flex items-center justify-center mx-auto mb-4 shadow-[0px_15px_40px_rgba(241,97,18,0.4)]">
@@ -542,39 +546,6 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
                     </div>
                   </form>
                 </>
-              ) : (
-                <div className="text-center py-8">
-                  <div className="w-20 h-20 bg-gradient-to-r from-green-500 to-green-600 rounded-full flex items-center justify-center mx-auto mb-6 shadow-[0px_20px_50px_rgba(34,197,94,0.4)]">
-                    <CheckCircle className="w-10 h-10 text-white" />
-                  </div>
-
-                  <h2 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
-                    Thank You!
-                  </h2>
-
-                  <p className="text-lg text-gray-600 mb-8 leading-relaxed max-w-md mx-auto">
-                    Our team will contact you within 24 hours to confirm your free assessment.
-                  </p>
-
-                  <div className="space-y-4">
-                    <div className="bg-gradient-to-r from-[#1F396D]/10 to-[#F16112]/10 rounded-xl p-6 backdrop-blur-xl border-2 border-white/60">
-                      <h3 className="font-semibold text-[#1F396D] mb-2">What happens next?</h3>
-                      <ul className="text-sm text-gray-600 space-y-1 text-left">
-                        <li>✓ We'll review your child's information</li>
-                        <li>✓ Schedule a convenient assessment time</li>
-                        <li>✓ Provide personalized learning recommendations</li>
-                      </ul>
-                    </div>
-
-                    <Button
-                      onClick={resetAndClose}
-                      className="bg-gradient-to-r from-[#1F396D] to-[#29335C] hover:from-[#29335C] hover:to-[#1F396D] text-white rounded-xl px-8 py-3 font-semibold shadow-lg hover:shadow-xl transition-all duration-300"
-                    >
-                      Close
-                    </Button>
-                  </div>
-                </div>
-              )}
               </CardContent>
             </div>
           </div>

--- a/src/components/camps/__tests__/summer-camp-data.test.ts
+++ b/src/components/camps/__tests__/summer-camp-data.test.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 
 import {
   hydrateSummerCampData,
+  getMinimumPublishedSummerCampPriceUsd,
   LEARNING_MODE_KEYS,
   LEARNING_MODE_FORMAT,
   LEARNING_MODE_TIME,
@@ -215,5 +216,29 @@ describe('hydrateSummerCampData (programs)', () => {
     const roblox = SUMMER_CAMP_PROGRAMS.find((p) => p.id === 'roblox-in-person');
     expect(roblox).toBeDefined();
     expect(roblox!.category).toBe('Half-Day Camps');
+  });
+});
+
+describe('getMinimumPublishedSummerCampPriceUsd', () => {
+  it('is the global minimum in hydrated EN data (Event JSON-LD offer price source)', () => {
+    const min = getMinimumPublishedSummerCampPriceUsd();
+    const { programs, olympiadTierConfigs } = loadHydrated();
+    const all: number[] = [];
+    for (const p of programs) {
+      if (p.startingPrice > 0) all.push(p.startingPrice);
+      for (const l of p.levels) {
+        l.slots.forEach((s) => all.push(s.price));
+        if (l.priceByProgramAndFormat) {
+          for (const m of Object.values(l.priceByProgramAndFormat)) {
+            all.push(m.Online, m['In-Person']);
+          }
+        }
+      }
+    }
+    for (const t of olympiadTierConfigs) {
+      all.push(t.priceByFormat.Online, t.priceByFormat['In-Person']);
+    }
+    expect(min).toBe(Math.min(...all));
+    expect(min).toBe(259);
   });
 });

--- a/src/components/form-thank-you/FormThankYouJsonLd.tsx
+++ b/src/components/form-thank-you/FormThankYouJsonLd.tsx
@@ -1,0 +1,33 @@
+import { getFormThankYouContent } from '@/data/form-thank-you/getFormThankYouContent';
+import type { FormThankYouId } from '@/data/form-thank-you/types';
+import { absoluteSiteUrl } from '@/lib/publicPath';
+import { generateFormThankYouJsonLd } from '@/lib/seo/structuredData';
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
+
+type Props = {
+  formId: FormThankYouId;
+  locale: string;
+  /** Public path e.g. `/book-assessment/thank-you` (no locale prefix). */
+  publicPagePath: string;
+};
+
+/**
+ * Injects a single @graph (BreadcrumbList + WebPage) for form thank-you routes.
+ */
+export function FormThankYouJsonLd({ formId, locale, publicPagePath }: Props) {
+  const c = getFormThankYouContent(formId, locale);
+  const pageUrl = absoluteSiteUrl(publicPagePath, locale, getCanonicalSiteUrl());
+  const graph = generateFormThankYouJsonLd({
+    name: c.title,
+    description: c.metaDescription,
+    pageUrl,
+    locale,
+    formId,
+  });
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
+    />
+  );
+}

--- a/src/components/form-thank-you/FormThankYouView.tsx
+++ b/src/components/form-thank-you/FormThankYouView.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link';
+import { CheckCircle, Clock, Shield, ThumbsUp } from 'lucide-react';
+import type { FormThankYouContent } from '@/data/form-thank-you/types';
+import { publicPath } from '@/lib/publicPath';
+
+const HIGHLIGHT_ICONS = [Clock, Shield, ThumbsUp] as const;
+
+type Props = {
+  content: FormThankYouContent;
+  /** next-intl / [locale] segment */
+  locale: string;
+};
+
+/**
+ * Centered thank-you content driven by JSON; CTA hrefs are locale-prefixed via publicPath.
+ */
+export function FormThankYouView({ content, locale }: Props) {
+  const p = (path: string) => publicPath(path, locale);
+  return (
+    <div
+      className="min-h-screen bg-gradient-to-b from-slate-50 to-white font-sans"
+      data-testid="form-thank-you"
+    >
+      <div className="container mx-auto max-w-xl px-4 py-14 md:px-6 md:py-20">
+        <div className="mb-8 flex justify-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-r from-emerald-500 to-emerald-600 shadow-lg">
+            <CheckCircle className="h-10 w-10 text-white" aria-hidden />
+          </div>
+        </div>
+        {content.kicker && (
+          <p className="text-center text-sm font-medium text-emerald-800">{content.kicker}</p>
+        )}
+        <h1 className="mt-2 text-center text-2xl font-bold tracking-tight text-slate-900 md:text-3xl">
+          {content.title}
+        </h1>
+        <div className="mt-6 space-y-4 text-center text-slate-700">
+          {content.body.map((paragraph, i) => (
+            <p key={i} className="text-base leading-relaxed">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+        {content.highlights && content.highlights.length > 0 && (
+          <ul className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {content.highlights.map((h, i) => {
+              const Icon = HIGHLIGHT_ICONS[i % HIGHLIGHT_ICONS.length];
+              return (
+                <li
+                  key={h.text}
+                  className="flex flex-col items-center gap-2 rounded-lg border border-slate-200 bg-white/80 px-3 py-4 text-center"
+                >
+                  {Icon && <Icon className="h-6 w-6 text-emerald-700" aria-hidden />}
+                  <span className="text-sm text-slate-600">{h.text}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <div className="mt-10 flex flex-col gap-3 sm:mx-auto sm:max-w-md">
+          <Link
+            href={p(content.primaryCta.path)}
+            className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#F16112] px-7 py-3.5 text-center text-sm font-semibold text-white transition-colors hover:bg-[#d3540f] md:text-base"
+          >
+            {content.primaryCta.label}
+          </Link>
+          {content.secondaryCta && (
+            <Link
+              href={p(content.secondaryCta.path)}
+              className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg border-2 border-[#1F396D] bg-white px-7 py-3.5 text-center text-sm font-semibold text-[#1F396D] transition-colors hover:bg-slate-50 md:text-base"
+            >
+              {content.secondaryCta.label}
+            </Link>
+          )}
+        </div>
+        <p className="mt-10 text-center">
+          <Link
+            href={p(content.backLink.path)}
+            className="text-sm font-semibold text-[#1F396D] hover:underline"
+          >
+            {content.backLink.label}
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Header/Dropdown.tsx
+++ b/src/components/layout/Header/Dropdown.tsx
@@ -108,7 +108,7 @@ export default function Dropdown({
       {/* FIX #2: ADD MOUSE ENTER AND MOUSE LEAVE - Keeps dropdown open when cursor moves onto the dropdown panel and triggers close delay when cursor leaves the dropdown panel */}
       {visibleItems.length > 0 && (
         <div 
-          className={`absolute top-full left-0 mt-2 w-80 bg-white border-2 border-gray-200 shadow-[0px_20px_60px_rgba(31,57,109,0.2)] rounded-2xl transition-all duration-300 ring-1 ring-gray-200 overflow-visible ${
+          className={`absolute top-full left-0 z-50 mt-2 w-80 bg-white border-2 border-gray-200 shadow-[0px_20px_60px_rgba(31,57,109,0.2)] rounded-2xl transition-all duration-300 ring-1 ring-gray-200 overflow-visible ${
             isOpen ? 'opacity-100 visible translate-y-0' : 'opacity-0 invisible -translate-y-2'
           }`}
           onMouseEnter={onMouseEnter} 

--- a/src/components/layout/Header/Navigation.tsx
+++ b/src/components/layout/Header/Navigation.tsx
@@ -44,7 +44,11 @@ export default function Navigation({
   return (
     <>
       {/* Desktop Navigation */}
-      <nav className="header-desktop-nav">
+      {/*
+        Stack nav above the utility column (search/cart/enroll) so open dropdowns and
+        submenus are not covered by a later flex sibling. See .header-dropdown-panel in globals.
+      */}
+      <nav className="header-desktop-nav relative z-[100]">
         {menuItems
           .filter((item) => item.key !== 'enroll') // Filter out enroll button as it's now in UtilityIcons
           .map((item) => (

--- a/src/components/layout/Header/UtilityIcons.tsx
+++ b/src/components/layout/Header/UtilityIcons.tsx
@@ -25,7 +25,7 @@ export default function UtilityIcons({ cartItemCount, createLocaleUrl, showCart 
   };
 
   return (
-    <div className="hidden lg:flex items-center space-x-3 flex-shrink-0">
+    <div className="header-utilities relative z-0 hidden lg:flex items-center space-x-3 flex-shrink-0">
       <div className="flex items-center space-x-3">
         <SearchBar />
         {showCart && (

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { useLocale } from 'next-intl';
+import { publicPath } from '@/lib/publicPath';
 import { useChatbot } from '../../contexts/ChatbotContext';
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -42,6 +45,8 @@ import { CONTACT_INFO } from '@/lib/constants';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 
 export default function Contact() {
+  const router = useRouter();
+  const locale = useLocale();
   const { openChatbot } = useChatbot();
   const t = useTranslations('contact');
   const dispatch = useAppDispatch();
@@ -61,7 +66,6 @@ export default function Contact() {
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [agreeToCommunications, setAgreeToCommunications] = useState(false);
@@ -119,7 +123,8 @@ export default function Contact() {
       });
 
       if (result.success) {
-        setIsSubmitted(true);
+        router.replace(publicPath('/contact/thank-you', locale));
+        return;
       } else {
         if (result.errors?.length) {
           const byField = result.errors.reduce<Record<string, string>>((acc, { field, message }) => {
@@ -165,39 +170,6 @@ export default function Contact() {
     googleMapsUrl: `https://maps.google.com/?q=${encodeURIComponent(CONTACT_INFO.address)}`,
     directionsUrl: `https://maps.google.com/?daddr=${encodeURIComponent(CONTACT_INFO.address)}`
   };
-
-  if (isSubmitted) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
-        <Card className="max-w-md w-full bg-white shadow-xl">
-          <CardContent className="p-8 text-center">
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-              <CheckCircle className="w-8 h-8 text-green-600" />
-            </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">{t('success.title')}</h1>
-            <p className="text-gray-600 mb-6">
-              {t('success.description')}
-            </p>
-            <div className="space-y-3">
-              <Button 
-                className="w-full bg-[#1F396D] hover:bg-[#29335C] text-white"
-                onClick={() => setIsSubmitted(false)}
-              >
-                Send Another Message
-              </Button>
-              <Button 
-                variant="outline"
-                className="w-full border-[#F16112] text-[#F16112] hover:bg-[#F16112] hover:text-white"
-              >
-                <Phone className="w-4 h-4 mr-2" />
-                Call {CONTACT_INFO.phone}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -79,7 +79,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-[110] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[200] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/src/data/form-thank-you/en.json
+++ b/src/data/form-thank-you/en.json
@@ -1,0 +1,59 @@
+{
+  "book-assessment": {
+    "version": 1,
+    "metaTitle": "Assessment request received | GrowWise",
+    "metaDescription": "Thank you — we received your free assessment booking. Our team will contact you within 24 hours to confirm your appointment.",
+    "title": "Thank you for your request",
+    "kicker": "Submission completed successfully.",
+    "body": [
+      "We've received your free assessment booking request. Our team will contact you within 24 hours to confirm your appointment."
+    ],
+    "highlights": [
+      { "text": "24-hour response guaranteed" },
+      { "text": "Your data is secure" },
+      { "text": "Welcome to GrowWise!" }
+    ],
+    "primaryCta": { "label": "Book another assessment", "path": "/book-assessment" },
+    "secondaryCta": { "label": "Explore programs", "path": "/programs" },
+    "backLink": { "label": "Back to home", "path": "/" }
+  },
+  "enroll": {
+    "version": 1,
+    "metaTitle": "Enrollment request received | GrowWise",
+    "metaDescription": "Thank you for your enrollment request. A GrowWise advisor will contact you within 24 hours.",
+    "title": "Thank you for enrolling with GrowWise",
+    "kicker": "We received your information.",
+    "body": [
+      "We will contact you within 24 hours to discuss next steps and answer your questions."
+    ],
+    "primaryCta": { "label": "View programs", "path": "/programs" },
+    "secondaryCta": { "label": "Book a free assessment", "path": "/book-assessment" },
+    "backLink": { "label": "Back to enrollment", "path": "/enroll" }
+  },
+  "enroll-academic": {
+    "version": 1,
+    "metaTitle": "Academic enrollment request received | GrowWise",
+    "metaDescription": "Thank you for your academic enrollment request. We will connect with you within 24 hours.",
+    "title": "Thank you for your academic enrollment request",
+    "kicker": "We received your details.",
+    "body": [
+      "Our team will contact you within 24 hours to discuss placement and next steps for your child's academic journey."
+    ],
+    "primaryCta": { "label": "View academic programs", "path": "/academic" },
+    "secondaryCta": { "label": "Book a free assessment", "path": "/book-assessment" },
+    "backLink": { "label": "Back to academic enrollment", "path": "/enroll-academic" }
+  },
+  "contact": {
+    "version": 1,
+    "metaTitle": "Message received | GrowWise",
+    "metaDescription": "Thank you for contacting GrowWise. We will respond as soon as possible, typically within one business day.",
+    "title": "Thank you for your message",
+    "kicker": "Your message was sent successfully.",
+    "body": [
+      "A GrowWise team member will get back to you soon, typically within one business day. For urgent needs, you can also call us directly from the contact page."
+    ],
+    "primaryCta": { "label": "Send another message", "path": "/contact" },
+    "secondaryCta": { "label": "Book a free assessment", "path": "/book-assessment" },
+    "backLink": { "label": "Back to contact", "path": "/contact" }
+  }
+}

--- a/src/data/form-thank-you/getFormThankYouContent.ts
+++ b/src/data/form-thank-you/getFormThankYouContent.ts
@@ -1,0 +1,45 @@
+import { getValidLocale } from '@/i18n/localeConfig';
+import enContent from './en.json';
+import type { FormThankYouContent, FormThankYouContentMap, FormThankYouId } from './types';
+
+const en = enContent as FormThankYouContentMap;
+
+/** Add more locale files here as they are introduced. */
+const byLocale: Record<string, FormThankYouContentMap> = {
+  en,
+};
+
+function isFormThankYouId(x: string): x is FormThankYouId {
+  return x in en;
+}
+
+function mapForLocale(locale: string): FormThankYouContentMap {
+  const key = getValidLocale(locale);
+  return byLocale[key] ?? en;
+}
+
+/**
+ * Resolves thank-you copy for a form. Falls back to English if the locale has no file yet.
+ */
+export function getFormThankYouContent(
+  formId: FormThankYouId,
+  locale: string
+): FormThankYouContent {
+  if (!isFormThankYouId(formId)) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(`[getFormThankYouContent] unknown formId: ${formId}, using book-assessment`);
+    }
+    return en['book-assessment'];
+  }
+  const map = mapForLocale(locale);
+  const entry = map[formId] ?? en[formId];
+  return entry;
+}
+
+export function getFormThankYouContentByKey(
+  formId: string,
+  locale: string
+): FormThankYouContent | null {
+  if (!isFormThankYouId(formId)) return null;
+  return getFormThankYouContent(formId, locale);
+}

--- a/src/data/form-thank-you/types.ts
+++ b/src/data/form-thank-you/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Type-safe form thank-you page content. Copy lives in per-locale JSON (currently en).
+ */
+
+export const FORM_THANK_YOU_IDS = [
+  'book-assessment',
+  'enroll',
+  'enroll-academic',
+  'contact',
+] as const;
+
+export type FormThankYouId = (typeof FORM_THANK_YOU_IDS)[number];
+
+export interface FormThankYouCta {
+  label: string;
+  /** Site path without locale prefix, e.g. /book-assessment */
+  path: string;
+}
+
+export interface FormThankYouContent {
+  version: number;
+  /** Used for <title> and Open Graph */
+  metaTitle: string;
+  metaDescription: string;
+  /** H1 (visible) */
+  title: string;
+  /** Optional short line above the title */
+  kicker?: string;
+  /** One or more body paragraphs */
+  body: string[];
+  /** Optional icon rows (e.g. assessment) */
+  highlights?: ReadonlyArray<{ text: string }>;
+  /** Primary CTA (e.g. "Book again") */
+  primaryCta: FormThankYouCta;
+  /** Optional second action */
+  secondaryCta?: FormThankYouCta;
+  /** Text link back to a parent page */
+  backLink: FormThankYouCta;
+}
+
+export type FormThankYouContentMap = Record<FormThankYouId, FormThankYouContent>;

--- a/src/lib/seo/formThankYouMetadata.ts
+++ b/src/lib/seo/formThankYouMetadata.ts
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import { getFormThankYouContent } from '@/data/form-thank-you/getFormThankYouContent';
+import type { FormThankYouId } from '@/data/form-thank-you/types';
+import { getValidLocale } from '@/i18n/localeConfig';
+import { generatePageMetadata } from '@/lib/seo/metadata';
+
+/**
+ * Robots: noindex,follow; title/description from JSON (single source of truth).
+ */
+export function buildFormThankYouMetadata(
+  formId: FormThankYouId,
+  path: string,
+  rawLocale: string
+): Metadata {
+  const locale = getValidLocale(rawLocale);
+  const c = getFormThankYouContent(formId, locale);
+  return generatePageMetadata({
+    title: c.metaTitle,
+    description: c.metaDescription,
+    locale,
+    path,
+    indexable: false,
+  });
+}

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -19,6 +19,8 @@ interface PageMetadataOptions {
   type?: "website" | "article";
   publishedTime?: string;
   modifiedTime?: string;
+  /** If false, emit noindex,follow (conversion / thank-you pages). Defaults to true. */
+  indexable?: boolean;
 }
 
 /**
@@ -61,6 +63,7 @@ export function generatePageMetadata({
   type = "website",
   publishedTime,
   modifiedTime,
+  indexable = true,
 }: PageMetadataOptions): Metadata {
   const baseUrl = getCanonicalSiteUrl();
   const pathForUrl = path === "" ? "/" : path;
@@ -116,10 +119,10 @@ export function generatePageMetadata({
       canonical: url,
     },
     robots: {
-      index: true,
+      index: indexable,
       follow: true,
       googleBot: {
-        index: true,
+        index: indexable,
         follow: true,
         "max-video-preview": -1,
         "max-image-preview": "large",

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -162,12 +162,42 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/book-assessment': {
-    title: 'Book Free Grades 1-12 Assessment | GrowWise',
+    title: 'Free Academic Assessment in Dublin, CA | GrowWise',
     description:
-      'Book a free Grades 1-12 placement assessment in Dublin, CA. Understand strengths, gaps, and the right next step.',
+      'Book a free academic assessment for your child at GrowWise in Dublin, CA. Get expert evaluation in math or English and a personalized learning plan.',
     keywords:
-      'free assessment, placement assessment, Grades 1-12 assessment, academic evaluation, free tutoring assessment Dublin CA, book assessment',
+      'free academic assessment Dublin CA, free assessment, placement assessment, math English evaluation, personalized learning plan, book assessment',
     path: '/book-assessment',
+  },
+
+  // Thank-you: runtime `generateMetadata` uses `buildFormThankYouMetadata` + `src/data/form-thank-you/en.json` (noindex).
+  '/book-assessment/thank-you': {
+    title: 'Assessment request received | GrowWise',
+    description:
+      'Thank you — we received your free assessment booking. Our team will contact you within 24 hours to confirm your appointment.',
+    keywords: 'GrowWise, assessment, thank you, confirmation',
+    path: '/book-assessment/thank-you',
+  },
+  '/enroll-academic/thank-you': {
+    title: 'Academic enrollment request received | GrowWise',
+    description:
+      'Thank you for your academic enrollment request. We will connect with you within 24 hours.',
+    keywords: 'GrowWise, academic enrollment, thank you',
+    path: '/enroll-academic/thank-you',
+  },
+  '/enroll/thank-you': {
+    title: 'Enrollment request received | GrowWise',
+    description:
+      'Thank you for your enrollment request. A GrowWise advisor will contact you within 24 hours.',
+    keywords: 'GrowWise, enrollment, thank you',
+    path: '/enroll/thank-you',
+  },
+  '/contact/thank-you': {
+    title: 'Message received | GrowWise',
+    description:
+      'Thank you for contacting GrowWise. We will respond as soon as possible, typically within one business day.',
+    keywords: 'GrowWise, contact, thank you',
+    path: '/contact/thank-you',
   },
 
   '/camps': {

--- a/src/lib/seo/structuredData.ts
+++ b/src/lib/seo/structuredData.ts
@@ -3,7 +3,9 @@
  * Schema.org markup for better search engine understanding
  */
 
+import type { FormThankYouId } from '@/data/form-thank-you/types'
 import { CONTACT_INFO } from '@/lib/constants'
+import { absoluteSiteUrl } from '@/lib/publicPath'
 import { getCanonicalSiteUrl } from './siteUrl'
 
 const CANONICAL_BASE = getCanonicalSiteUrl()
@@ -457,6 +459,60 @@ export function generateBreadcrumbSchema(items: Array<{
 }
 
 /**
+ * WebPage for a program/marketing URL — mirrors form-thank-you WebPage; site org graph stays in root layout.
+ */
+export function generateWebPageJsonLd({
+  name,
+  description,
+  url,
+  inLanguage = "en-US",
+}: {
+  name: string
+  description: string
+  url: string
+  inLanguage?: string
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": name,
+    "description": description,
+    "url": url,
+    "inLanguage": inLanguage,
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "GrowWise",
+      "url": CANONICAL_BASE,
+    },
+    "about": {
+      "@type": "EducationalOrganization",
+      "name": "GrowWise",
+      "url": CANONICAL_BASE,
+    },
+  }
+}
+
+/**
+ * ItemList of public URLs (e.g. summer program detail pages). Each entry must map to a real on-site route.
+ */
+export function generateItemListSchema(
+  name: string,
+  items: ReadonlyArray<{ name: string; url: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": name,
+    "itemListElement": items.map((item, index) => ({
+      "@type": "ListItem",
+      "position": index + 1,
+      "name": item.name,
+      "item": item.url,
+    })),
+  }
+}
+
+/**
  * Generate Article structured data (for blog posts)
  * Only include verified fields — never invent dates, images, or author names not visible on the page.
  */
@@ -500,5 +556,75 @@ export function generateArticleSchema({
     ...(datePublished && { "datePublished": datePublished }),
     ...(dateModified && { "dateModified": dateModified }),
   }
+}
+
+const BREADCRUMB_FOR_FORM: Record<
+  FormThankYouId,
+  { parentName: string; parentPath: string }
+> = {
+  'book-assessment': { parentName: 'Book assessment', parentPath: '/book-assessment' },
+  enroll: { parentName: 'Enroll', parentPath: '/enroll' },
+  'enroll-academic': { parentName: 'Academic enrollment', parentPath: '/enroll-academic' },
+  contact: { parentName: 'Contact', parentPath: '/contact' },
+};
+
+/**
+ * JSON-LD for form thank-you pages: BreadcrumbList + WebPage in one @graph.
+ * No PII; aligns with home WebPage pattern in (home)/layout.tsx.
+ */
+export function generateFormThankYouJsonLd({
+  name,
+  description,
+  pageUrl,
+  locale,
+  inLanguage = 'en-US',
+  formId,
+}: {
+  name: string;
+  description: string;
+  pageUrl: string;
+  /** Used with publicPath for Home and parent funnel URLs. */
+  locale: string;
+  inLanguage?: string;
+  formId: FormThankYouId;
+}): Record<string, unknown> {
+  const { parentName, parentPath } = BREADCRUMB_FOR_FORM[formId];
+  const homeUrl = absoluteSiteUrl('/', locale, CANONICAL_BASE);
+  const parentUrl = absoluteSiteUrl(parentPath, locale, CANONICAL_BASE);
+
+  const breadcrumb: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: homeUrl },
+      { '@type': 'ListItem', position: 2, name: parentName, item: parentUrl },
+      { '@type': 'ListItem', position: 3, name: 'Thank you', item: pageUrl },
+    ],
+  };
+
+  const orgUrl = homeUrl;
+  const webPage: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name,
+    description,
+    url: pageUrl,
+    inLanguage,
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'GrowWise',
+      url: orgUrl,
+    },
+    about: {
+      '@type': 'EducationalOrganization',
+      name: 'GrowWise',
+      url: orgUrl,
+    },
+  };
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [breadcrumb, webPage],
+  };
 }
 

--- a/src/lib/summer-camp-data.ts
+++ b/src/lib/summer-camp-data.ts
@@ -275,6 +275,39 @@ export function getDefaultSummerCampData(): ReturnType<typeof hydrateSummerCampD
   return _defaultData;
 }
 
+/**
+ * Lowest published USD price across default camp data (all slot prices, per-format prices, and Olympiad tiers).
+ * Used for Event JSON-LD `Offer.price` (e.g. GSC) so the value matches on-page pricing, not GTM or data layer.
+ */
+export function getMinimumPublishedSummerCampPriceUsd(): number {
+  const { programs, olympiadTierConfigs } = getDefaultSummerCampData();
+  const candidates: number[] = [];
+  for (const p of programs) {
+    if (p.startingPrice > 0) candidates.push(p.startingPrice);
+    for (const level of p.levels) {
+      for (const s of level.slots) {
+        if (s.price > 0) candidates.push(s.price);
+      }
+      if (level.priceByProgramAndFormat) {
+        for (const byFmt of Object.values(level.priceByProgramAndFormat)) {
+          for (const n of Object.values(byFmt)) {
+            if (n > 0) candidates.push(n);
+          }
+        }
+      }
+    }
+  }
+  for (const t of olympiadTierConfigs) {
+    for (const n of Object.values(t.priceByFormat)) {
+      if (n > 0) candidates.push(n);
+    }
+  }
+  if (candidates.length === 0) {
+    throw new Error('getMinimumPublishedSummerCampPriceUsd: no positive prices in camp data');
+  }
+  return Math.min(...candidates);
+}
+
 /** Fetches summer camp data from the mock API (same pattern as FAQ, academic, math, steam). Fallback to en if locale file missing. */
 export async function fetchSummerCampData(locale: string): Promise<{
   programs: Program[];

--- a/src/lib/testimonialsApi.ts
+++ b/src/lib/testimonialsApi.ts
@@ -123,7 +123,19 @@ class TestimonialsApiService {
         console.warn('⚠️ Backend API error, using default testimonials:', data.error);
         return this.getDefaultTestimonials(limit || null, offset, minRating);
       }
-      
+
+      // Backend returns 200 with empty `testimonials` when Google/credentials are unavailable
+      // (replaces previous HTTP 500 for the same condition).
+      const source = (data as { data?: { testimonials?: TestimonialVM[]; source?: string } }).data?.source;
+      if (
+        data.success &&
+        data.data?.testimonials?.length === 0 &&
+        (source === 'unavailable' || source === 'empty')
+      ) {
+        console.warn(`⚠️ No live testimonials; using default testimonials (source: ${source})`);
+        return this.getDefaultTestimonials(limit || null, offset, minRating);
+      }
+
       return data;
     } catch (error) {
       console.warn('⚠️ Backend API unavailable, using default testimonials:', error);


### PR DESCRIPTION
## Summary
- **Book assessment:** Day/time schedule selects, updated H1 + `metadataConfig`, Service JSON-LD (`@id`, `City` `areaServed`, richer `offers`), remove optional notes block; `assessment` API + e2e updates.
- **Thank-you flows:** JSON-driven thank-you routes for book-assessment, contact, enroll, enroll-academic; `FormThankYouView`, `FormThankYouJsonLd`, `router.replace` on success.
- **Header / UI:** Nav stacks above search/cart/enroll; `SelectContent` z-200; dropdown panel `z-50` (fixes pointer interception).
- **Other:** Testimonial API hardening/timeout; summer camp GSC data; `package.json` and related.

## Test plan
- [ ] `npm test` (Jest)
- [ ] `npx playwright install && npm run test:e2e` as needed
- [ ] Manual: book assessment submit → thank-you; header dropdowns; grade/type/schedule selects

Branch: `feature/book-assessment-thankyou-seo-header`

Made with [Cursor](https://cursor.com)