### PR TITLE
Math Finals Prep: remove free session, align copy and SEO

### DIFF
--- a/public/api/mock/en/header.json
+++ b/public/api/mock/en/header.json
@@ -78,7 +78,7 @@
               },
               {
                 "title": "Math Finals Prep",
-                "description": "End-of-year finals support & complimentary preview session",
+                "description": "End-of-year finals support & structured prep program",
                 "icon": "Target",
                 "href": "/math-finals-practice-session",
                 "gradient": "from-[#1F396D] to-[#F16112]"

--- a/src/app/[locale]/math-finals-practice-session/layout.tsx
+++ b/src/app/[locale]/math-finals-practice-session/layout.tsx
@@ -3,14 +3,15 @@ import { generateMetadataFromPath } from '@/lib/seo/metadata'
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
 import { absoluteSiteUrl } from '@/lib/publicPath'
 import { CONTACT_INFO } from '@/lib/constants'
+import { MATH_FINALS_PRACTICE_SESSION_DESCRIPTION } from '@/lib/seo/metadataConfig'
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
   const metadata = generateMetadataFromPath('/math-finals-practice-session', locale)
   return (
     metadata || {
-      title: 'Free math finals practice | GrowWise',
-      description: 'Free in-center high school math finals practice session in Dublin, CA.',
+      title: 'High School Math Finals Prep | GrowWise',
+      description: MATH_FINALS_PRACTICE_SESSION_DESCRIPTION,
     }
   )
 }
