### PR TITLE
fix(self-check): working Calendly link on done page

### DIFF
--- a/src/app/[locale]/self-check/done/page.tsx
+++ b/src/app/[locale]/self-check/done/page.tsx
@@ -2,8 +2,7 @@ import { ArrowLeft, CheckCircle2, Mail, Phone } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { CONTACT_INFO } from '@/lib/constants';
 
-// Live Calendly account (growwiseschool/workshop and growwise/workshop are 404)
-const BOOKING_URL = 'https://calendly.com/thegrowwise';
+const BOOKING_URL = 'https://calendly.com/connect-thegrowwise/new-meeting';
 
 export default function SelfCheckDonePage() {
   const phoneHref = `tel:+1${CONTACT_INFO.phone.replace(/\D/g, '')}`;

--- a/src/app/[locale]/self-check/done/page.tsx
+++ b/src/app/[locale]/self-check/done/page.tsx
@@ -2,7 +2,8 @@ import { ArrowLeft, CheckCircle2, Mail, Phone } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { CONTACT_INFO } from '@/lib/constants';
 
-const BOOKING_URL = 'https://calendly.com/thegrowwise/30min';
+// Same URL as report email CTA in quiz-completion.php
+const BOOKING_URL = 'https://calendly.com/growwiseschool/workshop';
 
 export default function SelfCheckDonePage() {
   const phoneHref = `tel:+1${CONTACT_INFO.phone.replace(/\D/g, '')}`;

--- a/src/app/[locale]/self-check/done/page.tsx
+++ b/src/app/[locale]/self-check/done/page.tsx
@@ -2,8 +2,8 @@ import { ArrowLeft, CheckCircle2, Mail, Phone } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { CONTACT_INFO } from '@/lib/constants';
 
-// Same URL as report email CTA in quiz-completion.php
-const BOOKING_URL = 'https://calendly.com/growwiseschool/workshop';
+// Live Calendly account (growwiseschool/workshop and growwise/workshop are 404)
+const BOOKING_URL = 'https://calendly.com/thegrowwise';
 
 export default function SelfCheckDonePage() {
   const phoneHref = `tel:+1${CONTACT_INFO.phone.replace(/\D/g, '')}`;

--- a/src/app/[locale]/self-check/done/page.tsx
+++ b/src/app/[locale]/self-check/done/page.tsx
@@ -2,8 +2,9 @@ import { ArrowLeft, CheckCircle2, Mail, Phone } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { CONTACT_INFO } from '@/lib/constants';
 
+const BOOKING_URL = 'https://calendly.com/thegrowwise/30min';
+
 export default function SelfCheckDonePage() {
-  const workshopUrl = process.env.NEXT_PUBLIC_WORKSHOP_BOOKING_URL ?? 'https://calendly.com/growwiseschool/workshop';
   const phoneHref = `tel:+1${CONTACT_INFO.phone.replace(/\D/g, '')}`;
 
   return (
@@ -45,7 +46,7 @@ export default function SelfCheckDonePage() {
               Book your free 1:1 Personalized Plan Preparation with a GrowWise teacher.
             </p>
             <a
-              href={workshopUrl}
+              href={BOOKING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-2 bg-[#F16112] hover:bg-[#d54f0a] text-white font-bold px-8 py-3 rounded-xl text-sm transition-colors shadow-md w-full sm:w-auto"
@@ -66,7 +67,7 @@ export default function SelfCheckDonePage() {
               6-week personalized plan targeting exactly what&#39;s holding your child back.
             </p>
             <a
-              href={process.env.NEXT_PUBLIC_WORKSHOP_CALENDLY_URL ?? process.env.NEXT_PUBLIC_WORKSHOP_BOOKING_URL ?? 'https://calendly.com/growwiseschool/workshop'}
+              href={BOOKING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-2 bg-[#1F396D] hover:bg-[#183056] text-white font-bold px-8 py-3 rounded-xl text-sm transition-colors shadow-md w-full sm:w-auto"


### PR DESCRIPTION
## Summary
- Fix broken booking CTAs on `/self-check/done` after quiz redirect
- Both buttons now link to the live Calendly event: `https://calendly.com/thegrowwise/30min`
- Hardcoded on this page only so production env vars (`growwise/workshop`, 404) cannot override

## Scope
- **One file:** `src/app/[locale]/self-check/done/page.tsx`
- No WordPress / PHP / report email changes

## Test plan
- [ ] Complete self-check quiz flow and land on `/self-check/done`
- [ ] Click **Book Free 1:1 Plan Preparation** → Calendly loads (not 404)
- [ ] Click **Get Your 6-Week Personalized Plan** → same Calendly page loads


Made with [Cursor](https://cursor.com)