### PR TITLE
feat: Math finals practice landing, API, Brevo, and nav

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -97,6 +97,7 @@ META_CAPI_ACCESS_TOKEN=
 # BREVO_SENDER_EMAIL=   # must be a verified sender/domain in Brevo
 # BREVO_SENDER_NAME=GrowWise
 # BREVO_LIST_LOTTERY=   # numeric list id (summer camp guide leads + Meta leads). List id 11 is never attached in code (see BREVO_LIST_IDS_EXCLUDED_FROM_AUTOMATION in src/lib/brevo.ts).
+# BREVO_LIST_MATH_FINALS=15   # Brevo list for /api/math-finals-practice leads (automations; attributes: see upsertMathFinalsLeadInBrevo in src/lib/brevo.ts)
 # Summer camp guide email (/api/summer-camp-lottery): tries Brevo first; if Brevo returns an error, falls back to SMTP_* below.
 # If both fail, the API returns 503 (no fake success). See server logs for [summer-camp-guide] and [brevo].
 # Create Text contact attributes for Meta sync: CAMP_INTEREST, GRADE, FIRSTNAME, LASTNAME, PHONE, SOURCE, etc.

--- a/public/api/mock/en/header.json
+++ b/public/api/mock/en/header.json
@@ -65,7 +65,25 @@
             "description": "Advanced mathematics for high school students",
             "icon": "GraduationCap",
             "href": "/courses/high-school-math",
-            "gradient": "from-[#29335C] to-[#1F396D]"
+            "gradient": "from-[#29335C] to-[#1F396D]",
+            "hasSubmenu": true,
+            "submenuHeaderSubtitle": "Tutoring, curriculum, and finals prep",
+            "submenuItems": [
+              {
+                "title": "High School Math",
+                "description": "Algebra I through Pre-Calculus — tutoring overview",
+                "icon": "GraduationCap",
+                "href": "/courses/high-school-math",
+                "gradient": "from-[#29335C] to-[#1F396D]"
+              },
+              {
+                "title": "Math Finals Prep",
+                "description": "End-of-year finals support & complimentary preview session",
+                "icon": "Target",
+                "href": "/math-finals-practice-session",
+                "gradient": "from-[#1F396D] to-[#F16112]"
+              }
+            ]
           },
           {
             "key": "satPrep",

--- a/src/app/[locale]/math-finals-practice-session/layout.tsx
+++ b/src/app/[locale]/math-finals-practice-session/layout.tsx
@@ -1,0 +1,77 @@
+import { Metadata } from 'next'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { CONTACT_INFO } from '@/lib/constants'
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params
+  const metadata = generateMetadataFromPath('/math-finals-practice-session', locale)
+  return (
+    metadata || {
+      title: 'Free math finals practice | GrowWise',
+      description: 'Free in-center high school math finals practice session in Dublin, CA.',
+    }
+  )
+}
+
+export default async function MathFinalsPracticeLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+
+  const serviceSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    '@id': absoluteSiteUrl('/math-finals-practice-session#service', locale, baseUrl),
+    name: 'Complimentary high school math finals session (Sunday 12–1 pm)',
+    description:
+      'One complimentary in-center session in the Sunday 12–1 pm window for high school students preparing for math finals (Algebra 1 through Pre-Calculus) at GrowWise in Dublin, CA. Paid four-session Math Finals Prep is a separate program.',
+    serviceType: 'Tutoring session',
+    provider: {
+      '@type': 'EducationalOrganization',
+      name: 'GrowWise',
+      url: baseUrl,
+      telephone: CONTACT_INFO.phone,
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: CONTACT_INFO.street,
+        addressLocality: 'Dublin',
+        addressRegion: 'CA',
+        postalCode: CONTACT_INFO.zipCode,
+        addressCountry: 'US',
+      },
+    },
+    areaServed: [
+      { '@type': 'City', name: 'Dublin' },
+      { '@type': 'City', name: 'Pleasanton' },
+      { '@type': 'City', name: 'San Ramon' },
+      { '@type': 'City', name: 'Livermore' },
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+      url: absoluteSiteUrl('/math-finals-practice-session', locale, baseUrl),
+      description:
+        'Complimentary Sunday session in the 12–1 pm window (registration required; capacity limited). Paid four-session Math Finals Prep is separate.',
+    },
+    url: absoluteSiteUrl('/math-finals-practice-session', locale, baseUrl),
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceSchema) }}
+      />
+      {children}
+    </>
+  )
+}

--- a/src/app/[locale]/math-finals-practice-session/page.tsx
+++ b/src/app/[locale]/math-finals-practice-session/page.tsx
@@ -1,0 +1,53 @@
+import { MathFinalsPracticeLanding } from '@/components/math-finals-practice/MathFinalsPracticeLanding'
+import { MATH_FINALS_PRACTICE_FAQS } from '@/data/math-finals-practice-faqs'
+import { getMetadataConfig } from '@/lib/seo/metadataConfig'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+import {
+  generateBreadcrumbSchema,
+  generateFAQPageSchema,
+  generateWebPageJsonLd,
+} from '@/lib/seo/structuredData'
+
+const PAGE_PATH = '/math-finals-practice-session'
+
+export default async function MathFinalsPracticePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+  const pageUrl = absoluteSiteUrl(PAGE_PATH, locale, baseUrl)
+  const meta = getMetadataConfig(PAGE_PATH)
+  const name =
+    meta?.title ?? 'Free High School Math Finals Practice Session | GrowWise'
+  const description =
+    meta?.description ??
+    'Request a high school math finals session in Dublin, CA — Sunday 12–1 pm or structured prep. Algebra 1 through Pre-Calculus.'
+
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: 'Math finals practice', url: pageUrl },
+  ])
+  const webPageSchema = generateWebPageJsonLd({ name, description, url: pageUrl })
+  const faqSchema = generateFAQPageSchema(MATH_FINALS_PRACTICE_FAQS)
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <MathFinalsPracticeLanding />
+    </>
+  )
+}

--- a/src/app/[locale]/math-finals-practice-session/thank-you/page.tsx
+++ b/src/app/[locale]/math-finals-practice-session/thank-you/page.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { absoluteSiteUrl, publicPath } from '@/lib/publicPath'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+import { generateBreadcrumbSchema, generateWebPageJsonLd } from '@/lib/seo/structuredData'
+
+const PAGE_PATH = '/math-finals-practice-session/thank-you'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  title: 'Request received | GrowWise',
+  description: 'We received your request for math finals support. Our team will follow up shortly.',
+}
+
+export default async function MathFinalsPracticeThankYouPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+  const pageUrl = absoluteSiteUrl(PAGE_PATH, locale, baseUrl)
+
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    {
+      name: 'Math finals practice',
+      url: absoluteSiteUrl('/math-finals-practice-session', locale, baseUrl),
+    },
+    { name: 'Thank you', url: pageUrl },
+  ])
+  const webPageSchema = generateWebPageJsonLd({
+    name: 'Math finals practice request received | GrowWise',
+    description: 'We received your request for math finals support. Our team will follow up shortly.',
+    url: pageUrl,
+  })
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageSchema) }}
+      />
+      <main className="min-h-[100dvh] bg-slate-50/80 text-slate-800">
+        <div className="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-20">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
+            Thank you — we received your request.
+          </h1>
+          <p className="mt-4 text-slate-600">
+            Our team will follow up shortly by email or phone to confirm next steps for the option you selected—the
+            four-session structured prep course or the complimentary Sunday session (12–1 pm time window).
+          </p>
+          <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Link
+              href={publicPath('/math-finals-practice-session', locale)}
+              className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#1F396D] px-6 py-3 text-sm font-semibold text-white hover:bg-[#162a52] sm:w-auto"
+            >
+              Back to session details
+            </Link>
+            <Link
+              href={publicPath('/enroll', locale)}
+              className="inline-flex min-h-[48px] w-full items-center justify-center rounded-lg border-2 border-[#1F396D] bg-white px-6 py-3 text-sm font-semibold text-[#1F396D] hover:bg-slate-50 sm:w-auto"
+            >
+              Explore enrollment
+            </Link>
+          </div>
+        </div>
+      </main>
+    </>
+  )
+}
+

