### PR TITLE
Academic summer programs hub + sticky pricing panel fix

### DIFF
--- a/src/components/camps/AcademicEnrollmentPanel.tsx
+++ b/src/components/camps/AcademicEnrollmentPanel.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
 const COPY = hubCopy.enrollmentPanel;
 
 const panelShellClass =
-  'bg-white rounded-[2rem] shadow-2xl border border-slate-100 overflow-hidden flex flex-col h-auto max-h-[calc(100vh-7rem)]';
+  'bg-white rounded-[2rem] shadow-2xl border border-slate-100 overflow-hidden flex flex-col h-full';
 
 function panelProgramForDisplay(program: Program): Program {
   if (program.id === 'algebra-1') {

--- a/src/components/camps/AcademicEnrollmentPanelScroll.tsx
+++ b/src/components/camps/AcademicEnrollmentPanelScroll.tsx
@@ -26,6 +26,9 @@ export function AcademicEnrollmentPanelScroll({
 
   useEffect(() => {
     hasScrolledRef.current = false;
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
     updateHint();
 
     const el = scrollRef.current;

--- a/src/components/camps/AcademicGetReadySlotsPanel.tsx
+++ b/src/components/camps/AcademicGetReadySlotsPanel.tsx
@@ -180,7 +180,7 @@ export function AcademicGetReadySlotsPanel({
       id="slots-panel"
       role="region"
       aria-label={program.title}
-      className="flex h-auto max-h-[calc(100vh-7rem)] flex-col overflow-hidden rounded-[2rem] border border-slate-100 bg-white shadow-2xl"
+      className="flex h-full flex-col overflow-hidden rounded-[2rem] border border-slate-100 bg-white shadow-2xl"
     >
       <AcademicMobileProgramSwitcher
         programs={programs}

--- a/src/components/camps/AcademicSprintSlotsPanel.tsx
+++ b/src/components/camps/AcademicSprintSlotsPanel.tsx
@@ -194,7 +194,7 @@ export function AcademicSprintSlotsPanel({
       id="slots-panel"
       role="region"
       aria-label={program.title}
-      className="flex h-auto max-h-[calc(100vh-7rem)] flex-col overflow-hidden rounded-[2rem] border border-slate-100 bg-white shadow-2xl"
+      className="flex h-full flex-col overflow-hidden rounded-[2rem] border border-slate-100 bg-white shadow-2xl"
     >
       <AcademicMobileProgramSwitcher
         programs={programs}

--- a/src/components/camps/AcademicSummerProgramsPage.tsx
+++ b/src/components/camps/AcademicSummerProgramsPage.tsx
@@ -66,14 +66,6 @@ function filterChipStyle(active: boolean) {
   return active ? FILTER_CHIP_STYLE.active : FILTER_CHIP_STYLE.inactive;
 }
 
-function scrollPanelToTop() {
-  const panel = document.getElementById('slots-panel');
-  const scrollRegion = panel?.querySelector('[data-academic-panel-scroll]');
-  if (scrollRegion instanceof HTMLElement) {
-    scrollRegion.scrollTop = 0;
-  }
-}
-
 function resolveProgramFromHash(hash: string): Program | null {
   const normalized = hash.replace(/^#/, '');
   if (!normalized.startsWith('track-')) return null;
@@ -124,6 +116,11 @@ export function AcademicSummerProgramsPage() {
       if (fromHash) {
         setProgramFilter('all');
         setSelectedProgram(fromHash);
+        if (typeof window !== 'undefined' && window.innerWidth < 1024) {
+          requestAnimationFrame(() => {
+            document.getElementById('slots-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          });
+        }
       }
     };
 
@@ -150,7 +147,6 @@ export function AcademicSummerProgramsPage() {
     setSelectedProgram(program);
     if (typeof window !== 'undefined') {
       window.history.replaceState(null, '', `#track-${program.id}`);
-      requestAnimationFrame(() => scrollPanelToTop());
       if (window.innerWidth < 1024) {
         document.getElementById('slots-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
@@ -177,7 +173,7 @@ export function AcademicSummerProgramsPage() {
         <section
           id="slots-section"
           ref={slotsSectionRef}
-          className="scroll-mt-24 relative box-border max-w-full overflow-x-hidden border-y border-slate-100 py-20"
+          className="scroll-mt-24 relative border-y border-slate-100 py-20"
           style={{
             background:
               'linear-gradient(135deg, #dbeafe 0%, #eff6ff 30%, #fff7ed 70%, #fed7aa 100%)',
@@ -193,8 +189,8 @@ export function AcademicSummerProgramsPage() {
           </div>
 
           <div className="container mx-auto px-4 md:px-6" style={{ position: 'relative', zIndex: 1 }}>
-            <div className="relative box-border grid w-full max-w-full items-start gap-8 max-sm:grid-cols-1 lg:grid-cols-12">
-              <div className="lg:col-span-7">
+            <div className="relative grid items-start gap-8 lg:grid-cols-12">
+              <div className="max-[768px]:overflow-x-hidden lg:col-span-7">
                 <div
                   className="mb-4 flex items-center justify-between gap-3 px-4 py-3 min-[769px]:hidden"
                   style={{
@@ -274,8 +270,15 @@ export function AcademicSummerProgramsPage() {
                 />
               </div>
 
-              {/* Right column: slots panel (sticky) — matches /camps/summer */}
-              <div className="lg:col-span-5 lg:sticky lg:top-24 lg:self-start lg:max-h-[calc(100vh-7rem)] max-[768px]:min-h-0">
+              {/* top/height: 13rem clears measured site header (172px @ 14px root); subtract bottom CTA when visible */}
+              <div
+                className={cn(
+                  'lg:col-span-5 lg:sticky lg:top-[13rem] max-[768px]:min-h-0',
+                  showStickyCta
+                    ? 'lg:h-[calc(100vh-13rem-5.5rem)]'
+                    : 'lg:h-[calc(100vh-13rem-1rem)]',
+                )}
+              >
                 <AcademicEnrollmentPanel
                   program={selectedProgram}
                   programs={PROGRAMS}

--- a/src/components/camps/academic-summer-programs-page.global.css
+++ b/src/components/camps/academic-summer-programs-page.global.css
@@ -1,5 +1,5 @@
 html:has([data-academic-summer-page]),
 body:has([data-academic-summer-page]) {
-  overflow-x: hidden;
   max-width: 100%;
+  overflow-x: clip;
 }

--- a/src/components/camps/academic-summer-programs-page.module.css
+++ b/src/components/camps/academic-summer-programs-page.module.css
@@ -1,19 +1,22 @@
 .pageRoot {
-  overflow-x: hidden;
   max-width: 100%;
   box-sizing: border-box;
 }
 
 .pageRoot main {
-  overflow-x: hidden;
   max-width: 100%;
   box-sizing: border-box;
 }
 
-.pageRoot main > section {
+/* :global(#slots-section) — CSS modules hash bare #ids in :not(), which would still apply overflow-x to #slots-section and break sticky panel + site header scroll */
+.pageRoot main > section:not(:global(#slots-section)) {
   max-width: 100%;
   box-sizing: border-box;
   overflow-x: hidden;
+}
+
+.pageRoot main > :global(#slots-section) {
+  overflow: visible;
 }
 
 @media (max-width: 639px) {


### PR DESCRIPTION
## Summary
- Adds the Academic Summer Programs hub page (`/camps/academic-summer-programs-dublin-ca`) with SEO, navigation, program cards, and enrollment panels.
- Fixes desktop sticky pricing panel behavior to match `/camps/summer`: panel stays pinned while browsing program cards, clears the site header, and no longer clips behind the bottom CTA bar on MacBook viewports.
- Resolves CSS Modules bug where `#slots-section` incorrectly received `overflow-x: hidden`, which broke sticky positioning.

## Sticky panel fixes (latest commit)
- Match summer camp click handler: desktop updates panel in place; mobile scrolls to `#slots-panel`.
- Exclude `#slots-section` from page overflow clipping using `:global(#slots-section)`.
- Size sticky wrapper with `top-[13rem]` and dynamic height that subtracts bottom CTA when visible.
- Panel shells use `h-full` so pricing rows scroll internally.

## Test plan
- [ ] Desktop (≥1024px): load `/camps/academic-summer-programs-dublin-ca`, confirm first program pre-selected and panel visible
- [ ] Desktop: scroll program cards — panel stays pinned below header, not clipped by bottom CTA
- [ ] Desktop: select Geometry Get Ready — all 3 cohort rows visible; panel does not cut off at bottom
- [ ] Mobile (<1024px): tap a program card — page scrolls to pricing panel below cards
- [ ] Compare sticky behavior with `/camps/summer` — should feel identical on desktop
- [ ] CI: academic summer e2e spec passes


Made with [Cursor](https://cursor.com)