### PR TITLE
ci: add nightly tests, PR gate, and Amplify prod deploy workflows

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,54 @@
+# Branch Protection Rules — `main`
+
+Configure under **Settings → Branches → Add rule → Branch name pattern: `main`**.
+
+## Required settings
+
+| Setting | Value |
+|---|---|
+| Require a pull request before merging | ✅ Enabled |
+| → Required approvals | 1 |
+| → Dismiss stale reviews when new commits are pushed | ✅ Enabled |
+| Require status checks to pass before merging | ✅ Enabled |
+| → Require branches to be up to date before merging | ✅ Enabled |
+| Require conversation resolution before merging | ✅ Enabled |
+| Do not allow bypassing the above settings | ✅ Enabled (even for admins) |
+
+## Required status check
+
+Add this check name exactly as shown (matches the `name:` field in `pr-gate.yml`):
+
+```
+Frontend — Jest + Playwright
+```
+
+> This check only appears in the selector after the first PR has run against `main`.
+
+## How the gate works
+
+1. Developer opens a PR from `dev` → `main`.
+2. `pr-gate.yml` runs Jest + Playwright automatically.
+3. If either fails, GitHub blocks the merge.
+4. After merge, `deploy.yml` triggers the Amplify prod deployment.
+
+## AWS Amplify branch configuration
+
+In the Amplify console (**App settings → General → Branches**):
+
+- **Production branch (`main`):** disable "Auto-build" so only the `deploy.yml` workflow triggers deploys — prevents double deployments on push.
+- **Staging branch (`dev`):** enable auto-build so every push to `dev` deploys to the staging Amplify environment automatically.
+- Set `NEXT_PUBLIC_API_BASE` as an Amplify environment variable:
+  - `main` → production API URL
+  - `dev` → value of `STAGING_API_URL`
+
+## Required GitHub secrets
+
+Add under **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | Already exists |
+| `AWS_SECRET_ACCESS_KEY` | Already exists |
+| `AMPLIFY_APP_ID` | Amplify app ID — last segment of the App ARN in Amplify console |
+| `STAGING_API_URL` | Dev backend URL — used during PR gate builds and nightly tests |
+| `GH_TOKEN` | GitHub PAT with `repo` scope — for auto-creating issues on nightly failure |