--- a/src/app/api/math-finals-practice/route.ts
+++ b/src/app/api/math-finals-practice/route.ts
@@ -1,0 +1,440 @@
+import { NextResponse } from 'next/server'
+import { CONTACT_INFO } from '@/lib/constants'
+import {
+  isBrevoTransactionalReady,
+  sendBrevoTransactionalEmail,
+  upsertMathFinalsLeadInBrevo,
+} from '@/lib/brevo'
+import { sendEmail, type EmailAttachment, type SendEmailResult } from '@/lib/email'
+import {
+  isMathFinalsPracticeInterest,
+  MATH_FINALS_INTEREST_LABELS,
+  type MathFinalsPracticeInterest,
+} from '@/data/math-finals-practice-interest'
+import { MATH_FINALS_PRACTICE_SUBJECTS, type MathFinalsPracticeSubject } from '@/data/math-finals-practice-subjects'
+
+export const maxDuration = 60
+
+const BREVO_RETRY_DELAY_MS = 450
+const BREVO_REPLY_TO = { email: CONTACT_INFO.email, name: 'GrowWise' } as const
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const MAX_AGENDA_BYTES = 5 * 1024 * 1024
+
+type ParsedMathFinalsForm = {
+  interest: MathFinalsPracticeInterest
+  parentName: string
+  studentName: string
+  grade: string
+  school: string
+  subject: MathFinalsPracticeSubject
+  parentEmail: string
+  parentPhone: string
+  notes: string
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function err(msg: string, status: number) {
+  return NextResponse.json({ success: false, error: msg }, { status })
+}
+
+/**
+ * Brevo transactional first (automation + deliverability), then SMTP — same as contact / summer-camp.
+ */
+async function sendMathFinalsEmailWithFallback(opts: {
+  to: string
+  subject: string
+  html: string
+  text: string
+  attachments?: EmailAttachment[]
+}): Promise<SendEmailResult> {
+  if (isBrevoTransactionalReady()) {
+    let lastErr: string | undefined
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, BREVO_RETRY_DELAY_MS))
+      }
+      const brevo = await sendBrevoTransactionalEmail({
+        ...opts,
+        replyTo: BREVO_REPLY_TO,
+      })
+      if (brevo.success) return brevo
+      lastErr = brevo.error
+      console.error(
+        `[math-finals-practice] Brevo transactional attempt ${attempt + 1}/2 failed:`,
+        brevo.error
+      )
+    }
+    console.error('[math-finals-practice] Brevo failed after retry; SMTP fallback.', lastErr)
+  } else {
+    console.warn(
+      '[math-finals-practice] Brevo not configured (BREVO_API_KEY + BREVO_SENDER_EMAIL); using SMTP if configured.'
+    )
+  }
+  return sendEmail({
+    to: opts.to,
+    subject: opts.subject,
+    html: opts.html,
+    text: opts.text,
+    replyTo: BREVO_REPLY_TO.email,
+    ...(opts.attachments?.length ? { attachments: opts.attachments } : {}),
+  })
+}
+
+function userFollowUpParagraphHtml(interest: MathFinalsPracticeInterest): string {
+  switch (interest) {
+    case 'structured_prep':
+      return 'Our team will follow up about the <strong>four-session structured finals prep</strong> course (paid)—scheduling, scope, and next steps.'
+    case 'free_sunday':
+      return 'We will follow up to confirm your <strong>complimentary Sunday finals</strong> session in the <strong>12–1 pm</strong> time window (exact slot when we contact you).'
+  }
+}
+
+function userFollowUpParagraphPlain(interest: MathFinalsPracticeInterest): string {
+  switch (interest) {
+    case 'structured_prep':
+      return 'Our team will follow up about the four-session structured finals prep course (paid)—scheduling, scope, and next steps.'
+    case 'free_sunday':
+      return 'We will follow up to confirm your complimentary Sunday finals session in the 12–1 pm time window (exact slot when we contact you).'
+  }
+}
+
+function parseForm(fields: {
+  interest: string
+  parentName: string
+  studentName: string
+  grade: string
+  school: string
+  subject: string
+  parentEmail: string
+  parentPhone: string
+  notes: string
+}):
+  | { ok: true; data: ParsedMathFinalsForm }
+  | { ok: false; error: string; status: number } {
+  const interestRaw = fields.interest.trim()
+  if (!isMathFinalsPracticeInterest(interestRaw)) {
+    return { ok: false, error: 'Please select which option you want.', status: 400 }
+  }
+  const interest = interestRaw
+
+  const parentName = fields.parentName.trim()
+  const studentName = fields.studentName.trim()
+  const grade = fields.grade.trim()
+  const school = fields.school.trim()
+  const subject = fields.subject.trim()
+  const parentEmail = fields.parentEmail.trim()
+  const parentPhone = fields.parentPhone.trim()
+  const notes = fields.notes.trim()
+
+  if (!parentName) return { ok: false, error: 'Parent name is required', status: 400 }
+  if (!studentName) return { ok: false, error: 'Student name is required', status: 400 }
+  if (!grade) return { ok: false, error: 'Grade is required', status: 400 }
+  if (!parentEmail) return { ok: false, error: 'Email is required', status: 400 }
+  if (!EMAIL_REGEX.test(parentEmail)) return { ok: false, error: 'Please enter a valid email address', status: 400 }
+  if (!parentPhone) return { ok: false, error: 'Phone is required', status: 400 }
+  if (!MATH_FINALS_PRACTICE_SUBJECTS.includes(subject as MathFinalsPracticeSubject)) {
+    return { ok: false, error: 'Please select a current math course.', status: 400 }
+  }
+
+  return {
+    ok: true,
+    data: {
+      interest,
+      parentName,
+      studentName,
+      grade,
+      school,
+      subject: subject as MathFinalsPracticeSubject,
+      parentEmail: parentEmail.toLowerCase(),
+      parentPhone,
+      notes: notes || '',
+    },
+  }
+}
+
+function parseFormDataFields(fd: globalThis.FormData) {
+  const getS = (k: string) => (typeof fd.get(k) === 'string' ? (fd.get(k) as string) : '')
+  return {
+    interestRaw: getS('interest'),
+    parentName: getS('parentName'),
+    studentName: getS('studentName'),
+    grade: getS('grade'),
+    school: getS('school'),
+    subject: getS('subject'),
+    parentEmail: getS('parentEmail'),
+    parentPhone: getS('parentPhone'),
+    notes: getS('notes'),
+    agendaFile: (() => {
+      const file = fd.get('q4Agenda')
+      if (file instanceof File && file.size > 0) {
+        if (file.size > MAX_AGENDA_BYTES) {
+          return { error: 'Upload must be 5 MB or smaller.' as const }
+        }
+        return { file }
+      }
+      return { file: null as File | null }
+    })(),
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const contentType = (request.headers.get('content-type') ?? '').toLowerCase()
+    let interestRaw: string
+    let parentName: string
+    let studentName: string
+    let grade: string
+    let school: string
+    let subject: string
+    let parentEmail: string
+    let parentPhone: string
+    let notes: string
+    let agendaFile: File | null = null
+
+    if (contentType.includes('application/json')) {
+      const body = (await request.json()) as Record<string, unknown>
+      interestRaw = typeof body.interest === 'string' ? body.interest : ''
+      parentName = typeof body.parentName === 'string' ? body.parentName : ''
+      studentName = typeof body.studentName === 'string' ? body.studentName : ''
+      grade = typeof body.grade === 'string' ? body.grade : ''
+      school = typeof body.school === 'string' ? body.school : ''
+      subject = typeof body.subject === 'string' ? body.subject : ''
+      parentEmail = typeof body.parentEmail === 'string' ? body.parentEmail : ''
+      parentPhone = typeof body.parentPhone === 'string' ? body.parentPhone : ''
+      notes = typeof body.notes === 'string' ? body.notes : ''
+    } else {
+      /** Browser `fetch`+`FormData` is multipart, but `Content-Type` can be empty in some clients — always use formData for non-JSON. */
+      const formData = await request.formData()
+      const p = parseFormDataFields(formData)
+      const ag = p.agendaFile
+      if ('error' in ag) {
+        return err(ag.error ?? 'Invalid file upload.', 400)
+      }
+      agendaFile = ag.file
+      interestRaw = p.interestRaw
+      parentName = p.parentName
+      studentName = p.studentName
+      grade = p.grade
+      school = p.school
+      subject = p.subject
+      parentEmail = p.parentEmail
+      parentPhone = p.parentPhone
+      notes = p.notes
+    }
+
+    const parsed = parseForm({
+      interest: interestRaw,
+      parentName,
+      studentName,
+      grade,
+      school,
+      subject,
+      parentEmail,
+      parentPhone,
+      notes,
+    })
+    if (!parsed.ok) {
+      return err(parsed.error, parsed.status)
+    }
+    const {
+      interest,
+      parentName: pName,
+      studentName: sName,
+      grade: g,
+      school: sch,
+      subject: subj,
+      parentEmail: pEmail,
+      parentPhone: pPhone,
+      notes: notesVal,
+    } = parsed.data
+
+    const ip = request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? ''
+    const timestamp = new Date().toISOString()
+    const interestLabel = MATH_FINALS_INTEREST_LABELS[interest]
+
+    let agendaAttachment: EmailAttachment | undefined
+    if (agendaFile) {
+      const buf = Buffer.from(await agendaFile.arrayBuffer())
+      const safeName = agendaFile.name.replace(/[^a-zA-Z0-9._-]+/g, '_') || 'q4-agenda'
+      agendaAttachment = {
+        filename: safeName,
+        content: buf,
+        contentType: agendaFile.type || 'application/octet-stream',
+      }
+    }
+
+    const record = {
+      interest,
+      interestLabel,
+      parentName: pName,
+      studentName: sName,
+      grade: g,
+      school: sch,
+      subject: subj,
+      parentEmail: pEmail,
+      parentPhone: pPhone,
+      notes: notesVal || undefined,
+      q4AgendaAttached: Boolean(agendaAttachment),
+      event: 'HS Math Finals — form',
+      timestamp,
+      ip: ip || undefined,
+    }
+
+    console.log('[math-finals-practice]', { ...record, parentPhone: '[redacted]' })
+
+    const userSubject = 'We received your request | GrowWise'
+    const followUpHtml = userFollowUpParagraphHtml(interest)
+    const agendaLineHtml = agendaAttachment
+      ? '<p>We received your <strong>Quarter 4 topics or class outline</strong> upload.</p>'
+      : ''
+    const agendaLinePlain = agendaAttachment
+      ? 'We received your Quarter 4 topics or class outline upload.\n\n'
+      : ''
+
+    const userHtml = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #1F396D;">Request received</h2>
+        <p>Hi ${escapeHtml(pName)},</p>
+        <p>Thank you for reaching out about math finals support at GrowWise.</p>
+        <p><strong>Your request:</strong> ${escapeHtml(interestLabel)}</p>
+        ${agendaLineHtml}
+        <p>${followUpHtml}</p>
+        <p>If you have questions in the meantime, contact us at ${escapeHtml(CONTACT_INFO.email)} or ${escapeHtml(CONTACT_INFO.phone)}.</p>
+        <p>— GrowWise</p>
+      </div>
+    `
+    const userText = `Hi ${pName},\n\nThank you for reaching out about math finals support at GrowWise.\n\nYour request: ${interestLabel}\n\n${agendaLinePlain}${userFollowUpParagraphPlain(interest)}\n\nQuestions: ${CONTACT_INFO.email} or ${CONTACT_INFO.phone}.\n\n— GrowWise`
+
+    const brevoReady = isBrevoTransactionalReady()
+
+    const userResult = await sendMathFinalsEmailWithFallback({
+      to: pEmail,
+      subject: userSubject,
+      html: userHtml,
+      text: userText,
+    })
+    if (!userResult.success) {
+      console.error(
+        '[math-finals-practice] User confirmation email failed after Brevo + SMTP:',
+        userResult.error
+      )
+      return NextResponse.json(
+        {
+          success: false,
+          error: `We could not send your confirmation email. Please try again in a few minutes or contact ${CONTACT_INFO.email}.`,
+        },
+        { status: 503 }
+      )
+    }
+
+    const businessSubject = `Math finals lead (${interest}) — ${pName}`
+    const agendaNote = agendaAttachment
+      ? `<p><strong>Q4 topics / outline:</strong> attached (${escapeHtml(agendaAttachment.filename)})</p>`
+      : '<p><strong>Q4 topics / outline:</strong> not uploaded</p>'
+
+    const businessHtml = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #1F396D;">New math finals lead</h2>
+        <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
+          <p><strong>Interest:</strong> ${escapeHtml(interestLabel)} (${escapeHtml(interest)})</p>
+          <p><strong>Parent:</strong> ${escapeHtml(pName)}</p>
+          <p><strong>Email:</strong> ${escapeHtml(pEmail)}</p>
+          <p><strong>Phone:</strong> ${escapeHtml(pPhone)}</p>
+          <p><strong>Student:</strong> ${escapeHtml(sName)}</p>
+          <p><strong>Grade:</strong> ${escapeHtml(g)}</p>
+          <p><strong>School:</strong> ${sch ? escapeHtml(sch) : 'Not provided'}</p>
+          <p><strong>Current math course:</strong> ${escapeHtml(subj)}</p>
+          ${agendaNote}
+          ${notesVal ? `<p><strong>Notes:</strong> ${escapeHtml(notesVal)}</p>` : ''}
+          <p><strong>Submitted (UTC):</strong> ${escapeHtml(timestamp)}</p>
+          ${ip ? `<p><strong>IP:</strong> ${escapeHtml(ip)}</p>` : ''}
+        </div>
+      </div>
+    `
+    const businessText = [
+      'New math finals lead',
+      `Interest: ${interestLabel} (${interest})`,
+      `Parent: ${pName}`,
+      `Email: ${pEmail}`,
+      `Phone: ${pPhone}`,
+      `Student: ${sName}`,
+      `Grade: ${g}`,
+      `School: ${sch}`,
+      `Current math course: ${subj}`,
+      `Q4 topics / outline: ${agendaAttachment ? `attached (${agendaAttachment.filename})` : 'not uploaded'}`,
+      notesVal && `Notes: ${notesVal}`,
+      `Submitted: ${timestamp}`,
+    ]
+      .filter(Boolean)
+      .join('\n')
+
+    const businessResult = await sendMathFinalsEmailWithFallback({
+      to: CONTACT_INFO.businessEmail,
+      subject: businessSubject,
+      html: businessHtml,
+      text: businessText,
+      ...(agendaAttachment ? { attachments: [agendaAttachment] } : {}),
+    })
+    if (!businessResult.success) {
+      console.warn(
+        '[math-finals-practice] Business notification failed (user email already sent):',
+        businessResult.error
+      )
+    }
+
+    let brevoListResult: SendEmailResult | undefined
+    if (brevoReady) {
+      brevoListResult = await upsertMathFinalsLeadInBrevo({
+        email: pEmail,
+        interestKey: interest,
+        interestLabel,
+        parentName: pName,
+        studentName: sName,
+        grade: g,
+        school: sch,
+        subject: subj,
+        phone: pPhone,
+        notes: notesVal,
+        q4AgendaUploaded: Boolean(agendaAttachment),
+        submittedAtIso: timestamp,
+      })
+      if (!brevoListResult.success) {
+        console.warn(
+          '[math-finals-practice] Brevo contact/list sync failed (emails may have sent).',
+          brevoListResult.error
+        )
+      }
+    }
+
+    const payload: Record<string, unknown> = {
+      success: true,
+      message: 'We received your request. Our team will follow up shortly.',
+    }
+    if (process.env.NODE_ENV === 'development') {
+      payload.emailDebug = {
+        userEmailSent: userResult.success,
+        businessEmailSent: businessResult.success,
+        brevoTransactionalConfigured: brevoReady,
+        ...(brevoReady && brevoListResult
+          ? {
+              brevoListOrContactSync: brevoListResult.success,
+              ...(brevoListResult.error ? { brevoListError: brevoListResult.error } : {}),
+            }
+          : {}),
+      }
+    }
+
+    return NextResponse.json(payload)
+  } catch {
+    return err('An error occurred. Please try again.', 500)
+  }
+}

