### PR TITLE
SEO: Fix sitemap XML routing, summer hero copy, llms.txt

### DIFF
--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,33 @@
+/** Plain-text crawl hints for LLMs — fixed host URLs per product spec. */
+
+const BODY = `# GrowWise School
+
+> K-12 tutoring and STEAM enrichment in Dublin, CA. Math, English, coding, AI, robotics, SAT prep, and summer camps for Grades 1–12 in the Tri-Valley.
+
+## Programs
+- [Academic (Math & English)](https://www.growwiseschool.org/academic)
+- [STEAM (Coding, AI, Game Dev)](https://www.growwiseschool.org/steam)
+- [Summer Camps](https://www.growwiseschool.org/camps/summer)
+- [SAT Prep](https://www.growwiseschool.org/courses/sat-prep)
+- [Workshops](https://www.growwiseschool.org/workshop-calendar)
+
+## Info
+- [About](https://www.growwiseschool.org/about)
+- [Contact](https://www.growwiseschool.org/contact)
+- [Blog](https://www.growwiseschool.org/growwise-blogs)
+
+Location: 4564 Dublin Blvd, Dublin, CA 94568
+Phone: (925) 456-4606
+Serving: Dublin, Pleasanton, San Ramon, Livermore
+`
+
+export async function GET(): Promise<Response> {
+  return new Response(BODY, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/i18n/messages/summer-camp-canonical-en.json
+++ b/src/i18n/messages/summer-camp-canonical-en.json
@@ -1,7 +1,7 @@
 {
   "hero": {
-    "h1": "This summer, your child builds something real.",
-    "subhead": "Coding, AI, Robotics, Game Dev & Math Camps · Grades 1–12 · Dublin CA · Limited seats",
+    "h1": "Summer STEAM Camps in Dublin, CA",
+    "subhead": "This summer, your child builds something real. Coding, AI, Robotics & Math · Grades 1–12 · Limited seats",
     "primaryCta": "Reserve a Spot →",
     "secondaryCta": "Get Camp Guide →",
     "brochurePdf": "/assets/camps/SummerCampBrochure.pdf",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,6 +47,15 @@ function rewriteLocalePrefixedNextAssets(request: NextRequest): NextResponse | n
   return NextResponse.rewrite(url);
 }
 
+/** Sitemaps, robots, and llms.txt must bypass next-intl so Route Handlers return XML/plain text, not HTML. */
+const SEO_ROUTES_BYPASS_INTL = new Set([
+  '/sitemap.xml',
+  '/sitemap-pages.xml',
+  '/sitemap-blogs.xml',
+  '/robots.txt',
+  '/llms.txt',
+]);
+
 /**
  * With `src/app`, Next.js expects middleware beside `src/app` (`src/middleware.ts`).
  * A root-level `middleware.ts` can be ignored in some setups, which makes `/` 404
@@ -54,6 +63,9 @@ function rewriteLocalePrefixedNextAssets(request: NextRequest): NextResponse | n
  */
 export default function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+  if (SEO_ROUTES_BYPASS_INTL.has(pathname)) {
+    return NextResponse.next();
+  }
   // Non-localized App Router segments (`app/camp/...` at repo root). Running next-intl on these
   // can fight with `[locale]/camp/[slug]` and caused redirect loops to the same URL.
   if (pathname === '/camp' || pathname.startsWith('/camp/')) {
@@ -70,6 +82,6 @@ export default function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     '/',
-    '/((?!api|_next|_vercel|.*\\..*).*)',
+    '/((?!api|_next|_vercel|sitemap\\.xml|sitemap-pages\\.xml|sitemap-blogs\\.xml|robots\\.txt|llms\\.txt|.*\\..*).*)',
   ],
 };


### PR DESCRIPTION
## Summary
- **Middleware:** Bypass next-intl for `/sitemap.xml`, `/sitemap-pages.xml`, `/sitemap-blogs.xml`, `/robots.txt`, and `/llms.txt` so route handlers return XML/plain text instead of HTML; tighten matcher exclusions.
- **Summer camp hero:** Update `summer-camp-canonical-en.json` only (H1 + subtitle swap). No metadata/schema changes.
- **New route:** `GET /llms.txt` with `text/plain; charset=utf-8` and fixed crawl hints content.

## Verify
- `curl -sI` on sitemap URLs → `application/xml`
- `/camps/summer` hero shows new H1 + subtitle
- `/llms.txt` → plain text

Resolved middleware cherry-pick against `main`: kept `main`'s middleware shape (no implicit locale rewrite from other branches).

Made with [Cursor](https://cursor.com)