--- a/.github/CICD_RUNBOOK.md
+++ b/.github/CICD_RUNBOOK.md
@@ -1,0 +1,169 @@
+# CI/CD Runbook — GrowWise Frontend
+
+A plain-English guide to how the pipeline works, where to add keys, and how to debug failures.
+
+---
+
+## What the pipeline does (plain English)
+
+```
+You push code to dev
+        │
+        ▼
+Amplify auto-builds staging  ◄── you can preview the site here
+        │
+        ▼
+You open a PR  dev → main
+        │
+        ▼
+GitHub Actions runs tests automatically (pr-gate.yml)
+  ├── Jest unit tests
+  └── Playwright E2E tests
+        │
+   pass? ──► merge is allowed
+   fail? ──► merge is BLOCKED until fixed
+        │
+        ▼
+You merge the PR
+        │
+        ▼
+GitHub Actions deploys to production (deploy.yml)
+  └── Triggers Amplify prod build
+        │
+        ▼
+Every night at 02:15 UTC (nightly-frontend.yml)
+  ├── Jest
+  ├── Playwright E2E against staging
+  └── Lighthouse performance smoke
+       └── If anything fails → GitHub issue auto-created
+```
+
+---
+
+## Where to add tokens and keys
+
+**All secrets live in one place:**
+
+> `github.com/thegrowwise/growwise_newui`  
+> → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
+
+### Secrets to add right now (pipeline won't work without these)
+
+| Secret name | What it is | Where to get it |
+|---|---|---|
+| `STAGING_API_URL` | The URL of your dev/staging backend (e.g. `https://dev.api.growwiseschool.org`) | Your AWS Elastic Beanstalk dev environment URL, or the Lambda dev endpoint |
+| `AMPLIFY_APP_ID` | Your Amplify app's ID | AWS Console → Amplify → your app → **App settings** → **General** → copy the value after the last `/` in the App ARN (looks like `d1abc2defg`) |
+| `GH_TOKEN` | GitHub Personal Access Token | GitHub → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens** → New token → give it `repo` read/write for Issues |
+
+### Secrets already configured (no action needed)
+
+| Secret name | Used by |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | Amplify prod deploy |
+| `AWS_SECRET_ACCESS_KEY` | Amplify prod deploy |
+
+---
+
+## How to add a secret (step by step)
+
+1. Go to `github.com/thegrowwise/growwise_newui`
+2. Click **Settings** (top menu of the repo)
+3. Left sidebar → **Secrets and variables** → **Actions**
+4. Click **New repository secret**
+5. Paste the secret name exactly as shown in the table above (case-sensitive)
+6. Paste the value
+7. Click **Add secret**
+
+> Never put secrets in code files or `.env` files that get committed. GitHub secrets are encrypted and only exposed to workflows at run time.
+
+---
+
+## How to manually trigger a workflow (no waiting until 2am)
+
+1. Go to `github.com/thegrowwise/growwise_newui/actions`
+2. Click **Nightly Tests — Frontend** in the left list
+3. Click **Run workflow** (top right)
+4. Leave branch as `dev` → click **Run workflow**
+
+Use this to verify the pipeline works before relying on the nightly schedule.
+
+---
+
+## How to set up branch protection on `main`
+
+Do this once after merging PR #227 into `dev`.
+
+1. Go to `github.com/thegrowwise/growwise_newui` → **Settings** → **Branches**
+2. Click **Add branch ruleset** (or **Add rule** on older GitHub UI)
+3. Branch name pattern: `main`
+4. Enable these settings:
+   - ✅ Require a pull request before merging (1 approval)
+   - ✅ Dismiss stale reviews when new commits are pushed
+   - ✅ Require status checks to pass before merging
+   - ✅ Require branches to be up to date before merging
+   - ✅ Require conversation resolution before merging
+   - ✅ Do not allow bypassing (even for admins)
+5. Under **Required status checks** → search for and add:
+   ```
+   Frontend — Jest + Playwright
+   ```
+   > This only appears after the first PR has run the `pr-gate.yml` workflow.
+
+---
+
+## How to set up Amplify environments
+
+In **AWS Console → Amplify → your app**:
+
+| Branch | Auto-build | `NEXT_PUBLIC_API_BASE` value |
+|---|---|---|
+| `dev` | ✅ On | Your staging backend URL |
+| `main` | ❌ Off | Your production API URL |
+
+Turn off auto-build on `main` so only the `deploy.yml` workflow triggers prod deployments — otherwise every push fires two deploys.
+
+---
+
+## Debugging a failed workflow run
+
+1. Go to `github.com/thegrowwise/growwise_newui/actions`
+2. Click the failed run (red ✗)
+3. Click the failed job name
+4. Expand the failed step — the error is printed there
+
+### Common failures and fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `secret not found` or build uses wrong URL | `STAGING_API_URL` not set | Add the secret (see above) |
+| Jest passes, Playwright fails | Server didn't start in time | Check if `npm run start` output shows an error in the logs |
+| Amplify deploy step fails | `AMPLIFY_APP_ID` wrong or IAM permissions missing | Verify the App ID in Amplify console; ensure the AWS key has `amplify:StartJob` permission |
+| Nightly issue not created | `GH_TOKEN` not set or missing `repo` scope | Recreate the token with `repo` scope |
+| Lighthouse step fails | `perf:ci` script missing or Chrome install failed | Check `package.json` has a `perf:ci` script |
+
+---
+
+## Day-to-day workflow for the team
+
+```
+1. Create a feature branch from dev
+2. Make changes, test locally (npm test + npm run test:e2e)
+3. Push branch → open PR into dev
+4. Merge into dev → staging auto-deploys via Amplify
+5. When ready to ship → open PR from dev → main
+6. PR gate runs automatically — fix anything red
+7. Get 1 approval → merge
+8. deploy.yml fires → production updates automatically
+```
+
+---
+
+## File reference
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/pr-gate.yml` | Blocks merge to main if tests fail |
+| `.github/workflows/nightly-frontend.yml` | Nightly test run against staging |
+| `.github/workflows/deploy.yml` | Triggers Amplify prod deploy on merge to main |
+| `.github/BRANCH_PROTECTION.md` | Branch protection settings reference |
+| `.github/CICD_RUNBOOK.md` | This file |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Production Deploy — Frontend
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-frontend-prod:
+    name: Deploy Frontend — Amplify (prod)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Trigger Amplify production deployment
+        run: |
+          JOB=$(aws amplify start-job \
+            --app-id "${{ secrets.AMPLIFY_APP_ID }}" \
+            --branch-name main \
+            --job-type RELEASE \
+            --query 'jobSummary.jobId' \
+            --output text)
+          echo "Amplify job started: $JOB"
+
+          while true; do
+            STATUS=$(aws amplify get-job \
+              --app-id "${{ secrets.AMPLIFY_APP_ID }}" \
+              --branch-name main \
+              --job-id "$JOB" \
+              --query 'job.summary.status' \
+              --output text)
+            echo "Status: $STATUS"
+            if [[ "$STATUS" == "SUCCEED" ]]; then
+              echo "Deployment succeeded."
+              break
+            elif [[ "$STATUS" == "FAILED" || "$STATUS" == "CANCELLED" ]]; then
+              echo "Deployment failed: $STATUS"
+              exit 1
+            fi
+            sleep 30
+          done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,41 +6,11 @@ on:
 
 jobs:
   deploy-frontend-prod:
-    name: Deploy Frontend — Amplify (prod)
+    name: Deploy Frontend — Vercel (prod)
     runs-on: ubuntu-latest
 
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Trigger Amplify production deployment
+      - name: Trigger Vercel production deployment
         run: |
-          JOB=$(aws amplify start-job \
-            --app-id "${{ secrets.AMPLIFY_APP_ID }}" \
-            --branch-name main \
-            --job-type RELEASE \
-            --query 'jobSummary.jobId' \
-            --output text)
-          echo "Amplify job started: $JOB"
-
-          while true; do
-            STATUS=$(aws amplify get-job \
-              --app-id "${{ secrets.AMPLIFY_APP_ID }}" \
-              --branch-name main \
-              --job-id "$JOB" \
-              --query 'job.summary.status' \
-              --output text)
-            echo "Status: $STATUS"
-            if [[ "$STATUS" == "SUCCEED" ]]; then
-              echo "Deployment succeeded."
-              break
-            elif [[ "$STATUS" == "FAILED" || "$STATUS" == "CANCELLED" ]]; then
-              echo "Deployment failed: $STATUS"
-              exit 1
-            fi
-            sleep 30
-          done
+          curl -s -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_PROD }}"
+          echo "Vercel production deployment triggered."

--- a/.github/workflows/nightly-frontend.yml
+++ b/.github/workflows/nightly-frontend.yml
@@ -1,0 +1,102 @@
+name: Nightly Tests — Frontend
+
+on:
+  schedule:
+    - cron: '15 2 * * *'  # 02:15 UTC daily
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Jest + Playwright + Lighthouse against staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js
+        env:
+          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
+        run: npm run build
+
+      - name: Run Jest
+        env:
+          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
+          CI: true
+        run: npm run test:ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Next.js server
+        env:
+          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
+          PORT: 3000
+        run: npm run start &
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run Playwright E2E
+        env:
+          E2E_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_WORKERS: '2'
+          CI: true
+        run: npx playwright test --project=chromium
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-nightly
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Install Chrome for Lighthouse
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Run Lighthouse smoke
+        env:
+          LIGHTHOUSE_TARGET_URL: http://localhost:3000
+        run: npm run perf:ci
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report-nightly
+          path: performance-testing/results/
+          retention-days: 7
+
+  open-issue-on-failure:
+    name: Open GitHub issue on failure
+    needs: test
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          DATE=$(date -u '+%Y-%m-%d')
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue create \
+            --title "Nightly frontend tests failed — ${DATE}" \
+            --body "## Nightly frontend test failure
+
+          **Date:** ${DATE}
+          **Run:** [View logs](${RUN_URL})
+          **API:** \`STAGING_API_URL\`
+
+          One or more of Jest / Playwright / Lighthouse smoke tests failed." \
+            --label "bug,ci-failure" \
+            --repo ${{ github.repository }}

--- a/.github/workflows/nightly-frontend.yml
+++ b/.github/workflows/nightly-frontend.yml
@@ -22,13 +22,10 @@ jobs:
         run: npm ci
 
       - name: Build Next.js
-        env:
-          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
         run: npm run build
 
       - name: Run Jest
         env:
-          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
           CI: true
         run: npm run test:ci
 
@@ -37,7 +34,6 @@ jobs:
 
       - name: Start Next.js server
         env:
-          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
           PORT: 3000
         run: npm run start &
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,59 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-frontend:
+    name: Frontend — Jest + Playwright
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js
+        env:
+          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
+        run: npm run build
+
+      - name: Run Jest
+        env:
+          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
+          CI: true
+        run: npm run test:ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Next.js server
+        env:
+          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
+          PORT: 3000
+        run: npm run start &
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run Playwright E2E
+        env:
+          E2E_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_WORKERS: '2'
+          CI: true
+        run: npx playwright test --project=chromium
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-pr-${{ github.event.pull_request.number }}
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -21,13 +21,10 @@ jobs:
         run: npm ci
 
       - name: Build Next.js
-        env:
-          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
         run: npm run build
 
       - name: Run Jest
         env:
-          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
           CI: true
         run: npm run test:ci
 
@@ -36,7 +33,6 @@ jobs:
 
       - name: Start Next.js server
         env:
-          NEXT_PUBLIC_API_BASE: ${{ secrets.STAGING_API_URL }}
           PORT: 3000
         run: npm run start &
 


### PR DESCRIPTION
## Summary

- **`nightly-frontend.yml`** — runs Jest + Playwright + Lighthouse at 02:15 UTC daily against staging; auto-creates a GitHub issue on failure
- **`pr-gate.yml`** — blocks merge to `main` if Jest or Playwright fails on any PR from `dev`
- **`deploy.yml`** — triggers AWS Amplify prod deployment on push to `main`
- **`BRANCH_PROTECTION.md`** — documents required branch protection settings and secrets to configure

## Secrets needed before workflows run

Add these in **Settings → Secrets and variables → Actions**:

| Secret | Purpose |
|---|---|
| `AMPLIFY_APP_ID` | Amplify app ID for prod deploy |
| `STAGING_API_URL` | Dev backend URL for PR gate builds + nightly tests |
| `GH_TOKEN` | GitHub PAT (`repo` scope) for auto-creating issues on nightly failure |

`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` already exist.

## Test plan

- [ ] Merge this PR into `dev`, then open a test PR from `dev` → `main` and confirm `Frontend — Jest + Playwright` status check appears and passes
- [ ] Trigger nightly workflow manually: Actions → Nightly Tests — Frontend → Run workflow
- [ ] Set up branch protection on `main` per `BRANCH_PROTECTION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)