--- a/src/components/form/FormPrivacyConsent.tsx
+++ b/src/components/form/FormPrivacyConsent.tsx
@@ -21,6 +21,8 @@ export interface FormPrivacyConsentProps {
   showSubmitDisclaimer?: boolean;
   /** Layout variant: default (full blocks), compact (single block, smaller spacing) */
   variant?: 'default' | 'compact';
+  /** When true, one card: privacy + consent share column alignment; smaller privacy text (math-finals style). */
+  alignPrivacyWithConsent?: boolean;
   /** Optional class for the wrapper */
   className?: string;
 }
@@ -37,6 +39,7 @@ export default function FormPrivacyConsent({
   required = true,
   showSubmitDisclaimer = true,
   variant = 'default',
+  alignPrivacyWithConsent = false,
   className,
 }: FormPrivacyConsentProps) {
   const t = useTranslations('commonForm.privacy');
@@ -44,6 +47,69 @@ export default function FormPrivacyConsent({
   const blockClass = variant === 'compact'
     ? 'space-y-3 p-4 bg-gray-100 rounded-xl border border-gray-200'
     : 'space-y-4 p-4 sm:p-6 md:p-8 bg-gray-100 rounded-xl md:rounded-2xl border border-gray-200';
+
+  const colIcon = 'w-10 flex shrink-0 justify-center';
+
+  if (alignPrivacyWithConsent) {
+    return (
+      <div className={cn('space-y-3', className)}>
+        <div className={blockClass}>
+          <div className="flex items-start gap-2.5">
+            <div className={colIcon}>
+              <div className="rounded-lg bg-[#1F396D] p-1.5">
+                <Shield className="h-4 w-4 text-white" aria-hidden />
+              </div>
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="mb-0.5 text-sm font-semibold text-gray-900">{t('title')}</h3>
+              <p className="text-xs leading-relaxed text-gray-600">{t('description')}</p>
+            </div>
+          </div>
+          <div className="mt-3 border-t border-gray-200/90 pt-3">
+            <div className="flex items-start gap-2.5">
+              <div className={cn(colIcon, 'pt-0.5')}>
+                <Checkbox
+                  id={checkboxId}
+                  checked={checked}
+                  onCheckedChange={(value) => onCheckedChange(value === true)}
+                  required={required}
+                  className={cn(
+                    'h-5 w-5 flex-shrink-0 border-2 border-gray-400 data-[state=checked]:border-[#1F396D] data-[state=checked]:bg-[#1F396D]',
+                    error && 'border-red-500',
+                  )}
+                  aria-invalid={!!error}
+                  aria-describedby={error ? `${checkboxId}-error` : undefined}
+                />
+              </div>
+              <Label
+                htmlFor={checkboxId}
+                id={`${checkboxId}-label`}
+                className="flex-1 cursor-pointer text-sm leading-relaxed text-gray-700"
+              >
+                {t('agreeLabel')}
+              </Label>
+            </div>
+            {error && (
+              <p
+                id={`${checkboxId}-error`}
+                className="mt-2 flex items-center gap-1 pl-0 text-xs text-red-600 sm:pl-12"
+                role="alert"
+              >
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                {error}
+              </p>
+            )}
+          </div>
+        </div>
+        {showSubmitDisclaimer && (
+          <p className="flex items-center justify-center gap-1.5 text-center text-xs text-gray-500">
+            <Shield className="h-3.5 w-3.5 flex-shrink-0 text-green-600" aria-hidden />
+            {t('submitDisclaimer')}
+          </p>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className={cn('space-y-4', className)}>

--- a/src/components/layout/Header/Dropdown.tsx
+++ b/src/components/layout/Header/Dropdown.tsx
@@ -124,7 +124,15 @@ export default function Dropdown({
           {/* Menu Items */}
           <div className="py-1 overflow-visible">
             {visibleItems.map((dropdownItem, index) => {
-              const isDropdownItemActive = pathname?.startsWith(createLocaleUrl(dropdownItem.href));
+              const isDropdownItemActive = (() => {
+                if (pathname?.startsWith(createLocaleUrl(dropdownItem.href))) return true;
+                if (dropdownItem.submenuItems?.length) {
+                  return dropdownItem.submenuItems.some((sub) =>
+                    pathname?.startsWith(createLocaleUrl(sub.href))
+                  );
+                }
+                return false;
+              })();
               const hasSubmenu = dropdownItem.hasSubmenu && dropdownItem.submenuItems;
               const isSubmenuOpen = openSubmenus[dropdownItem.key];
               

--- a/src/components/layout/Header/DropdownItem.tsx
+++ b/src/components/layout/Header/DropdownItem.tsx
@@ -117,11 +117,13 @@ export default function DropdownItem({
       
       {/* Submenu */}
       {hasSubmenu && item.submenuItems && isSubmenuOpen && (
-        <Submenu 
+        <Submenu
+          parentItem={item}
           items={item.submenuItems}
           onItemClick={onItemClick}
           onSubmenuEnter={onSubmenuEnter}
           onSubmenuLeave={onSubmenuLeave}
+          createLocaleUrl={createLocaleUrl}
           colors={colors}
         />
       )}
@@ -130,15 +132,19 @@ export default function DropdownItem({
 }
 
 interface SubmenuProps {
+  parentItem: DropdownItemType;
   items: SubmenuItem[];
   onItemClick: () => void;
   onSubmenuEnter: () => void;
   onSubmenuLeave: () => void;
+  createLocaleUrl: (path: string) => string;
   colors: { primary: string; secondary: string };
 }
 
-function Submenu({ items, onItemClick, onSubmenuEnter, onSubmenuLeave, colors }: SubmenuProps) {
+function Submenu({ parentItem, items, onItemClick, onSubmenuEnter, onSubmenuLeave, createLocaleUrl, colors }: SubmenuProps) {
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+  const headerTitle = parentItem.submenuHeaderTitle ?? parentItem.title;
+  const headerSubtitle = parentItem.submenuHeaderSubtitle ?? 'Select your subject';
 
   return (
     <div 
@@ -148,8 +154,8 @@ function Submenu({ items, onItemClick, onSubmenuEnter, onSubmenuLeave, colors }:
     >
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-[#1F396D]/5 to-[#F16112]/5 border-b border-gray-100">
-        <div className="font-semibold text-gray-900 text-sm">Courses</div>
-        <p className="text-xs text-gray-600 mt-0.5">Select your subject</p>
+        <div className="font-semibold text-gray-900 text-sm">{headerTitle}</div>
+        <p className="text-xs text-gray-600 mt-0.5">{headerSubtitle}</p>
       </div>
       
       {/* Items */}
@@ -163,7 +169,7 @@ function Submenu({ items, onItemClick, onSubmenuEnter, onSubmenuLeave, colors }:
           return (
             <Link
               key={subItem.title}
-              href={subItem.href}
+              href={createLocaleUrl(subItem.href)}
               onClick={onItemClick}
               onMouseEnter={() => setHoveredItem(subItem.title)}
               onMouseLeave={() => setHoveredItem(null)}

--- a/src/components/layout/Header/MobileNavigation.tsx
+++ b/src/components/layout/Header/MobileNavigation.tsx
@@ -163,6 +163,36 @@ export default function MobileNavigation({
                             {isExpanded && visibleDropdownItems.length > 0 && (
                               <div className="ml-4 mt-1 mb-2 space-y-1 border-l-2 border-gray-200 pl-4">
                                 {visibleDropdownItems.map((dropdownItem) => {
+                                  if (dropdownItem.hasSubmenu && dropdownItem.submenuItems?.length) {
+                                    return (
+                                      <div key={dropdownItem.key} className="mb-2 last:mb-0">
+                                        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide py-1.5 px-2">
+                                          {dropdownItem.title}
+                                        </p>
+                                        <div className="space-y-0.5 pl-0">
+                                          {dropdownItem.submenuItems.map((sub) => {
+                                            const isSubActive = pathname?.startsWith(
+                                              createLocaleUrl(sub.href)
+                                            );
+                                            return (
+                                              <Link
+                                                key={sub.title}
+                                                href={createLocaleUrl(sub.href)}
+                                                className={`block py-2 px-2 text-sm transition-colors duration-200 rounded-lg ${
+                                                  isSubActive
+                                                    ? 'text-[#1F396D] bg-[#1F396D]/10 font-medium'
+                                                    : 'text-gray-600 hover:text-[#F16112] hover:bg-gray-50'
+                                                }`}
+                                                onClick={onCloseMobileMenu}
+                                              >
+                                                {sub.title}
+                                              </Link>
+                                            );
+                                          })}
+                                        </div>
+                                      </div>
+                                    );
+                                  }
                                   const isDropdownItemActive = pathname?.startsWith(
                                     createLocaleUrl(dropdownItem.href)
                                   );

--- a/src/components/layout/Header/constants.ts
+++ b/src/components/layout/Header/constants.ts
@@ -121,6 +121,24 @@ export const FALLBACK_MENU_ITEMS: MenuItem[] = [
           icon: 'GraduationCap',
           href: '/courses/high-school-math',
           gradient: 'from-[#29335C] to-[#1F396D]',
+          hasSubmenu: true,
+          submenuHeaderSubtitle: 'Tutoring, curriculum, and finals prep',
+          submenuItems: [
+            {
+              title: 'High School Math',
+              description: 'Algebra I through Pre-Calculus — tutoring overview',
+              icon: 'GraduationCap',
+              href: '/courses/high-school-math',
+              gradient: 'from-[#29335C] to-[#1F396D]',
+            },
+            {
+              title: 'Math Finals Prep',
+              description: 'End-of-year finals support & complimentary preview session',
+              icon: 'Target',
+              href: '/math-finals-practice-session',
+              gradient: 'from-[#1F396D] to-[#F16112]',
+            },
+          ],
         },
         {
           key: 'satPrep',

--- a/src/components/layout/Header/types.ts
+++ b/src/components/layout/Header/types.ts
@@ -27,6 +27,10 @@ export interface DropdownItem {
   visible?: boolean;
   hasSubmenu?: boolean;
   submenuItems?: SubmenuItem[];
+  /** Optional submenu panel header; defaults to `title` (e.g. "High School Math"). */
+  submenuHeaderTitle?: string;
+  /** Optional submenu panel subtitle; defaults to "Select your subject". */
+  submenuHeaderSubtitle?: string;
 }
 
 export interface SubmenuItem {

--- a/src/components/layout/Header/utils.ts
+++ b/src/components/layout/Header/utils.ts
@@ -40,10 +40,26 @@ export function getVariant(variant?: string): VariantStyles {
   return VARIANT_STYLES[(variant as keyof typeof VARIANT_STYLES) || 'blue'] || VARIANT_STYLES.blue;
 }
 
+function isDropdownItemPathActive(
+  dropdownItem: { href: string; hasSubmenu?: boolean; submenuItems?: { href: string }[] },
+  pathname: string | null,
+  locale: string
+): boolean {
+  if (pathname?.startsWith(createLocaleUrl(dropdownItem.href, locale))) {
+    return true;
+  }
+  if (dropdownItem.submenuItems?.length) {
+    return dropdownItem.submenuItems.some((sub) =>
+      pathname?.startsWith(createLocaleUrl(sub.href, locale))
+    );
+  }
+  return false;
+}
+
 export function isMenuItemActive(item: MenuItem, pathname: string | null, locale: string): boolean {
   if (item.type === 'dropdown' && item.dropdown) {
     return item.dropdown.items.some((dropdownItem) =>
-      pathname?.startsWith(createLocaleUrl(dropdownItem.href, locale)),
+      isDropdownItemPathActive(dropdownItem, pathname, locale)
     );
   }
   return pathname === createLocaleUrl(item.href, locale);

--- a/src/components/math-finals-practice/MathFinalsPracticeLanding.tsx
+++ b/src/components/math-finals-practice/MathFinalsPracticeLanding.tsx
@@ -1,0 +1,725 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { useLocale } from 'next-intl'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import FormPrivacyConsent from '@/components/form/FormPrivacyConsent'
+import { MATH_FINALS_PRACTICE_FAQS } from '@/data/math-finals-practice-faqs'
+import {
+  isMathFinalsPracticeInterest,
+  type MathFinalsPracticeInterest,
+} from '@/data/math-finals-practice-interest'
+import {
+  MATH_FINALS_PRACTICE_SUBJECTS,
+  type MathFinalsPracticeSubject,
+} from '@/data/math-finals-practice-subjects'
+import { PHONE_PLACEHOLDER } from '@/lib/constants'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { publicPath } from '@/lib/publicPath'
+import { cn } from '@/lib/utils'
+import {
+  BookOpen,
+  Calculator,
+  CheckCircle2,
+  FileText,
+  GraduationCap,
+  ListChecks,
+  Loader2,
+  Mail,
+  MessageSquare,
+  Phone,
+  School,
+  User,
+} from 'lucide-react'
+
+const sectionClass = 'mx-auto max-w-3xl px-4 sm:px-6'
+const h2Class = 'text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl'
+
+/** Discourages password-manager extensions (LastPass, etc.) from injecting extra DOM; avoids hydration mismatch vs SSR. */
+const PM_NO_INJECT = { 'data-lpignore': 'true' } as const
+
+const HS_GRADES = ['Grade 9', 'Grade 10', 'Grade 11', 'Grade 12'] as const
+
+const WHAT_TO_EXPECT_BULLETS: readonly string[] = [
+  'School-aligned Quarter 4 topics preparation',
+  'Fast-paced 2-hour session: 1 hour of teaching and 1 hour of practice',
+  'One complimentary session per student',
+  'New topics in each session; previous topics are not repeated',
+]
+
+const INTEREST_OPTIONS: ReadonlyArray<{ value: MathFinalsPracticeInterest; label: string }> = [
+  {
+    value: 'structured_prep',
+    label: 'Request the four-session structured finals prep course',
+  },
+  {
+    value: 'free_sunday',
+    label: 'Request the complimentary Sunday finals session (12–1 pm)',
+  },
+]
+
+type FormState = {
+  interest: string
+  parentName: string
+  studentName: string
+  grade: string
+  school: string
+  subject: string
+  parentEmail: string
+  parentPhone: string
+  notes: string
+}
+
+const initialForm: FormState = {
+  interest: '',
+  parentName: '',
+  studentName: '',
+  grade: '',
+  school: '',
+  subject: '',
+  parentEmail: '',
+  parentPhone: '',
+  notes: '',
+}
+
+export function MathFinalsPracticeLanding() {
+  const router = useRouter()
+  const locale = useLocale()
+  const agendaInputRef = useRef<HTMLInputElement>(null)
+  const [form, setForm] = useState<FormState>(initialForm)
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({})
+  const [agree, setAgree] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [focusedField, setFocusedField] = useState<string | null>(null)
+
+  const setField = useCallback(
+    (k: keyof FormState, v: string) => {
+      setForm((f) => ({ ...f, [k]: v }))
+      setErrors((e) => {
+        const n = { ...e }
+        delete n[k]
+        return n
+      })
+      if (submitError) setSubmitError(null)
+    },
+    [submitError],
+  )
+
+  const validate = useCallback((): boolean => {
+    const e: Partial<Record<keyof FormState, string>> = {}
+    if (!form.interest || !isMathFinalsPracticeInterest(form.interest)) {
+      e.interest = 'Please select which option you want.'
+    }
+    if (!form.parentName.trim()) e.parentName = 'Please enter the parent or guardian name.'
+    if (!form.studentName.trim()) e.studentName = "Please enter the student's name."
+    if (!form.grade) e.grade = 'Please select a grade level.'
+    if (!MATH_FINALS_PRACTICE_SUBJECTS.includes(form.subject as MathFinalsPracticeSubject)) {
+      e.subject = 'Please select a current math course.'
+    }
+    if (!form.parentEmail.trim()) e.parentEmail = 'Please enter an email address.'
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.parentEmail.trim())) {
+      e.parentEmail = 'Please enter a valid email address.'
+    }
+    if (!form.parentPhone.trim()) e.parentPhone = 'Please enter a phone number.'
+    setErrors(e)
+    return Object.keys(e).length === 0
+  }, [form])
+
+  const onSubmit = async (ev: React.FormEvent) => {
+    ev.preventDefault()
+    if (!agree) {
+      setSubmitError('Please agree to the communications opt-in to submit this form.')
+      return
+    }
+    setSubmitError(null)
+    if (!validate()) return
+    setSubmitting(true)
+    try {
+      const fd = new FormData()
+      fd.set('interest', form.interest)
+      fd.set('parentName', form.parentName.trim())
+      fd.set('studentName', form.studentName.trim())
+      fd.set('grade', form.grade)
+      fd.set('school', form.school.trim())
+      fd.set('subject', form.subject)
+      fd.set('parentEmail', form.parentEmail.trim())
+      fd.set('parentPhone', form.parentPhone.trim())
+      fd.set('notes', form.notes.trim())
+      const file = agendaInputRef.current?.files?.[0]
+      if (file && file.size > 0) {
+        fd.set('q4Agenda', file)
+      }
+
+      const res = await fetch('/api/math-finals-practice', {
+        method: 'POST',
+        body: fd,
+      })
+      const data = (await res.json().catch(() => ({}))) as { success?: boolean; error?: string; message?: string }
+      if (!res.ok) {
+        setSubmitError(data.error || 'Something went wrong. Please try again.')
+        return
+      }
+      if (data.success) {
+        setForm(initialForm)
+        if (agendaInputRef.current) agendaInputRef.current.value = ''
+        router.push(publicPath('/math-finals-practice-session/thank-you', locale))
+      } else {
+        setSubmitError(data.error || 'Something went wrong. Please try again.')
+      }
+    } catch {
+      setSubmitError('Network error. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <main className="bg-slate-50/80 text-slate-800">
+      {/* 1. Hero */}
+      <section
+        className="border-b border-slate-200/80 bg-white pb-16 pt-14 sm:pb-24 sm:pt-20"
+        aria-labelledby="math-finals-hero-title"
+      >
+        <div className={cn(sectionClass, 'max-w-4xl text-center')}>
+          <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-600">
+            <span>GrowWise In-center</span>
+            <span className="h-1 w-1 rounded-full bg-slate-400" aria-hidden />
+            <span>Sunday 12–1 pm</span>
+          </div>
+          <h1
+            id="math-finals-hero-title"
+            className="mt-6 text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl md:text-6xl"
+          >
+            High School Math Finals Practice in Dublin, CA
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-base text-slate-600 sm:text-lg">
+            One complimentary hour of exam-style practice covering <strong>Algebra 1</strong>, <strong>Geometry</strong>,
+            <strong> Algebra 2</strong>, and <strong>Pre-Calculus</strong>. This session is dedicated to finals-style
+            review—not foundational tutoring.
+          </p>
+          <p className="mx-auto mt-4 max-w-2xl text-sm font-medium text-[#F16112]">
+            Strictly limited to one complimentary session per student.
+          </p>
+          <div className="mt-10 flex w-full max-w-2xl flex-col items-center justify-center gap-3 sm:mx-auto sm:flex-row sm:gap-4">
+            <Button
+              asChild
+              className="h-11 w-full max-w-[280px] rounded-full bg-gradient-to-r from-[#F16112] to-[#F1894F] px-7 text-base font-semibold text-white shadow-lg transition-all duration-300 hover:from-[#d54f0a] hover:to-[#F16112] hover:shadow-xl sm:max-w-none sm:w-auto"
+            >
+              <a href="#signup">Reserve Free Practice Spot</a>
+            </Button>
+            <a
+              href="#what-to-expect"
+              className="text-center text-sm font-semibold text-slate-600 underline-offset-4 hover:underline"
+            >
+              What to expect
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* 2. What to expect — free session offer (2 hours: teach + practice) */}
+      <section
+        id="what-to-expect"
+        className="border-b border-slate-200/80 bg-slate-50/90 py-8 sm:py-10"
+        aria-labelledby="what-to-expect-heading"
+      >
+        <div className={cn(sectionClass, 'max-w-3xl')}>
+          <h2
+            id="what-to-expect-heading"
+            className="text-center text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl"
+          >
+            What to expect in your free session
+          </h2>
+          <p className="mx-auto mt-2 max-w-xl text-center text-slate-600">
+            In-center in Dublin, CA. One complimentary session per student.
+          </p>
+          <ul className="mt-5 grid gap-2.5 sm:grid-cols-2 sm:mt-6" role="list">
+            {WHAT_TO_EXPECT_BULLETS.map((line) => (
+              <li
+                key={line}
+                className="flex gap-3 rounded-xl border border-slate-200/90 bg-white p-3.5 text-left text-sm leading-snug text-slate-700 shadow-sm"
+              >
+                <CheckCircle2 className="h-5 w-5 shrink-0 text-[#F16112]" aria-hidden />
+                <span>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* 3. Signup form — Book Assessment style (navy/orange, card + gradient panels) */}
+      <section
+        id="signup"
+        className="scroll-mt-20 py-16 sm:py-20 bg-gradient-to-br from-gray-50 via-white to-gray-50 relative overflow-hidden"
+        aria-labelledby="signup-heading"
+      >
+        <div className="absolute inset-0 pointer-events-none opacity-30 overflow-hidden" aria-hidden>
+          <div className="absolute top-20 left-4 w-72 h-72 bg-gradient-to-br from-[#1F396D]/10 to-transparent rounded-full blur-3xl sm:left-10" />
+          <div className="absolute bottom-10 right-4 w-80 h-80 bg-gradient-to-br from-[#F16112]/10 to-transparent rounded-full blur-3xl sm:right-10" />
+        </div>
+        <div className="relative mx-auto max-w-4xl px-4 sm:px-6">
+          <h2 id="signup-heading" className={cn(h2Class, 'text-center text-gray-900')}>
+            Request Your Spot
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">We’ll follow up by email or phone.</p>
+
+          <Card className="mt-8 border-2 border-white/60 bg-white/95 shadow-2xl backdrop-blur-xl rounded-xl md:rounded-3xl overflow-hidden">
+            <CardContent className="p-4 sm:p-6 md:p-8 lg:pt-8">
+              {/* data-* attrs: keep password manager extensions from injecting DOM (hydration mismatch vs SSR). */}
+              <form
+                onSubmit={onSubmit}
+                className="space-y-6 md:space-y-8"
+                noValidate
+                data-lpignore="true"
+                data-1p-ignore
+                data-bwignore
+                data-dashlane-ignore="true"
+              >
+                {/* Your request */}
+                <div className="space-y-4 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 p-4 sm:p-6 md:p-8">
+                  <div className="flex items-center gap-2 sm:gap-3 border-b-2 border-[#1F396D]/20 pb-3 md:pb-4">
+                    <div className="rounded-lg bg-gradient-to-br from-[#1F396D] to-[#29335C] p-2 sm:rounded-xl sm:p-3">
+                      <ListChecks className="h-5 w-5 text-white sm:h-6 sm:w-6" aria-hidden />
+                    </div>
+                    <div>
+                      <h3 className="text-lg text-gray-900 sm:text-xl">Your request</h3>
+                      <p className="text-xs text-gray-500 sm:text-sm">Structured prep (paid) or complimentary Sunday session</p>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <span id="interest-label" className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base">
+                      <ListChecks className="h-4 w-4 shrink-0 text-[#F16112]" aria-hidden />
+                      Which option would you like? <span className="text-red-500">*</span>
+                    </span>
+                    <RadioGroup
+                      value={form.interest || undefined}
+                      onValueChange={(v) => setField('interest', v)}
+                      className="flex flex-col gap-2.5"
+                      aria-labelledby="interest-label"
+                    >
+                      {INTEREST_OPTIONS.map(({ value, label }) => (
+                        <label
+                          key={value}
+                          htmlFor={`interest-${value}`}
+                          className={cn(
+                            'flex cursor-pointer gap-3 rounded-lg border-2 p-3 transition-colors md:rounded-xl md:p-3.5',
+                            form.interest === value
+                              ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5'
+                              : 'border-gray-200 bg-white hover:border-[#F16112]/30',
+                          )}
+                        >
+                          <RadioGroupItem
+                            value={value}
+                            id={`interest-${value}`}
+                            className="mt-0.5 shrink-0 border-2 border-gray-400 text-[#F16112]"
+                          />
+                          <span className="text-sm font-medium leading-snug text-gray-800">{label}</span>
+                        </label>
+                      ))}
+                    </RadioGroup>
+                    {errors.interest && (
+                      <p className="text-sm text-red-600" role="alert">
+                        {errors.interest}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Parent & contact */}
+                <div className="space-y-4 md:space-y-6 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 p-4 sm:p-6 md:p-8">
+                  <div className="flex items-center gap-2 sm:gap-3 border-b-2 border-[#1F396D]/20 pb-3 md:pb-4">
+                    <div className="rounded-lg bg-gradient-to-br from-[#1F396D] to-[#29335C] p-2 sm:rounded-xl sm:p-3">
+                      <User className="h-5 w-5 text-white sm:h-6 sm:w-6" aria-hidden />
+                    </div>
+                    <div>
+                      <h3 className="text-lg text-gray-900 sm:text-xl">Parent & contact</h3>
+                      <p className="text-xs text-gray-500 sm:text-sm">How we reach you</p>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="parentName"
+                        className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                      >
+                        <User className="h-4 w-4 text-[#F16112]" aria-hidden />
+                        Parent name <span className="text-red-500">*</span>
+                      </Label>
+                      <Input
+                        {...PM_NO_INJECT}
+                        id="parentName"
+                        value={form.parentName}
+                        onChange={(e) => setField('parentName', e.target.value)}
+                        onFocus={() => setFocusedField('parentName')}
+                        onBlur={() => setFocusedField(null)}
+                        className={cn(
+                          'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                          focusedField === 'parentName'
+                            ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10'
+                            : 'border-gray-300 hover:border-gray-400',
+                          errors.parentName && 'border-red-500',
+                        )}
+                        autoComplete="name"
+                      />
+                      {errors.parentName && <p className="text-sm text-red-600">{errors.parentName}</p>}
+                    </div>
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="parentEmail"
+                        className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                      >
+                        <Mail className="h-4 w-4 text-[#1F396D]" aria-hidden />
+                        Parent email <span className="text-red-500">*</span>
+                      </Label>
+                      <Input
+                        {...PM_NO_INJECT}
+                        id="parentEmail"
+                        type="email"
+                        inputMode="email"
+                        value={form.parentEmail}
+                        onChange={(e) => setField('parentEmail', e.target.value)}
+                        onFocus={() => setFocusedField('parentEmail')}
+                        onBlur={() => setFocusedField(null)}
+                        className={cn(
+                          'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                          focusedField === 'parentEmail'
+                            ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10'
+                            : 'border-gray-300 hover:border-gray-400',
+                          errors.parentEmail && 'border-red-500',
+                        )}
+                        autoComplete="email"
+                      />
+                      {errors.parentEmail && <p className="text-sm text-red-600">{errors.parentEmail}</p>}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="studentName"
+                        className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                      >
+                        <GraduationCap className="h-4 w-4 text-[#F16112]" aria-hidden />
+                        Student name <span className="text-red-500">*</span>
+                      </Label>
+                      <Input
+                        {...PM_NO_INJECT}
+                        id="studentName"
+                        value={form.studentName}
+                        onChange={(e) => setField('studentName', e.target.value)}
+                        onFocus={() => setFocusedField('studentName')}
+                        onBlur={() => setFocusedField(null)}
+                        className={cn(
+                          'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                          focusedField === 'studentName'
+                            ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10'
+                            : 'border-gray-300 hover:border-gray-400',
+                          errors.studentName && 'border-red-500',
+                        )}
+                      />
+                      {errors.studentName && <p className="text-sm text-red-600">{errors.studentName}</p>}
+                    </div>
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="parentPhone"
+                        className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                      >
+                        <Phone className="h-4 w-4 text-[#F16112]" aria-hidden />
+                        Parent phone <span className="text-red-500">*</span>
+                      </Label>
+                      <Input
+                        {...PM_NO_INJECT}
+                        id="parentPhone"
+                        type="tel"
+                        inputMode="tel"
+                        placeholder={PHONE_PLACEHOLDER}
+                        value={form.parentPhone}
+                        onChange={(e) => setField('parentPhone', e.target.value)}
+                        onFocus={() => setFocusedField('parentPhone')}
+                        onBlur={() => setFocusedField(null)}
+                        className={cn(
+                          'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                          focusedField === 'parentPhone'
+                            ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10'
+                            : 'border-gray-300 hover:border-gray-400',
+                          errors.parentPhone && 'border-red-500',
+                        )}
+                        autoComplete="tel"
+                      />
+                      {errors.parentPhone && <p className="text-sm text-red-600">{errors.parentPhone}</p>}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Course details */}
+                <div className="space-y-4 md:space-y-6 rounded-xl md:rounded-2xl border-2 border-[#F16112]/10 bg-gradient-to-br from-[#F16112]/5 to-[#F1894F]/5 p-4 sm:p-6 md:p-8">
+                  <div className="flex items-center gap-2 sm:gap-3 border-b-2 border-[#F16112]/20 pb-3 md:pb-4">
+                    <div className="rounded-lg bg-gradient-to-br from-[#F16112] to-[#F1894F] p-2 sm:rounded-xl sm:p-3">
+                      <BookOpen className="h-5 w-5 text-white sm:h-6 sm:w-6" aria-hidden />
+                    </div>
+                    <div>
+                      <h3 className="text-lg text-gray-900 sm:text-xl">Course details</h3>
+                      <p className="text-xs text-gray-500 sm:text-sm">Grade, course, and school</p>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="grade-select"
+                        className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                      >
+                        <BookOpen className="h-4 w-4 text-[#1F396D]" aria-hidden />
+                        Grade <span className="text-red-500">*</span>
+                      </Label>
+                      <Select onValueChange={(v) => setField('grade', v)} value={form.grade || undefined}>
+                        <SelectTrigger
+                          {...PM_NO_INJECT}
+                          id="grade-select"
+                          className={cn(
+                            'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                            errors.grade
+                              ? 'border-red-500'
+                              : 'border-gray-300 hover:border-gray-400',
+                          )}
+                        >
+                          <SelectValue placeholder="Select grade" />
+                        </SelectTrigger>
+                        <SelectContent className="rounded-xl border-2 border-white/60 bg-white/95 shadow-2xl backdrop-blur-xl">
+                          {HS_GRADES.map((g) => (
+                            <SelectItem key={g} value={g} className="py-2.5 hover:bg-[#F16112]/10">
+                              {g}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {errors.grade && <p className="text-sm text-red-600">{errors.grade}</p>}
+                    </div>
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="subject-select"
+                        className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                      >
+                        <Calculator className="h-4 w-4 text-[#F16112]" aria-hidden />
+                        Current math course <span className="text-red-500">*</span>
+                      </Label>
+                      <Select value={form.subject || undefined} onValueChange={(v) => setField('subject', v)}>
+                        <SelectTrigger
+                          {...PM_NO_INJECT}
+                          id="subject-select"
+                          className={cn(
+                            'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                            errors.subject
+                              ? 'border-red-500'
+                              : 'border-gray-300 hover:border-gray-400',
+                          )}
+                          aria-describedby="subject-hint"
+                        >
+                          <SelectValue placeholder="Select current course" />
+                        </SelectTrigger>
+                        <SelectContent className="rounded-xl border-2 border-white/60 bg-white/95 shadow-2xl backdrop-blur-xl">
+                          {MATH_FINALS_PRACTICE_SUBJECTS.map((s) => (
+                            <SelectItem key={s} value={s} className="py-2.5 hover:bg-[#F16112]/10">
+                              {s}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <p id="subject-hint" className="text-xs text-gray-500">
+                        Algebra 1, Geometry, Algebra 2, or Pre-Calculus.
+                      </p>
+                      {errors.subject && <p className="text-sm text-red-600">{errors.subject}</p>}
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="school"
+                      className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                    >
+                      <School className="h-4 w-4 text-[#1F396D]" aria-hidden />
+                      School (optional)
+                    </Label>
+                    <Input
+                      {...PM_NO_INJECT}
+                      id="school"
+                      value={form.school}
+                      onChange={(e) => setField('school', e.target.value)}
+                      onFocus={() => setFocusedField('school')}
+                      onBlur={() => setFocusedField(null)}
+                      className={cn(
+                        'h-12 rounded-lg border-2 bg-white text-sm transition-all sm:text-base md:rounded-xl',
+                        focusedField === 'school'
+                          ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10'
+                          : 'border-gray-300 hover:border-gray-400',
+                      )}
+                      autoComplete="organization"
+                      placeholder="High school name"
+                    />
+                  </div>
+                </div>
+
+                {/* Optional upload & notes */}
+                <div className="space-y-4 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 p-4 sm:p-6 md:p-8">
+                  <div className="flex items-center gap-2 sm:gap-3 border-b-2 border-[#1F396D]/20 pb-3 md:pb-4">
+                    <div className="rounded-lg bg-gradient-to-br from-[#1F396D] to-[#F16112] p-2 sm:rounded-xl sm:p-3">
+                      <FileText className="h-5 w-5 text-white sm:h-6 sm:w-6" aria-hidden />
+                    </div>
+                    <div>
+                      <h3 className="text-lg text-gray-900 sm:text-xl">Optional</h3>
+                      <p className="text-xs text-gray-500 sm:text-sm">Helps us align the session to your class</p>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="q4-agenda"
+                      className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                    >
+                      <FileText className="h-4 w-4 text-[#F16112]" aria-hidden />
+                      Upload Quarter 4 topics or class outline (optional)
+                    </Label>
+                    <p className="text-xs text-gray-500">PDF or image, max 5 MB.</p>
+                    <input
+                      {...PM_NO_INJECT}
+                      ref={agendaInputRef}
+                      id="q4-agenda"
+                      name="q4Agenda"
+                      type="file"
+                      accept=".pdf,image/jpeg,image/jpg,image/png,image/webp,application/pdf"
+                      className="block w-full text-sm text-gray-600 file:mr-3 file:rounded-md file:border-0 file:bg-gradient-to-r file:from-[#1F396D]/10 file:to-[#F16112]/10 file:px-3 file:py-2 file:text-sm file:font-medium file:text-gray-800 hover:file:from-[#1F396D]/15 hover:file:to-[#F16112]/15"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="notes"
+                      className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base"
+                    >
+                      <MessageSquare className="h-4 w-4 text-[#1F396D]" aria-hidden />
+                      Notes (optional)
+                    </Label>
+                    <Textarea
+                      {...PM_NO_INJECT}
+                      id="notes"
+                      rows={2}
+                      value={form.notes}
+                      onChange={(e) => setField('notes', e.target.value)}
+                      onFocus={() => setFocusedField('notes')}
+                      onBlur={() => setFocusedField(null)}
+                      className={cn(
+                        'min-h-[52px] max-h-32 resize-y rounded-lg border-2 text-sm leading-snug transition-all md:rounded-xl',
+                        focusedField === 'notes'
+                          ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10'
+                          : 'border-gray-300 hover:border-gray-400',
+                        'bg-white',
+                      )}
+                      placeholder="Anything we should know about your student or timing."
+                    />
+                  </div>
+                </div>
+
+                <FormPrivacyConsent
+                  checkboxId="math-finals-consent"
+                  checked={agree}
+                  onCheckedChange={(c) => setAgree(!!c)}
+                  required
+                  showSubmitDisclaimer
+                  variant="compact"
+                  alignPrivacyWithConsent
+                />
+                {submitError && (
+                  <p className="text-sm text-red-600" role="alert">
+                    {submitError}
+                  </p>
+                )}
+                <p className="text-sm text-gray-600">
+                  We usually reply within <strong>one business day</strong>. Your information is only used to schedule
+                  this request and follow up about GrowWise programs—you can ask us to stop anytime.
+                </p>
+                <div className="flex w-full justify-center">
+                  <Button
+                    type="submit"
+                    disabled={submitting}
+                    className="h-11 w-auto min-w-[8.25rem] rounded-full bg-[#1F396D] px-6 text-base font-semibold text-white shadow-md transition-colors hover:bg-[#162a52]"
+                  >
+                    {submitting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Submitting…
+                      </>
+                    ) : (
+                      'Submit'
+                    )}
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* 7. FAQ */}
+      <section className="bg-gray-50 py-16 px-4 sm:px-6 lg:px-8" aria-labelledby="faq-heading">
+        <div className="mx-auto max-w-4xl">
+          <div className="text-center mb-12">
+            <h2 id="faq-heading" className="text-3xl font-bold text-gray-900 mb-4">
+              Questions parents and students usually ask before booking
+            </h2>
+            <p className="text-lg text-gray-600 mx-auto max-w-3xl">
+              This free high school math finals practice is designed for students who want one focused, exam-style
+              review session before finals. It is not a long-term tutoring program and it is not meant to reteach an
+              entire course in one hour.
+            </p>
+          </div>
+          <Accordion type="single" collapsible className="space-y-4">
+            {MATH_FINALS_PRACTICE_FAQS.map((faq, i) => (
+              <AccordionItem
+                value={`q-${i}`}
+                key={faq.question}
+                className="bg-white border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-all duration-200"
+              >
+                <AccordionTrigger className="px-6 py-4 text-left hover:no-underline">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-[#F16112]/10 rounded-lg flex items-center justify-center flex-shrink-0">
+                      <GraduationCap className="w-4 h-4 text-[#F16112]" aria-hidden />
+                    </div>
+                    <span className="font-semibold text-gray-900">{faq.question}</span>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent className="px-6 pb-4 text-gray-600">
+                  {faq.answer}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </section>
+
+      <section className="border-t border-slate-200/80 bg-slate-100/60 py-8">
+        <div className={cn(sectionClass, 'text-center')}>
+          <p className="text-sm text-slate-500">
+            Questions before you sign up? Use the form above and we will respond directly.
+          </p>
+          <div className="mt-4 flex w-full justify-center">
+            <Button
+              asChild
+              variant="outline"
+              className="h-10 rounded-full border-2 border-[#1F396D] px-5 text-base font-semibold text-[#1F396D] hover:bg-slate-50"
+            >
+              <a href="#signup">Reserve Free Practice Spot</a>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/data/math-finals-practice-faqs.ts
+++ b/src/data/math-finals-practice-faqs.ts
@@ -1,0 +1,78 @@
+import { CONTACT_INFO } from '@/lib/constants'
+
+/**
+ * Shared FAQ copy for the math finals practice landing (visible section + JSON-LD).
+ * Keep in sync: page server JSON-LD and MathFinalsPracticeLanding Accordion.
+ */
+export const MATH_FINALS_PRACTICE_FAQS: ReadonlyArray<{
+  question: string
+  answer: string
+}> = [
+  {
+    question: 'Is the Sunday 12–1 pm session free?',
+    answer:
+      'Yes. The complimentary in-center session is a preview in the Sunday 12–1 pm window—separate from the paid four-session prep course. It is not a full finals-prep package. Limited seats; registration is required.',
+  },
+  {
+    question: 'Are Math Finals Prep sessions free?',
+    answer:
+      'No. Only the complimentary Sunday session (12–1 pm window) is free. Math Finals Prep refers to the four-session structured finals-period program, which is paid. Our team will explain enrollment, schedule, and investment when you are ready.',
+  },
+  {
+    question: 'Who is this session for?',
+    answer:
+      'The preview hour is for high school students in the Tri-Valley and nearby areas who are preparing for end-of-year math finals and want focused, instructor-led practice. If you are unsure whether the level fits your student, share details in the form and we can confirm.',
+  },
+  {
+    question: 'What subjects are covered?',
+    answer:
+      'The preview is designed to support final exam prep for high school courses in Algebra 1, Geometry, Algebra 2, and Pre-Calculus. Your child should register for the subject that matches the course they are taking this year.',
+  },
+  {
+    question: 'Do we have to join the full Math Finals Prep program?',
+    answer:
+      'No. The complimentary session is optional. Math Finals Prep is also optional—you can request the preview only, ask about the paid program only, or both. There is no pressure to continue.',
+  },
+  {
+    question: 'Where is the session held?',
+    answer: `The in-person preview is at the GrowWise center: ${CONTACT_INFO.street}, ${CONTACT_INFO.city} ${CONTACT_INFO.zipCode}. (Room or check-in details are confirmed when we follow up on your request.)`,
+  },
+  {
+    question: 'Is this tutoring?',
+    answer:
+      'No. This is a structured finals practice session in the 12–1 pm window, not long-term tutoring. The goal is curriculum-aligned, exam-style practice and helping students identify what still needs review before their school exam.',
+  },
+  {
+    question: 'Will this help if my child has major foundational gaps?',
+    answer:
+      'Probably not on its own. This session is best for students who need targeted finals review, not full remediation of months of missed material. If a student has deeper gaps, ongoing tutoring is usually the better fit.',
+  },
+  {
+    question: 'What happens during the session?',
+    answer:
+      'The complimentary session is paced as a 2-hour experience (teaching and practice) aligned to Quarter 4 finals topics, with new topics in each session when offered on separate Sundays. The focus is finals-style work and what still needs attention before the school exam.',
+  },
+  {
+    question: 'Is this online or in person?',
+    answer: `This is an in-center session at GrowWise in ${CONTACT_INFO.city}, California.`,
+  },
+  {
+    question: 'How many free sessions can a student book?',
+    answer: 'One complimentary finals practice session per student.',
+  },
+  {
+    question: 'Is this a good fit for strong students too?',
+    answer:
+      'Yes. Students who are already doing reasonably well can still benefit from timed, exam-style practice and a final check on weak areas before finals week.',
+  },
+  {
+    question: 'What should students bring?',
+    answer:
+      'Students should bring the basics they would normally use for math work, such as pencils, an eraser, and any allowed calculator relevant to their course.',
+  },
+  {
+    question: 'Why are you offering this for free?',
+    answer:
+      'We want local students to get one structured opportunity to practice before finals in a calm, academic setting. It also gives families a chance to experience how GrowWise runs focused math support sessions.',
+  },
+]

--- a/src/data/math-finals-practice-interest.ts
+++ b/src/data/math-finals-practice-interest.ts
@@ -1,0 +1,13 @@
+export const MATH_FINALS_INTEREST_VALUES = ['structured_prep', 'free_sunday'] as const
+
+export type MathFinalsPracticeInterest = (typeof MATH_FINALS_INTEREST_VALUES)[number]
+
+/** Short labels for staff-facing emails and logs */
+export const MATH_FINALS_INTEREST_LABELS: Record<MathFinalsPracticeInterest, string> = {
+  structured_prep: 'Four-session structured finals prep course (paid)',
+  free_sunday: 'Complimentary Sunday finals session (12–1 pm)',
+}
+
+export function isMathFinalsPracticeInterest(v: string): v is MathFinalsPracticeInterest {
+  return (MATH_FINALS_INTEREST_VALUES as readonly string[]).includes(v)
+}

--- a/src/data/math-finals-practice-subjects.ts
+++ b/src/data/math-finals-practice-subjects.ts
@@ -1,0 +1,8 @@
+export const MATH_FINALS_PRACTICE_SUBJECTS = [
+  'Algebra 1',
+  'Geometry',
+  'Algebra 2',
+  'Pre-Calculus',
+] as const
+
+export type MathFinalsPracticeSubject = (typeof MATH_FINALS_PRACTICE_SUBJECTS)[number]

--- a/src/lib/brevo.ts
+++ b/src/lib/brevo.ts
@@ -2,6 +2,7 @@
  * Brevo (Sendinblue) REST API v3 — transactional email + contacts/lists.
  * Env: BREVO_API_KEY, BREVO_SENDER_EMAIL, BREVO_SENDER_NAME (optional),
  * BREVO_LIST_LOTTERY (numeric list id — summer camp guide leads + Meta Lead Ads upsert; legacy env name).
+ * BREVO_LIST_MATH_FINALS (numeric list id — high school math finals practice form; triggers automations).
  */
 
 import type { EmailAttachment, SendEmailResult } from '@/lib/email';
@@ -187,6 +188,114 @@ export async function addSummerCampLotteryContactToBrevoList(email: string): Pro
     const error = err instanceof Error ? err.message : 'List add failed';
     console.warn('[brevo] Lottery list contact error:', error);
     return { success: false, error };
+  }
+}
+
+/** Math finals practice form — fields synced to Brevo for list-based automations. */
+export interface MathFinalsLeadBrevoInput {
+  email: string
+  interestKey: string
+  interestLabel: string
+  parentName: string
+  studentName: string
+  grade: string
+  school: string
+  subject: string
+  phone: string
+  notes: string
+  q4AgendaUploaded: boolean
+  submittedAtIso: string
+}
+
+/**
+ * POST /v3/contacts — upsert lead and attach to `BREVO_LIST_MATH_FINALS` for Brevo automations.
+ * In Brevo: create Text attributes to match the keys in `attributes` (SOURCE, MATH_INTEREST, …) or map in workflows.
+ */
+export async function upsertMathFinalsLeadInBrevo(lead: MathFinalsLeadBrevoInput): Promise<SendEmailResult> {
+  const apiKey = getBrevoApiKey()
+  if (!apiKey) {
+    console.warn('[brevo] BREVO_API_KEY not set; skipping math finals lead upsert.')
+    return { success: false, error: 'Brevo not configured' }
+  }
+
+  const listIdRaw = process.env.BREVO_LIST_MATH_FINALS?.trim()
+  if (!listIdRaw) {
+    console.warn('[brevo] BREVO_LIST_MATH_FINALS not set; skipping math finals list/automation sync.')
+    return { success: false, error: 'BREVO_LIST_MATH_FINALS not set' }
+  }
+
+  const listId = Number.parseInt(listIdRaw, 10)
+  if (!Number.isFinite(listId)) {
+    console.warn('[brevo] BREVO_LIST_MATH_FINALS must be a numeric list id.')
+    return { success: false, error: 'Invalid BREVO_LIST_MATH_FINALS' }
+  }
+
+  const listIds = filterAutomationListIds([listId])
+  if (!listIds) {
+    console.warn(
+      '[brevo] BREVO_LIST_MATH_FINALS is excluded from automation; upserting contact without listIds.',
+      { listId }
+    )
+  }
+
+  const email = lead.email.trim().toLowerCase()
+  if (!email) {
+    return { success: false, error: 'No email' }
+  }
+
+  const attributes: Record<string, string> = {
+    SOURCE: 'math_finals_practice',
+    MATH_INTEREST: lead.interestLabel,
+    MATH_INTEREST_KEY: lead.interestKey,
+    GRADE: lead.grade,
+    PHONE: lead.phone,
+    PARENT_NAME: lead.parentName,
+    STUDENT_NAME: lead.studentName,
+    SCHOOL: lead.school,
+    MATH_COURSE: lead.subject,
+    Q4_AGENDA_UPLOADED: lead.q4AgendaUploaded ? 'yes' : 'no',
+    SUBMITTED_AT: lead.submittedAtIso,
+  }
+  const notesTrim = lead.notes.trim()
+  if (notesTrim) {
+    attributes.FORM_NOTES = notesTrim.slice(0, 5000)
+  }
+
+  try {
+    const res = await fetchWithTimeout(`${BREVO_API_BASE}/contacts`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'api-key': apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        attributes,
+        ...(listIds ? { listIds } : {}),
+        updateEnabled: true,
+      }),
+    })
+
+    const raw = await res.text()
+    let parsed: { message?: string } = {}
+    try {
+      parsed = raw ? (JSON.parse(raw) as typeof parsed) : {}
+    } catch {
+      /* ignore */
+    }
+
+    if (!res.ok) {
+      const errMsg = parsed.message || raw || `HTTP ${res.status}`
+      console.warn('[brevo] Math finals contact upsert failed:', errMsg)
+      return { success: false, error: errMsg }
+    }
+
+    return { success: true }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Math finals Brevo upsert failed'
+    console.warn('[brevo] Math finals contact upsert error:', error)
+    return { success: false, error }
   }
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -32,7 +32,7 @@ export const S3_IMAGE_BASE_URL =
 export function getS3ImageUrl(imagePath: string, size?: string): string {
   const basePath = imagePath.replace(/^\//, ''); // Remove leading slash if present
   if (size) {
-    // If size is provided, try to find size-specific version
+    // Try to find size-specific version
     // Format: images/founder/anshika-verma-300x180.png
     const ext = basePath.split('.').pop();
     const nameWithoutExt = basePath.replace(`.${ext}`, '');
@@ -48,4 +48,3 @@ export const BUSINESS_EMAIL = CONTACT_INFO.businessEmail;
 export const ADDRESS = CONTACT_INFO.address;
 export const FORMATTED_ADDRESS = CONTACT_INFO.formattedAddress;
 export const CITY = CONTACT_INFO.city;
-

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -170,6 +170,15 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
     path: '/book-assessment',
   },
 
+  '/math-finals-practice-session': {
+    title: 'Math Finals Sunday Session 12–1 | Dublin, CA | GrowWise',
+    description:
+      'Request a complimentary in-center high school math finals session (Sunday 12–1 pm) or four-session prep in Dublin, CA. Algebra 1 through Pre-Calculus.',
+    keywords:
+      'high school math finals prep, free math practice session, Dublin CA math tutoring, algebra finals, geometry finals, Pre-Calculus review, Tri-Valley math, GrowWise',
+    path: '/math-finals-practice-session',
+  },
+
   // Thank-you: runtime `generateMetadata` uses `buildFormThankYouMetadata` + `src/data/form-thank-you/en.json` (noindex).
   '/book-assessment/thank-you': {
     title: 'Assessment request received | GrowWise',

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -48,6 +48,7 @@ const corePages: SitemapEntry[] = [
   { path: '/enroll', priority: 0.9, changefreq: 'monthly' },
   { path: '/enroll-academic', priority: 0.9, changefreq: 'monthly' },
   { path: '/book-assessment', priority: 0.9, changefreq: 'monthly' },
+  { path: '/math-finals-practice-session', priority: 0.85, changefreq: 'weekly' },
   { path: '/workshop-calendar', priority: 0.8, changefreq: 'weekly' },
   { path: '/programs', priority: 0.8, changefreq: 'monthly' },
   { path: '/growwise-blogs', priority: 0.85, changefreq: 'weekly' },


### PR DESCRIPTION
## Summary
Adds the **High School Math Finals Practice** lead flow: localized pages, form submission API, Brevo transactional email + contact/list sync for automations, header navigation, SEO, and form UX hardening.

## What’s included
- **Pages:** `/math-finals-practice-session`, thank-you, Service JSON-LD layout
- **API:** `POST /api/math-finals-practice` (JSON + multipart), Brevo first with SMTP fallback; `BREVO_LIST_MATH_FINALS` for list-based automations (`env.local.example` documents list id **15**)
- **Nav:** Academic → High School Math → **Math Finals Prep** (+ mobile nested items)
- **Forms:** `FormPrivacyConsent` `alignPrivacyWithConsent`; `data-lpignore` / field attrs to reduce password-manager hydration noise
- **SEO:** metadata + sitemap entries

## How to test
1. `npm run build` / `npm run lint` / `npm test`
2. Set Brevo env vars locally; submit form; confirm emails and Brevo list **15**

## Checklist
- [x] Build passes
- [ ] Vercel env: `BREVO_LIST_MATH_FINALS=15` (and API key + sender) if not already set
- [ ] Backend `header.json` (if used) aligned with `public/api/mock/en/header.json` for production menu


Made with [Cursor](https://cursor.com)