### PR TITLE
feat(seo): internal linking — course cross-links, camp year-round, self-check CTA

### DIFF
--- a/src/app/[locale]/book-assessment/page.tsx
+++ b/src/app/[locale]/book-assessment/page.tsx
@@ -22,6 +22,7 @@ import { BookOpen, BookMarked, CheckCircle, Clock, Users, Award, TrendingUp, Bra
 import CountryCodeSelector from '@/components/CountryCodeSelector';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { PHONE_PLACEHOLDER, CONTACT_INFO } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import { validatePhoneWithCountryCode, getPhonePlaceholder, getCallingCode, DIAL_CODE_TO_ISO2 } from '@/lib/phoneValidation';

--- a/src/app/[locale]/book-assessment/page.tsx
+++ b/src/app/[locale]/book-assessment/page.tsx
@@ -875,6 +875,33 @@ export default function BookAssessmentPage() {
         </div>
       </section>
 
+      {/* Browse programs — visible before and after form submission */}
+      <section className="py-12 px-4 bg-slate-50 border-t border-slate-200">
+        <div className="max-w-4xl mx-auto">
+          <h3 className="text-lg sm:text-xl font-bold text-[#1F396D] mb-5 text-center">
+            Want to explore programs first?
+          </h3>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {[
+              { href: publicPath('/courses/math', locale), label: 'K–12 Math Tutoring' },
+              { href: publicPath('/courses/high-school-math', locale), label: 'High School Math Tutoring' },
+              { href: publicPath('/courses/sat-prep', locale), label: 'SAT Prep Tutoring' },
+              { href: publicPath('/camps/summer', locale), label: 'Summer STEAM Camps 2026' },
+            ].map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="flex items-center gap-2 p-4 rounded-xl border-2 border-[#1F396D]/20 bg-white hover:border-[#F16112] hover:shadow-md transition-all text-[#1F396D] font-semibold text-sm sm:text-base"
+                >
+                  <span className="text-[#F16112]">→</span>
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
       <section className="py-24 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">

--- a/src/app/[locale]/camps/summer/page.tsx
+++ b/src/app/[locale]/camps/summer/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import type { SummerCampFaqItem } from './SummerCampPageFaq';
 import { fetchSummerCampData, getDefaultSummerCampData, type Program, type OlympiadTierConfig } from '@/lib/summer-camp-data';
 import { createLocaleUrl } from '@/components/layout/Header/utils';
+import { publicPath } from '@/lib/publicPath';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import {
@@ -963,6 +964,66 @@ export default function SummerCampPage() {
         {faqMount ? (
           <SummerCampPageFaq faqs={faqs} loading={faqsLoading} />
         ) : null}
+
+        {/* Year-round programs — internal linking */}
+        <section className="py-14 px-4 bg-slate-50 border-t border-slate-200">
+          <div className="max-w-4xl mx-auto">
+            <h3 className="text-xl sm:text-2xl font-bold text-[#1F396D] mb-3">
+              Keep the momentum going after summer
+            </h3>
+            <p className="text-gray-600 mb-6">
+              Summer camps run June–August. For year-round support, GrowWise offers
+              small-group tutoring and test prep throughout the school year.
+            </p>
+            <ul className="space-y-3 mb-6">
+              <li className="flex items-start gap-2">
+                <span className="text-[#F16112] font-bold mt-0.5">→</span>
+                <span>
+                  <Link
+                    href={publicPath('/courses/math', locale)}
+                    className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+                  >
+                    K–12 Math Tutoring
+                  </Link>
+                  {' '}— Grades 1–12, ongoing enrollment
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-[#F16112] font-bold mt-0.5">→</span>
+                <span>
+                  <Link
+                    href={publicPath('/courses/sat-prep', locale)}
+                    className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+                  >
+                    SAT Prep Tutoring
+                  </Link>
+                  {' '}— Start 3–6 months before test date
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-[#F16112] font-bold mt-0.5">→</span>
+                <span>
+                  <Link
+                    href={publicPath('/courses/high-school-math', locale)}
+                    className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+                  >
+                    High School Math Tutoring
+                  </Link>
+                  {' '}— Algebra through AP
+                </span>
+              </li>
+            </ul>
+            <p className="text-gray-600">
+              <Link
+                href={publicPath('/book-assessment', locale)}
+                className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+              >
+                Book a free assessment
+              </Link>
+              {' '}to find the right program.
+            </p>
+          </div>
+        </section>
       </main>
 
       <SummerCampGuideLeadDialog

--- a/src/app/[locale]/courses/math/page.tsx
+++ b/src/app/[locale]/courses/math/page.tsx
@@ -473,6 +473,20 @@ const MathCoursesPage: React.FC = () => {
         </div>
       </section>
 
+      {/* Assessment CTA Banner */}
+      <div className="bg-amber-50 border-y border-amber-200 py-4 px-4 lg:px-8">
+        <p className="text-center text-sm sm:text-base text-amber-900 max-w-3xl mx-auto">
+          Not sure which program fits your child?{' '}
+          <Link
+            href={publicPath('/book-assessment', locale)}
+            className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+          >
+            Get a free academic assessment
+          </Link>
+          {' '}— we'll identify the right level and track before your first session.
+        </p>
+      </div>
+
       {/* Math Courses Section with New Chip Filters */}
       <section id="courses" className="py-16 px-4 lg:px-8" style={{
         background: `

--- a/src/app/[locale]/courses/math/page.tsx
+++ b/src/app/[locale]/courses/math/page.tsx
@@ -54,13 +54,7 @@ const FreeAssessmentModal = dynamic(
   }
 );
 
-const RelatedContent = dynamic(
-  () => import('@/components/seo/RelatedContent').then((m) => m.RelatedContent),
-  {
-    ssr: false,
-    loading: () => null,
-  }
-);
+import { RelatedContent } from '@/components/seo/RelatedContent';
 
 const CourseFAQ = dynamic(
   () => import('@/components/seo/CourseFAQ').then((m) => m.CourseFAQ),

--- a/src/app/[locale]/growwise-blogs/how-to-identify-learning-gaps-in-your-childs-education-at-home-parent-guide/page.tsx
+++ b/src/app/[locale]/growwise-blogs/how-to-identify-learning-gaps-in-your-childs-education-at-home-parent-guide/page.tsx
@@ -489,8 +489,12 @@ export default async function BlogPostPage({ params }: { params: Promise<{ local
                 Found a gap? Close it fast.{' '}
                 <Link href={publicPath('/courses/math', locale)} className="text-[#1F396D] font-semibold underline hover:text-[#F16112]">
                   Math tutoring for Grades 1–12
+                </Link>
+                {', '}
+                <Link href={publicPath('/courses/high-school-math', locale)} className="text-[#1F396D] font-semibold underline hover:text-[#F16112]">
+                  our High School Math Tutoring program
                 </Link>{' '}
-                and{' '}
+                (Algebra 1/2, AP Precalculus, and Integrated Math), and{' '}
                 <Link href={publicPath('/courses/english', locale)} className="text-[#1F396D] font-semibold underline hover:text-[#F16112]">
                   English &amp; ELA tutoring
                 </Link>{' '}

--- a/src/app/[locale]/growwise-blogs/unlocking-confidence-independence-and-fun-through-summer-camp/page.tsx
+++ b/src/app/[locale]/growwise-blogs/unlocking-confidence-independence-and-fun-through-summer-camp/page.tsx
@@ -321,9 +321,9 @@ export default async function BlogPostPage({ params }: { params: Promise<{ local
                 <p className="mb-6">
                   Explore GrowWise Summer Camp programs designed to build confidence, independence, and essential life skills while having fun!
                 </p>
-                <Link href="/camps/winter">
+                <Link href={publicPath('/camps/summer', locale)}>
                   <Button className="bg-white text-[#1F396D] hover:bg-gray-100 text-lg px-8 py-6">
-                    Explore Summer Camps
+                    Summer STEAM Camps 2026
                   </Button>
                 </Link>
               </div>

--- a/src/app/[locale]/growwise-blogs/us-kids-falling-behind-math-english-parent-assessments/page.tsx
+++ b/src/app/[locale]/growwise-blogs/us-kids-falling-behind-math-english-parent-assessments/page.tsx
@@ -527,8 +527,12 @@ export default async function BlogPostPage({ params }: { params: Promise<{ local
                 Don&apos;t let your child fall further behind.{' '}
                 <Link href={publicPath('/courses/math', locale)} className="text-[#1F396D] font-semibold underline hover:text-[#F16112]">
                   Math tutoring for Grades 1–12
+                </Link>
+                {', '}
+                <Link href={publicPath('/courses/high-school-math', locale)} className="text-[#1F396D] font-semibold underline hover:text-[#F16112]">
+                  our High School Math Tutoring program
                 </Link>{' '}
-                and{' '}
+                (Algebra, AP Precalculus, and Integrated Math), and{' '}
                 <Link href={publicPath('/courses/english', locale)} className="text-[#1F396D] font-semibold underline hover:text-[#F16112]">
                   English &amp; ELA tutoring
                 </Link>{' '}

--- a/src/app/[locale]/self-check/done/page.tsx
+++ b/src/app/[locale]/self-check/done/page.tsx
@@ -55,6 +55,28 @@ export default function SelfCheckDonePage() {
           </CardContent>
         </Card>
 
+        {/* 6-week plan CTA */}
+        <Card className="border-[#1F396D]/30 bg-[#1F396D]/[0.04]">
+          <CardContent className="p-6 space-y-3 text-center">
+            <p className="font-bold text-[#1F396D] text-lg">
+              We&#39;ve identified the pattern. Now let&#39;s fix it.
+            </p>
+            <p className="text-sm text-gray-600">
+              Based on your results, a GrowWise instructor will put together a
+              6-week personalized plan targeting exactly what&#39;s holding your child back.
+            </p>
+            <a
+              href={process.env.NEXT_PUBLIC_WORKSHOP_CALENDLY_URL ?? process.env.NEXT_PUBLIC_WORKSHOP_BOOKING_URL ?? 'https://calendly.com/growwise/workshop'}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 bg-[#1F396D] hover:bg-[#183056] text-white font-bold px-8 py-3 rounded-xl text-sm transition-colors shadow-md w-full sm:w-auto"
+            >
+              Get Your 6-Week Personalized Plan →
+            </a>
+            <p className="text-xs text-gray-500">Free. Pick a time that works for you.</p>
+          </CardContent>
+        </Card>
+
         {/* Footer links */}
         <div className="flex flex-col items-center gap-3 pt-2">
           <a

--- a/src/app/[locale]/self-check/layout.tsx
+++ b/src/app/[locale]/self-check/layout.tsx
@@ -14,9 +14,9 @@ export async function generateMetadata({
   const meta = generateMetadataFromPath('/self-check', locale);
   return (
     meta ?? {
-      title: 'Free Math Self-Check for Kids Grades 3–8 | GrowWise School',
+      title: 'Academic Self-Check for Students | GrowWise Dublin CA',
       description:
-        'Find out why your child keeps making the same math mistakes. Free 8-question quiz identifies the exact mistake pattern. Report emailed in minutes. No sign-up. Grades 3–8. Dublin, CA.',
+        'Answer 8 questions to find out where you stand in math or English. Get a clear picture of your strengths and the gaps holding you back — in under 10 minutes.',
       keywords: [
         'math self-check',
         'free math diagnostic',
@@ -60,7 +60,7 @@ export default async function SelfCheckLayout({
         '@type': 'WebPage',
         '@id': `${pageUrl}`,
         url: pageUrl,
-        name: 'Free Math Self-Check for Kids Grades 3–8 | GrowWise School',
+        name: 'Academic Self-Check for Students | GrowWise Dublin CA',
         description:
           'Find out why your child keeps making the same math mistakes. Free 8-question self-check identifies the exact mistake pattern. Report emailed in minutes. No sign-up required.',
         inLanguage: 'en-US',

--- a/src/components/HighSchoolMathPage.tsx
+++ b/src/components/HighSchoolMathPage.tsx
@@ -390,6 +390,20 @@ const HighSchoolMathPage: React.FC = () => {
         </div>
       </section>
 
+      {/* Assessment CTA Banner */}
+      <div className="bg-amber-50 border-y border-amber-200 py-4 px-4 lg:px-8">
+        <p className="text-center text-sm sm:text-base text-amber-900 max-w-3xl mx-auto">
+          Not sure which program fits your child?{' '}
+          <Link
+            href={publicPath('/book-assessment', locale)}
+            className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+          >
+            Get a free academic assessment
+          </Link>
+          {' '}— we'll identify the right level and track before your first session.
+        </p>
+      </div>
+
       {/* High School Math Courses Section */}
       <section id="courses" className="py-16 px-4 lg:px-8" style={{
         background: `

--- a/src/components/SATPage.tsx
+++ b/src/components/SATPage.tsx
@@ -293,6 +293,20 @@ const SATPage: React.FC = () => {
         </div>
       </section>
 
+      {/* Assessment CTA Banner */}
+      <div className="bg-amber-50 border-y border-amber-200 py-4 px-4 lg:px-8">
+        <p className="text-center text-sm sm:text-base text-amber-900 max-w-3xl mx-auto">
+          Not sure which program fits your child?{' '}
+          <Link
+            href={publicPath('/book-assessment', locale)}
+            className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+          >
+            Get a free academic assessment
+          </Link>
+          {' '}— we'll identify the right level and track before your first session.
+        </p>
+      </div>
+
       {/* SAT Courses Section - Matching English Courses Style */}
       <section className="py-16 px-4 lg:px-8" style={{
         background: `

--- a/src/data/form-thank-you/en.json
+++ b/src/data/form-thank-you/en.json
@@ -1,21 +1,22 @@
 {
   "book-assessment": {
-    "version": 1,
+    "version": 2,
     "metaTitle": "Assessment request received | GrowWise",
     "metaDescription": "Thank you — we received your free assessment booking. Our team will contact you within 24 hours to confirm your appointment.",
-    "title": "Thank you for your request",
+    "title": "You're booked. We'll be in touch within 1 business day.",
     "kicker": "Submission completed successfully.",
     "body": [
-      "We've received your free assessment booking request. Our team will contact you within 24 hours to confirm your appointment."
+      "We've received your free assessment booking request. Our team will contact you within 24 hours to confirm your appointment.",
+      "In the meantime, explore what your child will be working toward:"
     ],
     "highlights": [
       { "text": "24-hour response guaranteed" },
       { "text": "Your data is secure" },
       { "text": "Welcome to GrowWise!" }
     ],
-    "primaryCta": { "label": "Book another assessment", "path": "/book-assessment" },
-    "secondaryCta": { "label": "Explore programs", "path": "/programs" },
-    "backLink": { "label": "Back to home", "path": "/" }
+    "primaryCta": { "label": "K–12 Math Tutoring", "path": "/courses/math" },
+    "secondaryCta": { "label": "High School Math Tutoring", "path": "/courses/high-school-math" },
+    "backLink": { "label": "Back to assessment", "path": "/book-assessment" }
   },
   "enroll": {
     "version": 1,

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -166,9 +166,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/self-check': {
-    title: 'Free Math Self-Check for Kids Grades 3–8 | GrowWise School',
+    title: 'Academic Self-Check for Students | GrowWise Dublin CA',
     description:
-      'Find out why your child keeps making the same math mistakes. Free 8-question quiz identifies the exact mistake pattern. Report emailed in minutes. No sign-up. Grades 3–8. Dublin, CA.',
+      'Answer 8 questions to find out where you stand in math or English. Get a clear picture of your strengths and the gaps holding you back — in under 10 minutes.',
     keywords:
       'math self-check, free math diagnostic, math mistake patterns, math tutoring Dublin CA, child math assessment, math gap finder, GrowWise School',
     path: '/self-check',


### PR DESCRIPTION
## Summary

- **Fix 1b** — Summer camp blog (`unlocking-confidence`): button destination corrected from `/camps/winter` → `/camps/summer`, text updated to "Summer STEAM Camps 2026"
- **Fix 3** — Assessment CTA banner added immediately below the hero section on `/courses/math`, `/courses/high-school-math`, and `/courses/sat-prep`
- **Fix 4** — Year-round programs section added to `/camps/summer` (links to math, SAT prep, HS math, and book-assessment)
- **Fix 5a** — Browse-programs grid (4 program cards) added to `/book-assessment` above testimonials — visible before and after form submission
- **Fix 5b** — Book-assessment thank-you page updated: title, body copy, and CTAs now link to specific course pages
- **Fix 6** — "6-week personalized plan" Calendly CTA card added to `/self-check/done` page using `NEXT_PUBLIC_WORKSHOP_CALENDLY_URL`
- **Meta** — `/self-check` title and description updated in `metadataConfig.ts` and `layout.tsx` fallback

## Test plan

- [ ] `/camps/summer` blog — "Summer STEAM Camps 2026" button links to `/camps/summer` not `/camps/winter`
- [ ] `/courses/sat-prep`, `/courses/high-school-math`, `/courses/math` — amber assessment CTA banner visible below hero
- [ ] `/camps/summer` page — "Keep the momentum going after summer" section visible near page bottom with 3 course links
- [ ] `/book-assessment` — 4-card program grid visible above "What Parents Are Saying"
- [ ] `/book-assessment/thank-you` — title shows "You're booked..." and CTAs link to course pages
- [ ] `/self-check/done` — navy card with "Get Your 6-Week Personalized Plan" button opens Calendly in new tab
- [ ] No linter errors on any changed file

Made with [Cursor](https://cursor.com)