@@ -29,10 +30,9 @@ export default async function MathFinalsPracticeLayout({
     '@context': 'https://schema.org',
     '@type': 'Service',
     '@id': absoluteSiteUrl('/math-finals-practice-session#service', locale, baseUrl),
-    name: 'Complimentary high school math finals session (Sunday 12–1 pm)',
-    description:
-      'One complimentary in-center session in the Sunday 12–1 pm window for high school students preparing for math finals (Algebra 1, Algebra 2, and Pre-Calculus) at GrowWise in Dublin, CA. Paid four-session Math Finals Prep is a separate program.',
-    serviceType: 'Tutoring session',
+    name: 'High school Math Finals Prep (four-session program)',
+    description: MATH_FINALS_PRACTICE_SESSION_DESCRIPTION,
+    serviceType: 'Educational program',
     provider: {
       '@type': 'EducationalOrganization',
       name: 'GrowWise',
@@ -55,12 +55,11 @@ export default async function MathFinalsPracticeLayout({
     ],
     offers: {
       '@type': 'Offer',
-      price: '0',
       priceCurrency: 'USD',
       availability: 'https://schema.org/InStock',
       url: absoluteSiteUrl('/math-finals-practice-session', locale, baseUrl),
       description:
-        'Complimentary Sunday session in the 12–1 pm window (registration required; capacity limited). Paid four-session Math Finals Prep is separate.',
+        'Four-session Math Finals Prep. Contact GrowWise for current schedule, scope, and enrollment.',
     },
     url: absoluteSiteUrl('/math-finals-practice-session', locale, baseUrl),
   }

--- a/src/app/[locale]/math-finals-practice-session/page.tsx
+++ b/src/app/[locale]/math-finals-practice-session/page.tsx
@@ -1,6 +1,6 @@
 import { MathFinalsPracticeLanding } from '@/components/math-finals-practice/MathFinalsPracticeLanding'
 import { MATH_FINALS_PRACTICE_FAQS } from '@/data/math-finals-practice-faqs'
-import { getMetadataConfig } from '@/lib/seo/metadataConfig'
+import { getMetadataConfig, MATH_FINALS_PRACTICE_SESSION_DESCRIPTION } from '@/lib/seo/metadataConfig'
 import { absoluteSiteUrl } from '@/lib/publicPath'
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
 import {
@@ -20,11 +20,8 @@ export default async function MathFinalsPracticePage({
   const baseUrl = getCanonicalSiteUrl()
   const pageUrl = absoluteSiteUrl(PAGE_PATH, locale, baseUrl)
   const meta = getMetadataConfig(PAGE_PATH)
-  const name =
-    meta?.title ?? 'Free High School Math Finals Practice Session | GrowWise'
-  const description =
-    meta?.description ??
-    'Request a high school math finals session in Dublin, CA — Sunday 12–1 pm or structured prep. Algebra 1, Algebra 2, and Pre-Calculus.'
+  const name = meta?.title ?? 'High School Math Finals Prep | GrowWise'
+  const description = meta?.description ?? MATH_FINALS_PRACTICE_SESSION_DESCRIPTION
 
   const breadcrumbSchema = generateBreadcrumbSchema([
     { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },

--- a/src/app/[locale]/math-finals-practice-session/thank-you/page.tsx
+++ b/src/app/[locale]/math-finals-practice-session/thank-you/page.tsx
@@ -51,8 +51,8 @@ export default async function MathFinalsPracticeThankYouPage({
             Thank you — we received your request.
           </h1>
           <p className="mt-4 text-slate-600">
-            Our team will follow up shortly by email or phone to confirm next steps for the option you selected—the
-            four-session structured prep course or the complimentary Sunday session (12–1 pm time window).
+            Our team will follow up shortly by email or phone with next steps for the four-session Math Finals Prep
+            program—schedule, scope, and enrollment.
           </p>
           <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
             <Link

--- a/src/app/api/math-finals-practice/route.ts
+++ b/src/app/api/math-finals-practice/route.ts
@@ -6,11 +6,7 @@ import {
   upsertMathFinalsLeadInBrevo,
 } from '@/lib/brevo'
 import { sendEmail, type EmailAttachment, type SendEmailResult } from '@/lib/email'
-import {
-  isMathFinalsPracticeInterest,
-  MATH_FINALS_INTEREST_LABELS,
-  type MathFinalsPracticeInterest,
-} from '@/data/math-finals-practice-interest'
+import { isMathFinalsPracticeInterest, MATH_FINALS_INTEREST_LABELS, type MathFinalsPracticeInterest } from '@/data/math-finals-practice-interest'
 import { MATH_FINALS_PRACTICE_SUBJECTS, type MathFinalsPracticeSubject } from '@/data/math-finals-practice-subjects'
 
 export const maxDuration = 60
@@ -89,22 +85,12 @@ async function sendMathFinalsEmailWithFallback(opts: {
   })
 }
 
-function userFollowUpParagraphHtml(interest: MathFinalsPracticeInterest): string {
-  switch (interest) {
-    case 'structured_prep':
-      return 'Our team will follow up about the <strong>four-session structured finals prep</strong> course (paid)—scheduling, scope, and next steps.'
-    case 'free_sunday':
-      return 'We will follow up to confirm your <strong>complimentary Sunday finals</strong> session in the <strong>12–1 pm</strong> time window (exact slot when we contact you).'
-  }
+function userFollowUpParagraphHtml(_interest: MathFinalsPracticeInterest): string {
+  return 'Our team will follow up about the <strong>four-session Math Finals Prep</strong> program—scheduling, scope, enrollment, and next steps.'
 }
 
-function userFollowUpParagraphPlain(interest: MathFinalsPracticeInterest): string {
-  switch (interest) {
-    case 'structured_prep':
-      return 'Our team will follow up about the four-session structured finals prep course (paid)—scheduling, scope, and next steps.'
-    case 'free_sunday':
-      return 'We will follow up to confirm your complimentary Sunday finals session in the 12–1 pm time window (exact slot when we contact you).'
-  }
+function userFollowUpParagraphPlain(_interest: MathFinalsPracticeInterest): string {
+  return 'Our team will follow up about the four-session Math Finals Prep program—scheduling, scope, enrollment, and next steps.'
 }
 
 function parseForm(fields: {
@@ -121,10 +107,18 @@ function parseForm(fields: {
   | { ok: true; data: ParsedMathFinalsForm }
   | { ok: false; error: string; status: number } {
   const interestRaw = fields.interest.trim()
-  if (!isMathFinalsPracticeInterest(interestRaw)) {
-    return { ok: false, error: 'Please select which option you want.', status: 400 }
+  if (interestRaw === 'free_sunday') {
+    return {
+      ok: false,
+      error: 'That option is no longer available. Please refresh the page and submit again.',
+      status: 400,
+    }
   }
-  const interest = interestRaw
+  const interestCandidate = interestRaw || 'structured_prep'
+  if (!isMathFinalsPracticeInterest(interestCandidate)) {
+    return { ok: false, error: 'Invalid request. Please use the form on our website.', status: 400 }
+  }
+  const interest = interestCandidate
 
   const parentName = fields.parentName.trim()
   const studentName = fields.studentName.trim()

--- a/src/components/layout/Header/constants.ts
+++ b/src/components/layout/Header/constants.ts
@@ -133,7 +133,7 @@ export const FALLBACK_MENU_ITEMS: MenuItem[] = [
             },
             {
               title: 'Math Finals Prep',
-              description: 'End-of-year finals support & complimentary preview session',
+              description: 'End-of-year finals support & structured prep program',
               icon: 'Target',
               href: '/math-finals-practice-session',
               gradient: 'from-[#1F396D] to-[#F16112]',

--- a/src/components/math-finals-practice/MathFinalsPracticeLanding.tsx
+++ b/src/components/math-finals-practice/MathFinalsPracticeLanding.tsx
@@ -18,15 +18,10 @@ import {
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent'
 import { MATH_FINALS_PRACTICE_FAQS } from '@/data/math-finals-practice-faqs'
 import {
-  isMathFinalsPracticeInterest,
-  type MathFinalsPracticeInterest,
-} from '@/data/math-finals-practice-interest'
-import {
   MATH_FINALS_PRACTICE_SUBJECTS,
   type MathFinalsPracticeSubject,
 } from '@/data/math-finals-practice-subjects'
 import { PHONE_PLACEHOLDER } from '@/lib/constants'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { publicPath } from '@/lib/publicPath'
 import { cn } from '@/lib/utils'
 import {
@@ -35,7 +30,6 @@ import {
   CheckCircle2,
   FileText,
   GraduationCap,
-  ListChecks,
   Loader2,
   Mail,
   MessageSquare,
@@ -53,25 +47,13 @@ const PM_NO_INJECT = { 'data-lpignore': 'true' } as const
 const HS_GRADES = ['Grade 9', 'Grade 10', 'Grade 11', 'Grade 12'] as const
 
 const WHAT_TO_EXPECT_BULLETS: readonly string[] = [
-  'School-aligned Quarter 4 topics preparation',
-  'Fast-paced 2-hour session: 1 hour of teaching and 1 hour of practice',
-  'One complimentary session per student',
-  'New topics in each session; previous topics are not repeated',
-]
-
-const INTEREST_OPTIONS: ReadonlyArray<{ value: MathFinalsPracticeInterest; label: string }> = [
-  {
-    value: 'structured_prep',
-    label: 'Request the four-session structured finals prep course',
-  },
-  {
-    value: 'free_sunday',
-    label: 'Request the complimentary Sunday finals session (12–1 pm)',
-  },
+  'School-aligned Quarter 4 topics and finals-period focus',
+  'Four-session structured program with teaching and exam-style practice',
+  'In-center at GrowWise in Dublin, CA',
+  'Paced across multiple sessions for steady review before finals week',
 ]
 
 type FormState = {
-  interest: string
   parentName: string
   studentName: string
   grade: string
@@ -83,7 +65,6 @@ type FormState = {
 }
 
 const initialForm: FormState = {
-  interest: '',
   parentName: '',
   studentName: '',
   grade: '',
@@ -120,9 +101,6 @@ export function MathFinalsPracticeLanding() {
 
   const validate = useCallback((): boolean => {
     const e: Partial<Record<keyof FormState, string>> = {}
-    if (!form.interest || !isMathFinalsPracticeInterest(form.interest)) {
-      e.interest = 'Please select which option you want.'
-    }
     if (!form.parentName.trim()) e.parentName = 'Please enter the parent or guardian name.'
     if (!form.studentName.trim()) e.studentName = "Please enter the student's name."
     if (!form.grade) e.grade = 'Please select a grade level.'
@@ -150,7 +128,7 @@ export function MathFinalsPracticeLanding() {
     setSubmitting(true)
     try {
       const fd = new FormData()
-      fd.set('interest', form.interest)
+      fd.set('interest', 'structured_prep')
       fd.set('parentName', form.parentName.trim())
       fd.set('studentName', form.studentName.trim())
       fd.set('grade', form.grade)
@@ -198,27 +176,27 @@ export function MathFinalsPracticeLanding() {
           <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-600">
             <span>GrowWise In-center</span>
             <span className="h-1 w-1 rounded-full bg-slate-400" aria-hidden />
-            <span>Sunday 12–1 pm</span>
+            <span>Dublin, CA</span>
           </div>
           <h1
             id="math-finals-hero-title"
             className="mt-6 text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl md:text-6xl"
           >
-            High School Math Finals Practice in Dublin, CA
+            High School Math Finals Prep in Dublin, CA
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-base text-slate-600 sm:text-lg">
-            One complimentary hour of exam-style practice covering <strong>Algebra 1</strong>, <strong>Algebra 2</strong>, and <strong>Pre-Calculus</strong>. This session is dedicated to finals-style
-            review—not foundational tutoring.
+            In-center high school math finals prep in Dublin, CA for <strong>Algebra 1</strong>,{' '}
+            <strong>Algebra 2</strong>, and <strong>Pre-Calculus</strong> with exam-style practice.
           </p>
           <p className="mx-auto mt-4 max-w-2xl text-sm font-medium text-[#F16112]">
-            Strictly limited to one complimentary session per student.
+            Submit the form and our team will follow up with schedule, scope, and enrollment details.
           </p>
           <div className="mt-10 flex w-full max-w-2xl flex-col items-center justify-center gap-3 sm:mx-auto sm:flex-row sm:gap-4">
             <Button
               asChild
               className="h-11 w-full max-w-[280px] rounded-full bg-gradient-to-r from-[#F16112] to-[#F1894F] px-7 text-base font-semibold text-white shadow-lg transition-all duration-300 hover:from-[#d54f0a] hover:to-[#F16112] hover:shadow-xl sm:max-w-none sm:w-auto"
             >
-              <a href="#signup">Reserve Free Practice Spot</a>
+              <a href="#signup">Request Math Finals Prep</a>
             </Button>
             <a
               href="#what-to-expect"
@@ -230,7 +208,7 @@ export function MathFinalsPracticeLanding() {
         </div>
       </section>
 
-      {/* 2. What to expect — free session offer (2 hours: teach + practice) */}
+      {/* 2. What to expect */}
       <section
         id="what-to-expect"
         className="border-b border-slate-200/80 bg-slate-50/90 py-8 sm:py-10"
@@ -241,10 +219,10 @@ export function MathFinalsPracticeLanding() {
             id="what-to-expect-heading"
             className="text-center text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl"
           >
-            What to expect in your free session
+            What to expect
           </h2>
           <p className="mx-auto mt-2 max-w-xl text-center text-slate-600">
-            In-center in Dublin, CA. One complimentary session per student.
+            In-center in Dublin, CA. Our team confirms details when we respond to your request.
           </p>
           <ul className="mt-5 grid gap-2.5 sm:grid-cols-2 sm:mt-6" role="list">
             {WHAT_TO_EXPECT_BULLETS.map((line) => (
@@ -296,56 +274,6 @@ export function MathFinalsPracticeLanding() {
                 data-bwignore
                 data-dashlane-ignore="true"
               >
-                {/* Your request */}
-                <div className="space-y-4 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 p-4 sm:p-6 md:p-8">
-                  <div className="flex items-center gap-2 sm:gap-3 border-b-2 border-[#1F396D]/20 pb-3 md:pb-4">
-                    <div className="rounded-lg bg-gradient-to-br from-[#1F396D] to-[#29335C] p-2 sm:rounded-xl sm:p-3">
-                      <ListChecks className="h-5 w-5 text-white sm:h-6 sm:w-6" aria-hidden />
-                    </div>
-                    <div>
-                      <h3 className="text-lg text-gray-900 sm:text-xl">Your request</h3>
-                      <p className="text-xs text-gray-500 sm:text-sm">Structured prep (paid) or complimentary Sunday session</p>
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <span id="interest-label" className="flex items-center gap-2 text-sm font-medium text-gray-700 sm:text-base">
-                      <ListChecks className="h-4 w-4 shrink-0 text-[#F16112]" aria-hidden />
-                      Which option would you like? <span className="text-red-500">*</span>
-                    </span>
-                    <RadioGroup
-                      value={form.interest || undefined}
-                      onValueChange={(v) => setField('interest', v)}
-                      className="flex flex-col gap-2.5"
-                      aria-labelledby="interest-label"
-                    >
-                      {INTEREST_OPTIONS.map(({ value, label }) => (
-                        <label
-                          key={value}
-                          htmlFor={`interest-${value}`}
-                          className={cn(
-                            'flex cursor-pointer gap-3 rounded-lg border-2 p-3 transition-colors md:rounded-xl md:p-3.5',
-                            form.interest === value
-                              ? 'border-[#F16112] bg-gradient-to-r from-[#F16112]/5 to-[#F1894F]/5'
-                              : 'border-gray-200 bg-white hover:border-[#F16112]/30',
-                          )}
-                        >
-                          <RadioGroupItem
-                            value={value}
-                            id={`interest-${value}`}
-                            className="mt-0.5 shrink-0 border-2 border-gray-400 text-[#F16112]"
-                          />
-                          <span className="text-sm font-medium leading-snug text-gray-800">{label}</span>
-                        </label>
-                      ))}
-                    </RadioGroup>
-                    {errors.interest && (
-                      <p className="text-sm text-red-600" role="alert">
-                        {errors.interest}
-                      </p>
-                    )}
-                  </div>
-                </div>
-
                 {/* Parent & contact */}
                 <div className="space-y-4 md:space-y-6 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 p-4 sm:p-6 md:p-8">
                   <div className="flex items-center gap-2 sm:gap-3 border-b-2 border-[#1F396D]/20 pb-3 md:pb-4">
@@ -688,9 +616,8 @@ export function MathFinalsPracticeLanding() {
               Questions parents and students usually ask before booking
             </h2>
             <p className="text-lg text-gray-600 mx-auto max-w-3xl">
-              This free high school math finals practice is designed for students who want one focused, exam-style
-              review session before finals. It is not a long-term tutoring program and it is not meant to reteach an
-              entire course in one hour.
+              Math Finals Prep is for students who want structured, exam-style review before finals. It is not a
+              long-term tutoring plan and it is not designed to reteach an entire course in a short sequence.
             </p>
           </div>
           <Accordion type="single" collapsible className="space-y-4">
@@ -728,7 +655,7 @@ export function MathFinalsPracticeLanding() {
               variant="outline"
               className="h-10 rounded-full border-2 border-[#1F396D] px-5 text-base font-semibold text-[#1F396D] hover:bg-slate-50"
             >
-              <a href="#signup">Reserve Free Practice Spot</a>
+              <a href="#signup">Request Math Finals Prep</a>
             </Button>
           </div>
         </div>

--- a/src/data/math-finals-practice-faqs.ts
+++ b/src/data/math-finals-practice-faqs.ts
@@ -1,7 +1,7 @@
 import { CONTACT_INFO } from '@/lib/constants'
 
 /**
- * Shared FAQ copy for the math finals practice landing (visible section + JSON-LD).
+ * Shared FAQ copy for the math finals landing (visible section + JSON-LD).
  * Keep in sync: page server JSON-LD and MathFinalsPracticeLanding Accordion.
  */
 export const MATH_FINALS_PRACTICE_FAQS: ReadonlyArray<{
@@ -9,70 +9,56 @@ export const MATH_FINALS_PRACTICE_FAQS: ReadonlyArray<{
   answer: string
 }> = [
   {
-    question: 'Is the Sunday 12–1 pm session free?',
+    question: 'What is Math Finals Prep?',
     answer:
-      'Yes. The complimentary in-center session is a preview in the Sunday 12–1 pm window—separate from the paid four-session prep course. It is not a full finals-prep package. Limited seats; registration is required.',
+      'Math Finals Prep is GrowWise’s four-session, structured program for high school students preparing for end-of-year math finals. It focuses on exam-style practice and Quarter 4–aligned review for Algebra 1, Algebra 2, and Pre-Calculus—not reteaching an entire course in one sitting.',
   },
   {
-    question: 'Are Math Finals Prep sessions free?',
+    question: 'Who is this program for?',
     answer:
-      'No. Only the complimentary Sunday session (12–1 pm window) is free. Math Finals Prep refers to the four-session structured finals-period program, which is paid. Our team will explain enrollment, schedule, and investment when you are ready.',
-  },
-  {
-    question: 'Who is this session for?',
-    answer:
-      'The preview hour is for high school students in the Tri-Valley and nearby areas who are preparing for end-of-year math finals and want focused, instructor-led practice. If you are unsure whether the level fits your student, share details in the form and we can confirm.',
+      'It is for high school students in the Tri-Valley and nearby areas who want focused finals-period support before exams. If you are unsure about level or pacing, share details in the form and we can confirm fit.',
   },
   {
     question: 'What subjects are covered?',
     answer:
-      'The preview is designed to support final exam prep for high school courses in Algebra 1, Algebra 2, and Pre-Calculus. Your child should register for the subject that matches the course they are taking this year.',
+      'The program supports final exam prep for high school Algebra 1, Algebra 2, and Pre-Calculus. Register for the track that matches the course your student is taking this year.',
   },
   {
-    question: 'Do we have to join the full Math Finals Prep program?',
+    question: 'How do we enroll or get schedule details?',
     answer:
-      'No. The complimentary session is optional. Math Finals Prep is also optional—you can request the preview only, ask about the paid program only, or both. There is no pressure to continue.',
+      'Submit the request form. Our team will follow up by email or phone with session timing, structure, and enrollment steps—including investment—so you can decide with full information.',
   },
   {
-    question: 'Where is the session held?',
-    answer: `The in-person preview is at the GrowWise center: ${CONTACT_INFO.street}, ${CONTACT_INFO.city} ${CONTACT_INFO.zipCode}. (Room or check-in details are confirmed when we follow up on your request.)`,
+    question: 'Where is the program held?',
+    answer: `Sessions are in person at the GrowWise center: ${CONTACT_INFO.street}, ${CONTACT_INFO.city} ${CONTACT_INFO.zipCode}. (Room or check-in details are confirmed when we follow up.)`,
   },
   {
-    question: 'Is this tutoring?',
+    question: 'Is this the same as ongoing tutoring?',
     answer:
-      'No. This is a structured finals practice session in the 12–1 pm window, not long-term tutoring. The goal is curriculum-aligned, exam-style practice and helping students identify what still needs review before their school exam.',
+      'No. This is a time-bound finals prep program with a defined scope. Students who need long-term or full-course remediation usually benefit more from regular tutoring than from a short finals sequence alone.',
   },
   {
     question: 'Will this help if my child has major foundational gaps?',
     answer:
-      'Probably not on its own. This session is best for students who need targeted finals review, not full remediation of months of missed material. If a student has deeper gaps, ongoing tutoring is usually the better fit.',
+      'Probably not on its own. The program works best for students who need targeted finals review, not for catching up on months of missed material. If there are deeper gaps, ongoing tutoring is often the better fit.',
   },
   {
-    question: 'What happens during the session?',
+    question: 'What happens during the sessions?',
     answer:
-      'The complimentary session is paced as a 2-hour experience (teaching and practice) aligned to Quarter 4 finals topics, with new topics in each session when offered on separate Sundays. The focus is finals-style work and what still needs attention before the school exam.',
+      'Across the four sessions, students get instructor-led review and exam-style practice aligned to Quarter 4 finals topics, with attention to what still needs work before the school exam. Exact pacing is adjusted to the group and course track.',
   },
   {
     question: 'Is this online or in person?',
-    answer: `This is an in-center session at GrowWise in ${CONTACT_INFO.city}, California.`,
-  },
-  {
-    question: 'How many free sessions can a student book?',
-    answer: 'One complimentary finals practice session per student.',
+    answer: `This program runs in person at GrowWise in ${CONTACT_INFO.city}, California.`,
   },
   {
     question: 'Is this a good fit for strong students too?',
     answer:
-      'Yes. Students who are already doing reasonably well can still benefit from timed, exam-style practice and a final check on weak areas before finals week.',
+      'Yes. Students who are already doing well can still benefit from timed, exam-style practice and a final check on weak areas before finals week.',
   },
   {
     question: 'What should students bring?',
     answer:
-      'Students should bring the basics they would normally use for math work, such as pencils, an eraser, and any allowed calculator relevant to their course.',
-  },
-  {
-    question: 'Why are you offering this for free?',
-    answer:
-      'We want local students to get one structured opportunity to practice before finals in a calm, academic setting. It also gives families a chance to experience how GrowWise runs focused math support sessions.',
+      'Students should bring what they normally use for math work—pencils, an eraser, and any calculator allowed for their school course, if applicable.',
   },
 ]

--- a/src/data/math-finals-practice-interest.ts
+++ b/src/data/math-finals-practice-interest.ts
@@ -1,11 +1,10 @@
-export const MATH_FINALS_INTEREST_VALUES = ['structured_prep', 'free_sunday'] as const
+export const MATH_FINALS_INTEREST_VALUES = ['structured_prep'] as const
 
 export type MathFinalsPracticeInterest = (typeof MATH_FINALS_INTEREST_VALUES)[number]
 
 /** Short labels for staff-facing emails and logs */
 export const MATH_FINALS_INTEREST_LABELS: Record<MathFinalsPracticeInterest, string> = {
-  structured_prep: 'Four-session structured finals prep course (paid)',
-  free_sunday: 'Complimentary Sunday finals session (12–1 pm)',
+  structured_prep: 'Four-session structured finals prep course',
 }
 
 export function isMathFinalsPracticeInterest(v: string): v is MathFinalsPracticeInterest {

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -13,6 +13,10 @@ export interface PageMetadataConfig {
   type?: 'website' | 'article'
 }
 
+/** Used for `/math-finals-practice-session` meta tags, JSON-LD, and fallbacks. */
+export const MATH_FINALS_PRACTICE_SESSION_DESCRIPTION =
+  'In-center high school math finals prep in Dublin, CA for Algebra 1, Algebra 2, and Pre-Calculus with exam-style practice.'
+
 export const metadataConfig: Record<string, PageMetadataConfig> = {
   // Home page
   '/': {
@@ -171,11 +175,10 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/math-finals-practice-session': {
-    title: 'Math Finals Sunday Session 12–1 | Dublin, CA | GrowWise',
-    description:
-      'Request a complimentary in-center high school math finals session (Sunday 12–1 pm) or four-session prep in Dublin, CA. Algebra 1, Algebra 2, and Pre-Calculus.',
+    title: 'High School Math Finals Prep | Dublin, CA | GrowWise',
+    description: MATH_FINALS_PRACTICE_SESSION_DESCRIPTION,
     keywords:
-      'high school math finals prep, free math practice session, Dublin CA math tutoring, algebra 1 finals, algebra 2 finals, Pre-Calculus review, Tri-Valley math, GrowWise',
+      'high school math finals prep, Dublin CA math tutoring, algebra 1 finals, algebra 2 finals, Pre-Calculus review, Tri-Valley math, GrowWise',
     path: '/math-finals-practice-session',
   },
 


### PR DESCRIPTION
## Summary
Updates the Math Finals landing and related flows to **paid-only** four-session prep: removes the complimentary Sunday option end-to-end, simplifies the form, and aligns on-page hero text with SEO/JSON-LD.

## Changes
- **Landing**: Hero copy, "What to expect" bullets, removed "Your request" block; form always submits `structured_prep`.
- **API**: Rejects legacy `free_sunday`; confirmation emails reference Math Finals Prep only.
- **Data**: FAQs and `math-finals-practice-interest` updated (single interest type).
- **SEO**: Shared `MATH_FINALS_PRACTICE_SESSION_DESCRIPTION`; Service schema and page metadata/thank-you copy.
- **Nav**: Header fallback + mock API strings for Math Finals Prep.

## Testing
- `npm test` (Jest): 18 suites, 185 tests passed.

## Notes
- If Brevo automations depend on exact `MATH_INTEREST_KEY` / label strings, verify workflows after deploy.

Made with [Cursor](https://cursor.com)