### PR TITLE
Academic summer programs hub and four SEO landing pages

### DIFF
--- a/e2e/specs/academic-summer-programs.spec.ts
+++ b/e2e/specs/academic-summer-programs.spec.ts
@@ -24,7 +24,12 @@ test.describe('Academic summer programs hub', () => {
 
     await expect(
       page.locator('#program-grid').getByRole('link', {
-        name: 'Summer reading & writing program in Dublin, CA',
+        name: 'Read to Prove program details →',
+      }).first(),
+    ).toHaveAttribute('href', /\/camps\/summer-reading-writing-dublin-ca/);
+    await expect(
+      page.locator('#program-grid').getByRole('link', {
+        name: 'Write to Explain program details →',
       }).first(),
     ).toHaveAttribute('href', /\/camps\/summer-reading-writing-dublin-ca/);
     await expect(

--- a/e2e/specs/academic-summer-programs.spec.ts
+++ b/e2e/specs/academic-summer-programs.spec.ts
@@ -19,6 +19,31 @@ test.describe('Academic summer programs hub', () => {
     await expect(page.getByRole('link', { name: 'Book a free assessment' })).toBeVisible();
   });
 
+  test('program cards link to related SEO landing pages', async ({ page }) => {
+    await page.goto(localePath('/camps/academic-summer-programs-dublin-ca'));
+
+    await expect(
+      page.locator('#program-grid').getByRole('link', {
+        name: 'Summer reading & writing program in Dublin, CA',
+      }).first(),
+    ).toHaveAttribute('href', /\/camps\/summer-reading-writing-dublin-ca/);
+    await expect(
+      page.locator('#program-grid').getByRole('link', {
+        name: 'Summer math foundations program in Dublin, CA',
+      }).first(),
+    ).toHaveAttribute('href', /\/camps\/summer-math-foundations-dublin-ca/);
+    await expect(
+      page.locator('#program-grid').getByRole('link', {
+        name: 'Summer algebra program in Dublin, CA',
+      }).first(),
+    ).toHaveAttribute('href', /\/camps\/summer-algebra-dublin-ca/);
+    await expect(
+      page.locator('#program-grid').getByRole('link', {
+        name: 'Summer geometry program in Dublin, CA',
+      }).first(),
+    ).toHaveAttribute('href', /\/camps\/summer-geometry-precalculus-dublin-ca/);
+  });
+
   test('legacy sprint URL redirects to the hub', async ({ page }) => {
     await page.goto(localePath('/camps/academic-summer-sprint-dublin-ca'));
     await expect(page).toHaveURL(/\/camps\/academic-summer-programs-dublin-ca/);

--- a/e2e/specs/academic-summer-programs.spec.ts
+++ b/e2e/specs/academic-summer-programs.spec.ts
@@ -34,17 +34,17 @@ test.describe('Academic summer programs hub', () => {
     ).toHaveAttribute('href', /\/camps\/summer-reading-writing-dublin-ca/);
     await expect(
       page.locator('#program-grid').getByRole('link', {
-        name: 'Summer math foundations program in Dublin, CA',
+        name: 'Bridge the Gap Math program details →',
       }).first(),
     ).toHaveAttribute('href', /\/camps\/summer-math-foundations-dublin-ca/);
     await expect(
       page.locator('#program-grid').getByRole('link', {
-        name: 'Summer algebra program in Dublin, CA',
+        name: 'Algebra Get Ready program details →',
       }).first(),
     ).toHaveAttribute('href', /\/camps\/summer-algebra-dublin-ca/);
     await expect(
       page.locator('#program-grid').getByRole('link', {
-        name: 'Summer geometry program in Dublin, CA',
+        name: 'Geometry Get Ready program details →',
       }).first(),
     ).toHaveAttribute('href', /\/camps\/summer-geometry-precalculus-dublin-ca/);
   });

--- a/e2e/specs/camps-pages.spec.ts
+++ b/e2e/specs/camps-pages.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from '@playwright/test';
+import { localePath } from '../localePath';
+import {
+  ACADEMIC_HUB_FILTER_SMOKE_CASES,
+  CAMP_REDIRECT_PATHS,
+  getAcademicSeoPageSmokeExpectations,
+  getAllCampsSmokePaths,
+  getCampLandingPaths,
+} from '../../src/lib/camps/camp-pages-registry';
+import { getCampPage } from '../../src/lib/camps/get-camp-page';
+
+const HUB_PATH = '/camps/academic-summer-programs-dublin-ca';
+
+function visibleProgramTitleInGrid(page: Page, title: string) {
+  return page.locator('#program-grid').getByText(title, { exact: false }).locator('visible=true');
+}
+
+test.describe('Camps pages — smoke (200, h1, main landmark)', () => {
+  for (const path of getAllCampsSmokePaths()) {
+    test(`${path} loads with exactly one main h1`, async ({ page }) => {
+      const response = await page.goto(localePath(path));
+      expect(response?.status(), `Expected 200 for ${path}`).toBe(200);
+      await expect(page.locator('main h1')).toHaveCount(1);
+      await expect(page.locator('main h1')).toBeVisible();
+    });
+  }
+});
+
+test.describe('Camps pages — STEAM landing SEO content', () => {
+  for (const path of getCampLandingPaths()) {
+    const slug = path.replace('/camps/', '');
+    const campPage = getCampPage(slug);
+    test(`${path} shows camp h1 from data`, async ({ page }) => {
+      test.skip(!campPage, `Missing camp data for ${slug}`);
+      await page.goto(localePath(path));
+      await expect(page.locator('main h1')).toContainText(campPage!.h1);
+    });
+  }
+});
+
+test.describe('Camps pages — legacy redirects', () => {
+  for (const { from, toPattern } of CAMP_REDIRECT_PATHS) {
+    test(`${from} redirects`, async ({ page }) => {
+      await page.goto(localePath(from));
+      await expect(page).toHaveURL(toPattern);
+    });
+  }
+});
+
+test.describe('Academic SEO landing pages', () => {
+  for (const seoPage of getAcademicSeoPageSmokeExpectations()) {
+    test(`${seoPage.path} hero, FAQ, related links, no checkout panel`, async ({ page }) => {
+      await page.goto(localePath(seoPage.path));
+
+      await expect(page.locator('[data-academic-seo-landing]')).toBeVisible();
+      await expect(page.locator('main h1')).toHaveText(seoPage.h1);
+      await expect(page.getByRole('heading', { name: /Frequently Asked Questions/i })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Related summer programs' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'What your child will work on' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Who teaches this program' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Who this is right for' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: /Why GrowWise for/i })).toBeVisible();
+      await expect(page.locator('#faq button')).toHaveCount(5);
+
+      for (const relatedPath of seoPage.relatedPaths) {
+        const link = page.locator(`a[href="${relatedPath}"], a[href$="${relatedPath}"]`).first();
+        await expect(link).toBeVisible();
+      }
+
+      await expect(page.locator('#slots-panel')).toHaveCount(0);
+      await expect(page.getByRole('button', { name: /add to cart/i })).toHaveCount(0);
+    });
+
+    test(`${seoPage.path} primary CTA opens hub with filter=${seoPage.hubFilterQuery}`, async ({
+      page,
+    }) => {
+      await page.goto(localePath(seoPage.path));
+      const cta = page.getByRole('link', { name: 'View schedule & pricing →' }).first();
+      await expect(cta).toBeVisible();
+      await cta.click();
+      await expect(page).toHaveURL(
+        new RegExp(`/camps/academic-summer-programs-dublin-ca\\?filter=${seoPage.hubFilterQuery}`),
+      );
+    });
+  }
+});
+
+test.describe('Academic hub — filter query params', () => {
+  for (const filterCase of ACADEMIC_HUB_FILTER_SMOKE_CASES) {
+    const label = filterCase.query ?? 'default';
+    test(`?filter=${label} shows expected programs`, async ({ page }) => {
+      const url = filterCase.query
+        ? localePath(`${HUB_PATH}?filter=${filterCase.query}`)
+        : localePath(HUB_PATH);
+      await page.goto(url);
+
+      await expect(page.locator('#program-grid')).toBeVisible();
+
+      for (const title of filterCase.visibleProgramTitles) {
+        await expect(visibleProgramTitleInGrid(page, title).first()).toBeVisible();
+      }
+      for (const title of filterCase.hiddenProgramTitles) {
+        await expect(visibleProgramTitleInGrid(page, title)).toHaveCount(0);
+      }
+    });
+  }
+
+  test('invalid filter param falls back to all programs', async ({ page }) => {
+    await page.goto(localePath(`${HUB_PATH}?filter=not-a-real-filter`));
+    await expect(visibleProgramTitleInGrid(page, 'Read to Prove').first()).toBeVisible();
+    await expect(visibleProgramTitleInGrid(page, 'Geometry Get Ready').first()).toBeVisible();
+  });
+});
+
+test.describe('Academic SEO pages — structured data', () => {
+  for (const seoPage of getAcademicSeoPageSmokeExpectations()) {
+    test(`${seoPage.path} includes FAQPage JSON-LD`, async ({ page }) => {
+      await page.goto(localePath(seoPage.path));
+      const jsonLd = page.locator('script[type="application/ld+json"]');
+      await expect(jsonLd.first()).toBeAttached();
+      const contents = await jsonLd.allTextContents();
+      expect(contents.some((c) => c.includes('"FAQPage"'))).toBe(true);
+      expect(contents.some((c) => c.includes('"Course"') || c.includes('"ItemList"'))).toBe(true);
+    });
+  }
+});
+
+test.describe('Camps pages — mobile layout', () => {
+  for (const width of [375, 430] as const) {
+    test(`no horizontal overflow on academic hub at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 812 });
+      await page.goto(localePath(HUB_PATH));
+      const hasOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(hasOverflow).toBe(false);
+    });
+
+    test(`no horizontal overflow on reading/writing SEO page at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 812 });
+      await page.goto(localePath('/camps/summer-reading-writing-dublin-ca'));
+      const hasOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(hasOverflow).toBe(false);
+    });
+  }
+});

--- a/e2e/specs/courses-mobile.spec.ts
+++ b/e2e/specs/courses-mobile.spec.ts
@@ -8,6 +8,7 @@ test.describe('Courses pages (mobile)', () => {
     '/courses/english',
     '/courses/sat-prep',
     '/courses/high-school-math',
+    '/courses/integrated-math-1-dublin-ca',
   ];
 
   for (const path of paths) {

--- a/e2e/specs/summer-camp-academic-teaser.spec.ts
+++ b/e2e/specs/summer-camp-academic-teaser.spec.ts
@@ -15,21 +15,25 @@ test.describe('Summer camp academic teaser band', () => {
       /\/camps\/academic-summer-programs-dublin-ca/,
     );
 
-    const academicHeading = page.getByRole('heading', { name: 'Academic', exact: false }).first();
-    const aiHeading = page.getByRole('heading', { name: /AI & Game Development/i }).first();
+    const campChooser = page.getByRole('group', { name: 'Choose Your Camp' });
+    const academicHeading = campChooser.getByRole('heading', { level: 3, name: 'Academic', exact: true });
+    const aiHeading = campChooser.getByRole('heading', { level: 3, name: 'AI & Game Development', exact: true });
     await expect(academicHeading).toBeVisible();
     await expect(aiHeading).toBeVisible();
 
-    const academicBox = await academicHeading.boundingBox();
-    const teaserBox = await teaser.boundingBox();
-    const aiBox = await aiHeading.boundingBox();
-    expect(academicBox).not.toBeNull();
-    expect(teaserBox).not.toBeNull();
-    expect(aiBox).not.toBeNull();
-    if (academicBox && teaserBox && aiBox) {
-      expect(academicBox.y).toBeLessThan(teaserBox.y);
-      expect(teaserBox.y).toBeLessThan(aiBox.y);
-    }
+    const teaserBetweenSections = await campChooser.evaluate((campGroup) => {
+      const headings = Array.from(campGroup.querySelectorAll('h3'));
+      const academic = headings.find((heading) => heading.textContent?.trim() === 'Academic');
+      const ai = headings.find((heading) => heading.textContent?.trim() === 'AI & Game Development');
+      const teaserEl = campGroup.querySelector('aside[aria-labelledby="summer-academic-teaser-heading"]');
+      if (!academic || !ai || !teaserEl) return false;
+
+      const isBefore = (left: Element, right: Element) =>
+        Boolean(left.compareDocumentPosition(right) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+      return isBefore(academic, teaserEl) && isBefore(teaserEl, ai);
+    });
+    expect(teaserBetweenSections).toBe(true);
   });
 
   test('does not show duplicate bottom-page academic teaser', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:e2e:chromium": "playwright test --project=chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --project=chromium --headed --workers=1",
+    "test:e2e:camps": "playwright test e2e/specs/camps-pages.spec.ts e2e/specs/academic-summer-programs.spec.ts e2e/specs/summer-camp-academic-teaser.spec.ts --project=chromium",
+    "test:camps": "jest --testPathPatterns='camp-pages-registry|camp-routes|sitemapData|academic-summer-program-filters|metadata-length|academic-seo-landing-copy|AcademicSeoBodySectionsBlock'",
     "lighthouse:summer": "node scripts/lighthouse-summer-camp.mjs",
     "perf:lighthouse": "node performance-testing/scripts/lighthouse-batch.mjs",
     "perf:lighthouse:smoke": "node performance-testing/scripts/lighthouse-batch.mjs --smoke",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --project=chromium --headed --workers=1",
     "test:e2e:camps": "playwright test e2e/specs/camps-pages.spec.ts e2e/specs/academic-summer-programs.spec.ts e2e/specs/summer-camp-academic-teaser.spec.ts --project=chromium",
-    "test:camps": "jest --testPathPatterns='camp-pages-registry|camp-routes|sitemapData|academic-summer-program-filters|metadata-length|academic-seo-landing-copy|AcademicSeoBodySectionsBlock'",
+    "test:camps": "jest --testPathPatterns='camp-pages-registry|camp-routes|sitemapData|academic-summer-program-filters|metadata-length|academic-seo-landing-copy|AcademicSeoBodySectionsBlock|academic-summer-seo-links'",
     "lighthouse:summer": "node scripts/lighthouse-summer-camp.mjs",
     "perf:lighthouse": "node performance-testing/scripts/lighthouse-batch.mjs",
     "perf:lighthouse:smoke": "node performance-testing/scripts/lighthouse-batch.mjs --smoke",

--- a/src/app/[locale]/camps/academic-summer-programs-dublin-ca/page.tsx
+++ b/src/app/[locale]/camps/academic-summer-programs-dublin-ca/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import { AcademicSummerProgramsPage } from '@/components/camps/AcademicSummerProgramsPage';
 
 export default function AcademicSummerProgramsRoutePage() {
-  return <AcademicSummerProgramsPage />;
+  return (
+    <Suspense fallback={null}>
+      <AcademicSummerProgramsPage />
+    </Suspense>
+  );
 }

--- a/src/app/[locale]/camps/summer-algebra-dublin-ca/layout.tsx
+++ b/src/app/[locale]/camps/summer-algebra-dublin-ca/layout.tsx
@@ -1,0 +1,21 @@
+import {
+  AcademicSeoLandingLayout,
+  createAcademicSeoLandingGenerateMetadata,
+} from '@/components/camps/AcademicSeoLandingLayout';
+
+export const generateMetadata = createAcademicSeoLandingGenerateMetadata('algebra');
+
+export default async function SummerAlgebraDublinLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <AcademicSeoLandingLayout pageId="algebra" locale={locale}>
+      {children}
+    </AcademicSeoLandingLayout>
+  );
+}

--- a/src/app/[locale]/camps/summer-algebra-dublin-ca/page.tsx
+++ b/src/app/[locale]/camps/summer-algebra-dublin-ca/page.tsx
@@ -1,0 +1,10 @@
+import { AcademicSeoLandingPage } from '@/components/camps/AcademicSeoLandingPage';
+
+export default async function SummerAlgebraDublinPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return <AcademicSeoLandingPage pageId="algebra" locale={locale} />;
+}

--- a/src/app/[locale]/camps/summer-geometry-precalculus-dublin-ca/layout.tsx
+++ b/src/app/[locale]/camps/summer-geometry-precalculus-dublin-ca/layout.tsx
@@ -1,0 +1,21 @@
+import {
+  AcademicSeoLandingLayout,
+  createAcademicSeoLandingGenerateMetadata,
+} from '@/components/camps/AcademicSeoLandingLayout';
+
+export const generateMetadata = createAcademicSeoLandingGenerateMetadata('geometry');
+
+export default async function SummerGeometryPrecalculusDublinLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <AcademicSeoLandingLayout pageId="geometry" locale={locale}>
+      {children}
+    </AcademicSeoLandingLayout>
+  );
+}

--- a/src/app/[locale]/camps/summer-geometry-precalculus-dublin-ca/page.tsx
+++ b/src/app/[locale]/camps/summer-geometry-precalculus-dublin-ca/page.tsx
@@ -1,0 +1,10 @@
+import { AcademicSeoLandingPage } from '@/components/camps/AcademicSeoLandingPage';
+
+export default async function SummerGeometryPrecalculusDublinPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return <AcademicSeoLandingPage pageId="geometry" locale={locale} />;
+}

--- a/src/app/[locale]/camps/summer-math-foundations-dublin-ca/layout.tsx
+++ b/src/app/[locale]/camps/summer-math-foundations-dublin-ca/layout.tsx
@@ -1,0 +1,21 @@
+import {
+  AcademicSeoLandingLayout,
+  createAcademicSeoLandingGenerateMetadata,
+} from '@/components/camps/AcademicSeoLandingLayout';
+
+export const generateMetadata = createAcademicSeoLandingGenerateMetadata('mathFoundations');
+
+export default async function SummerMathFoundationsDublinLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <AcademicSeoLandingLayout pageId="mathFoundations" locale={locale}>
+      {children}
+    </AcademicSeoLandingLayout>
+  );
+}

--- a/src/app/[locale]/camps/summer-math-foundations-dublin-ca/page.tsx
+++ b/src/app/[locale]/camps/summer-math-foundations-dublin-ca/page.tsx
@@ -1,0 +1,10 @@
+import { AcademicSeoLandingPage } from '@/components/camps/AcademicSeoLandingPage';
+
+export default async function SummerMathFoundationsDublinPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return <AcademicSeoLandingPage pageId="mathFoundations" locale={locale} />;
+}

--- a/src/app/[locale]/camps/summer-reading-writing-dublin-ca/layout.tsx
+++ b/src/app/[locale]/camps/summer-reading-writing-dublin-ca/layout.tsx
@@ -1,0 +1,21 @@
+import {
+  AcademicSeoLandingLayout,
+  createAcademicSeoLandingGenerateMetadata,
+} from '@/components/camps/AcademicSeoLandingLayout';
+
+export const generateMetadata = createAcademicSeoLandingGenerateMetadata('readingWriting');
+
+export default async function SummerReadingWritingDublinLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <AcademicSeoLandingLayout pageId="readingWriting" locale={locale}>
+      {children}
+    </AcademicSeoLandingLayout>
+  );
+}

--- a/src/app/[locale]/camps/summer-reading-writing-dublin-ca/page.tsx
+++ b/src/app/[locale]/camps/summer-reading-writing-dublin-ca/page.tsx
@@ -1,0 +1,10 @@
+import { AcademicSeoLandingPage } from '@/components/camps/AcademicSeoLandingPage';
+
+export default async function SummerReadingWritingDublinPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return <AcademicSeoLandingPage pageId="readingWriting" locale={locale} />;
+}

--- a/src/app/[locale]/courses/integrated-math-1-dublin-ca/layout.tsx
+++ b/src/app/[locale]/courses/integrated-math-1-dublin-ca/layout.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from 'next'
+import FAQSchema from '@/components/schema/FAQSchema'
+import {
+  INTEGRATED_MATH_1_DUBLIN_CA_DESCRIPTION,
+  INTEGRATED_MATH_1_DUBLIN_CA_PATH,
+} from '@/data/integrated-math-1-dublin-ca-copy'
+import { INTEGRATED_MATH_1_DUBLIN_CA_FAQS } from '@/data/integrated-math-1-dublin-ca-faqs'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+import { generateBreadcrumbSchema, generateCourseSchema } from '@/lib/seo/structuredData'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const metadata = generateMetadataFromPath(INTEGRATED_MATH_1_DUBLIN_CA_PATH, locale)
+  return (
+    metadata ?? {
+      title: 'Integrated Math 1 Tutoring Dublin CA | GrowWise',
+      description: INTEGRATED_MATH_1_DUBLIN_CA_DESCRIPTION,
+    }
+  )
+}
+
+export default async function IntegratedMath1DublinCaLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+  const pageUrl = absoluteSiteUrl(INTEGRATED_MATH_1_DUBLIN_CA_PATH, locale, baseUrl)
+
+  const courseSchema = generateCourseSchema({
+    name: 'Integrated Math 1 Tutoring in Dublin, CA',
+    description: INTEGRATED_MATH_1_DUBLIN_CA_DESCRIPTION,
+    provider: 'GrowWise',
+    educationalLevel: 'High School',
+    teaches: [
+      'Integrated Math 1',
+      'Algebra foundations',
+      'Linear functions and graphing',
+      'Systems of equations',
+      'Exponential models',
+      'Coordinate geometry',
+      'Word problems and mathematical reasoning',
+    ],
+    coursePrerequisites: 'Middle school math or pre-algebra foundation',
+    url: pageUrl,
+    image: `${baseUrl}/assets/growwise-logo.png`,
+    offers: {
+      price: '35',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+      url: absoluteSiteUrl('/enroll', locale, baseUrl),
+    },
+  })
+
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: 'Programs', url: absoluteSiteUrl('/programs', locale, baseUrl) },
+    { name: 'Academic', url: absoluteSiteUrl('/academic', locale, baseUrl) },
+    { name: 'Integrated Math 1', url: pageUrl },
+  ])
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(courseSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
+      <FAQSchema faqs={[...INTEGRATED_MATH_1_DUBLIN_CA_FAQS]} />
+      {children}
+    </>
+  )
+}

--- a/src/app/[locale]/courses/integrated-math-1-dublin-ca/page.tsx
+++ b/src/app/[locale]/courses/integrated-math-1-dublin-ca/page.tsx
@@ -1,0 +1,5 @@
+import { IntegratedMath1TutoringPage } from '@/components/courses/IntegratedMath1TutoringPage'
+
+export default function IntegratedMath1DublinCaPage() {
+  return <IntegratedMath1TutoringPage />
+}

--- a/src/components/HighSchoolMathPage.tsx
+++ b/src/components/HighSchoolMathPage.tsx
@@ -642,7 +642,13 @@ const HighSchoolMathPage: React.FC = () => {
 
           <div>
             <h2 className="text-2xl lg:text-3xl font-bold text-gray-900 mb-3">Advanced Math Classes</h2>
-            <p className="text-gray-600 leading-relaxed">Our advanced math classes are designed for students working 1–2 grade levels ahead or targeting accelerated placement. We cover Integrated Math 1 &amp; 2, Geometry, and AP preparation.</p>
+            <p className="text-gray-600 leading-relaxed">
+              Our advanced math classes are designed for students working 1–2 grade levels ahead or targeting accelerated placement. We cover{' '}
+              <Link href={publicPath('/courses/integrated-math-1-dublin-ca', locale)} className="font-semibold text-[#1F396D] underline-offset-2 hover:text-[#F16112] hover:underline">
+                Integrated Math 1
+              </Link>{' '}
+              &amp; 2, Geometry, and AP preparation.
+            </p>
           </div>
 
           <p className="text-gray-600 leading-relaxed">

--- a/src/components/camps/AcademicProblemSection.tsx
+++ b/src/components/camps/AcademicProblemSection.tsx
@@ -1,8 +1,10 @@
 import copy from '@/i18n/messages/academic-summer-programs-en.json';
 import { SectionContainer } from '@/components/camps/SectionContainer';
 import styles from '@/components/camps/academic-problem-section.module.css';
+import { CONTACT_INFO } from '@/lib/constants';
 
 const SECTION = copy.problem;
+const phoneHref = `tel:${CONTACT_INFO.phone.replace(/\D/g, '')}`;
 
 function StatItem({
   value,
@@ -54,6 +56,20 @@ export function AcademicProblemSection() {
             <div className={styles.divider} aria-hidden="true" />
             <StatItem {...stat3} />
           </div>
+          <p className={styles.bannerMeta}>
+            <a
+              href="https://growwiseschool.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.bannerMetaLink}
+            >
+              growwiseschool.org
+            </a>
+            {' · '}
+            <a href={phoneHref} className={styles.bannerMetaLink}>
+              {CONTACT_INFO.phone}
+            </a>
+          </p>
           <p className={styles.bannerTransition}>{SECTION.transition}</p>
         </div>
       </div>

--- a/src/components/camps/AcademicProgramList.tsx
+++ b/src/components/camps/AcademicProgramList.tsx
@@ -2,9 +2,12 @@
 
 import { memo, useCallback, useMemo } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
 import { Check } from 'lucide-react';
 import type { Program } from '@/lib/summer-camp-data';
 import pageCopy from '@/i18n/messages/academic-summer-programs-en.json';
+import { createLocaleUrl } from '@/components/layout/Header/utils';
 import {
   getAcademicGetReadyPickCardMeta,
   getAcademicSprintPickCardMeta,
@@ -14,11 +17,19 @@ import {
   type AcademicSummerSprintTrackId,
 } from '@/lib/academic-summer-programs-hub-data';
 import {
+  getAcademicProgramSeoLink,
+  type AcademicProgramSeoSlugKey,
+} from '@/lib/academic-summer-seo-links';
+import {
   groupAcademicProgramsByWindow,
   type AcademicProgramGroup,
 } from '@/lib/academic-summer-program-groups';
 
 const COPY = pageCopy.programs;
+
+function academicSeoLinkLabel(labelKey: AcademicProgramSeoSlugKey): string | undefined {
+  return COPY.seoLinks[labelKey as keyof typeof COPY.seoLinks];
+}
 
 const CARD_BUTTON_CLASS = (isSelected: boolean) =>
   `group flex w-full flex-col overflow-hidden rounded-xl border-2 bg-white text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[#1F396D] focus-visible:ring-offset-2 ${
@@ -242,6 +253,7 @@ function renderProgramGrid(
   selectedProgramId: string | null,
   onSelectProgram: (program: Program) => void,
   layout: 'mobile' | 'desktop',
+  locale: string,
 ) {
   return programs.map((program, idx) => {
     const isSelected = selectedProgramId === program.id;
@@ -250,6 +262,8 @@ function renderProgramGrid(
     const isEnhancedCard = isSprint || isGetReady;
     const hasOddCount = programs.length % 2 !== 0;
     const isLastAndAlone = layout === 'desktop' && hasOddCount && idx === programs.length - 1;
+    const seo = getAcademicProgramSeoLink(program.id);
+    const seoLabel = seo ? academicSeoLinkLabel(seo.labelKey) : undefined;
 
     const imageSizes =
       layout === 'mobile'
@@ -278,7 +292,7 @@ function renderProgramGrid(
       <li
         key={program.id}
         id={`track-${program.id}`}
-        className={`scroll-mt-28 [content-visibility:auto] ${
+        className={`flex flex-col gap-2 scroll-mt-28 [content-visibility:auto] ${
           isEnhancedCard ? '[contain-intrinsic-size:auto_420px]' : '[contain-intrinsic-size:auto_300px]'
         } ${isLastAndAlone ? 'col-span-2' : ''}`}
       >
@@ -289,6 +303,14 @@ function renderProgramGrid(
           imageSizes={imageSizes}
           imageWrapperClassName={imageWrapperClassName}
         />
+        {seo && seoLabel ? (
+          <Link
+            href={createLocaleUrl(`/camps/${seo.slug}`, locale)}
+            className="-mt-0.5 rounded-sm px-0.5 text-[12px] font-semibold text-[#1F396D] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#1F396D] focus-visible:ring-offset-2"
+          >
+            {seoLabel}
+          </Link>
+        ) : null}
       </li>
     );
   });
@@ -305,6 +327,7 @@ export const AcademicProgramList = memo(function AcademicProgramList({
   selectedProgramId: string | null;
   onInquire?: () => void;
 }) {
+  const locale = useLocale();
   const groups = useMemo(() => groupAcademicProgramsByWindow(programs ?? []), [programs]);
 
   const sectionHeading = (group: AcademicProgramGroup) => COPY.groups[group].heading;
@@ -322,7 +345,7 @@ export const AcademicProgramList = memo(function AcademicProgramList({
               className="m-0 grid list-none grid-cols-1 gap-3 p-0"
               aria-label={sectionHeading(groupEntry.group)}
             >
-              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, 'mobile')}
+              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, 'mobile', locale)}
             </ul>
           </section>
         ))}
@@ -350,7 +373,7 @@ export const AcademicProgramList = memo(function AcademicProgramList({
               className="m-0 grid list-none grid-cols-2 gap-3 p-0"
               aria-label={sectionHeading(groupEntry.group)}
             >
-              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, 'desktop')}
+              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, 'desktop', locale)}
             </ul>
           </section>
         ))}

--- a/src/components/camps/AcademicSeoLandingLayout.tsx
+++ b/src/components/camps/AcademicSeoLandingLayout.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next';
+import FAQSchema from '@/components/schema/FAQSchema';
+import '@/components/camps/academic-summer-programs-page.global.css';
+import type { AcademicSeoLandingPageId } from '@/lib/academic-seo-landing-config';
+import {
+  ACADEMIC_SEO_LANDING_PAGES,
+  getAcademicSeoLandingPageConfig,
+} from '@/lib/academic-seo-landing-config';
+import { getAcademicSeoLandingCopy } from '@/lib/academic-seo-landing-copy';
+import { generateMetadataFromPath } from '@/lib/seo/metadata';
+import {
+  buildAcademicSeoLandingCourseSchema,
+  buildAcademicSeoLandingWebPageName,
+} from '@/lib/schema/academic-seo-landing-jsonld';
+import { generateBreadcrumbSchema, generateWebPageJsonLd } from '@/lib/seo/structuredData';
+import { absoluteSiteUrl } from '@/lib/publicPath';
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
+
+export function createAcademicSeoLandingGenerateMetadata(pageId: AcademicSeoLandingPageId) {
+  return async function generateMetadata({
+    params,
+  }: {
+    params: Promise<{ locale: string }>;
+  }): Promise<Metadata> {
+    const { locale } = await params;
+    const { path } = getAcademicSeoLandingPageConfig(pageId);
+    const metadata = generateMetadataFromPath(path, locale);
+    return metadata ?? {};
+  };
+}
+
+export function AcademicSeoLandingLayout({
+  pageId,
+  children,
+  locale,
+}: {
+  pageId: AcademicSeoLandingPageId;
+  children: React.ReactNode;
+  locale: string;
+}) {
+  const config = ACADEMIC_SEO_LANDING_PAGES[pageId];
+  const copy = getAcademicSeoLandingCopy(pageId);
+  const baseUrl = getCanonicalSiteUrl();
+  const pageUrl = absoluteSiteUrl(config.path, locale, baseUrl);
+
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: 'Camps', url: absoluteSiteUrl('/camps', locale, baseUrl) },
+    { name: config.breadcrumbLabel, url: pageUrl },
+  ]);
+
+  const webPageSchema = generateWebPageJsonLd({
+    name: `${buildAcademicSeoLandingWebPageName(pageId)} | GrowWise`,
+    description: copy.hero.subtext,
+    url: pageUrl,
+  });
+
+  const courseSchema = buildAcademicSeoLandingCourseSchema(pageId);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <FAQSchema faqs={[...copy.faq]} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(courseSchema) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/components/camps/AcademicSeoLandingPage.tsx
+++ b/src/components/camps/AcademicSeoLandingPage.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import Link from 'next/link';
+import { HelpCircle } from 'lucide-react';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { ACADEMIC_SUMMER_BANNER_SRC } from '@/components/camps/AcademicProgramsHero';
+import { SectionContainer } from '@/components/camps/SectionContainer';
+import { createLocaleUrl } from '@/components/layout/Header/utils';
+import '@/components/camps/academic-summer-programs-page.global.css';
+import {
+  ACADEMIC_SEO_HUB_PATH,
+  ACADEMIC_SEO_LANDING_PAGES,
+  type AcademicSeoLandingPageId,
+} from '@/lib/academic-seo-landing-config';
+import { ACADEMIC_HUB_FILTER_QUERY_VALUES } from '@/lib/academic-summer-program-filters';
+import { getAcademicSeoLandingCopy, type AcademicSeoBodySections, type AcademicSeoFitGroup } from '@/lib/academic-seo-landing-copy';
+import { buildAcademicSeoStaticProgramCard } from '@/lib/academic-seo-landing-program-cards';
+import {
+  formatAcademicSprintUsd,
+  getAcademicSummerProgramsHubData,
+} from '@/lib/academic-summer-programs-hub-data';
+import { getDefaultOpenFaqValues } from '@/lib/faq-accordion';
+import { cn } from '@/lib/utils';
+import Image from 'next/image';
+
+type AcademicSeoLandingPageProps = {
+  pageId: AcademicSeoLandingPageId;
+  locale: string;
+};
+
+function hubUrlWithFilter(
+  locale: string,
+  filter: keyof typeof ACADEMIC_HUB_FILTER_QUERY_VALUES,
+): string {
+  const query = ACADEMIC_HUB_FILTER_QUERY_VALUES[filter];
+  return createLocaleUrl(`${ACADEMIC_SEO_HUB_PATH}?filter=${query}`, locale);
+}
+
+function AcademicSeoStaticProgramCard({
+  card,
+}: {
+  card: NonNullable<ReturnType<typeof buildAcademicSeoStaticProgramCard>>;
+}) {
+  return (
+    <article className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex flex-col p-6">
+        <h2 className="font-heading text-lg font-bold text-[#1F396D] md:text-xl">{card.title}</h2>
+        <p className="mt-1.5 text-sm leading-relaxed text-slate-700">{card.tagline}</p>
+        <span className="mt-3 inline-flex w-fit rounded-full border border-[#1F396D]/20 bg-[#1F396D]/5 px-2.5 py-1 text-xs font-semibold text-[#1F396D]">
+          {card.gradeBadge}
+        </span>
+        <p className="mt-3 rounded-md bg-[#1F396D]/8 px-2.5 py-1.5 text-xs font-bold leading-snug text-[#1F396D]">
+          {card.scheduleLine}
+        </p>
+        <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 px-3 py-3">
+          <p className="text-[11px] font-bold uppercase tracking-[0.08em] text-slate-800">
+            {card.bestForLabel}
+          </p>
+          <ul className="mt-2 space-y-1.5" role="list">
+            {card.bestFor.map((item) => (
+              <li key={item} className="flex items-start gap-2 text-sm font-medium leading-snug text-slate-800">
+                <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-[#1F396D]" aria-hidden />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="mt-4 border-t border-slate-100 pt-4">
+          <p className="text-[11px] font-bold uppercase tracking-[0.08em] text-slate-500">Pricing</p>
+          <ul className="mt-2 space-y-1" role="list">
+            {card.pricingRows.map((row) => (
+              <li key={row.label} className="flex items-baseline justify-between gap-3 text-sm text-slate-800">
+                <span>{row.label}</span>
+                <span className="font-semibold text-[#1F396D]">{row.amount}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function AcademicSeoFitBulletList({ group }: { group: AcademicSeoFitGroup }) {
+  return (
+    <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3">
+      <p className="text-sm font-semibold text-slate-900">{group.label}</p>
+      <ul className="mt-2 space-y-1.5" role="list">
+        {group.items.map((item) => (
+          <li key={item} className="flex items-start gap-2 text-sm font-medium leading-snug text-slate-800">
+            <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-[#1F396D]" aria-hidden />
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function AcademicSeoBodySectionsBlock({ sections }: { sections: AcademicSeoBodySections }) {
+  return (
+    <SectionContainer className="bg-white">
+      <div className="mx-auto max-w-[720px] space-y-12">
+        <section aria-labelledby="what-your-child-will-work-on">
+          <h2
+            id="what-your-child-will-work-on"
+            className="font-heading text-xl font-bold text-[#1F396D] sm:text-2xl"
+          >
+            {sections.whatYourChildWillWorkOn.heading}
+          </h2>
+          <div className="mt-6 space-y-8">
+            {sections.whatYourChildWillWorkOn.subsections.map((subsection) => (
+              <div key={subsection.h3}>
+                <h3 className="font-heading text-base font-semibold text-[#1F396D] sm:text-lg">
+                  {subsection.h3}
+                </h3>
+                <div className="mt-4 space-y-4">
+                  {subsection.weeks.map((week) => (
+                    <p key={week.title} className="text-sm leading-relaxed text-slate-700 sm:text-base">
+                      <span className="font-semibold text-slate-900">{week.title}</span> {week.body}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby="who-teaches-this-program">
+          <h2
+            id="who-teaches-this-program"
+            className="font-heading text-xl font-bold text-[#1F396D] sm:text-2xl"
+          >
+            {sections.whoTeaches.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{sections.whoTeaches.body}</p>
+        </section>
+
+        <section aria-labelledby="who-this-is-right-for">
+          <h2
+            id="who-this-is-right-for"
+            className="font-heading text-xl font-bold text-[#1F396D] sm:text-2xl"
+          >
+            {sections.whoIsRightFor.heading}
+          </h2>
+          <div className="mt-4 space-y-4">
+            {sections.whoIsRightFor.groups.map((group) => (
+              <AcademicSeoFitBulletList key={group.label} group={group} />
+            ))}
+            {sections.whoIsRightFor.notRightFor ? (
+              <AcademicSeoFitBulletList group={sections.whoIsRightFor.notRightFor} />
+            ) : null}
+          </div>
+        </section>
+
+        <section aria-labelledby="why-growwise">
+          <h2 id="why-growwise" className="font-heading text-xl font-bold text-[#1F396D] sm:text-2xl">
+            {sections.whyGrowWise.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{sections.whyGrowWise.body}</p>
+        </section>
+      </div>
+    </SectionContainer>
+  );
+}
+
+export function AcademicSeoLandingPage({ pageId, locale }: AcademicSeoLandingPageProps) {
+  const config = ACADEMIC_SEO_LANDING_PAGES[pageId];
+  const copy = getAcademicSeoLandingCopy(pageId);
+  const hubCtaHref = hubUrlWithFilter(locale, config.hubFilter);
+  const hubAllHref = createLocaleUrl(ACADEMIC_SEO_HUB_PATH, locale);
+
+  const programCards = config.trackIds
+    .map((trackId) => {
+      const override = copy.programCardOverrides?.[trackId];
+      return buildAcademicSeoStaticProgramCard(trackId, override);
+    })
+    .filter((card): card is NonNullable<typeof card> => card !== null);
+
+  const defaultOpenFaqs = getDefaultOpenFaqValues(copy.faq.length, (idx) => `faq-${idx}`);
+
+  const valueAnchorText =
+    copy.valueAnchorPrefix && pageId === 'geometry'
+      ? `${copy.valueAnchorPrefix} ${formatAcademicSprintUsd(getAcademicSummerProgramsHubData().getReadyPricing.geometry.twoWeek)}.`
+      : null;
+
+  return (
+    <div
+      data-academic-seo-landing
+      className="min-h-screen bg-background font-sans selection:bg-[#1F396D]/20 selection:text-[#1F396D]"
+    >
+      <main>
+        <section
+          className="relative isolate w-full min-h-[min(48svh,17rem)] max-h-[600px] overflow-hidden md:min-h-[min(40vh,22rem)]"
+          aria-label="Program hero"
+        >
+          <div className="absolute inset-0 z-0">
+            <Image
+              src={ACADEMIC_SUMMER_BANNER_SRC}
+              alt={copy.hero.h1}
+              fill
+              priority
+              fetchPriority="high"
+              decoding="async"
+              quality={70}
+              sizes="(max-width: 768px) 100vw, min(1100px, 85vw)"
+              className="object-cover object-center select-none"
+              draggable={false}
+            />
+            <div className="absolute inset-0 z-[1] bg-[rgba(0,0,0,0.6)]" aria-hidden />
+          </div>
+          <div className="relative z-10 mx-auto flex w-full max-w-[1100px] flex-col justify-center px-5 py-8 sm:px-8 md:px-12 md:py-14 lg:px-16 lg:py-16">
+            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-200 md:text-sm">
+              {copy.hero.eyebrow}
+            </p>
+            <h1 className="font-heading mt-2 max-w-[700px] text-[1.5rem] font-bold leading-[1.15] text-white sm:text-[1.75rem] md:text-[2.25rem] lg:text-[2.625rem]">
+              {copy.hero.h1}
+            </h1>
+            <p className="mt-3 max-w-[650px] text-base leading-snug text-zinc-100 md:text-lg">{copy.hero.subtext}</p>
+            <div className="mt-5">
+              <Link
+                href={hubCtaHref}
+                className="inline-flex min-h-[44px] w-full max-w-md items-center justify-center rounded-lg bg-[#1F396D] px-6 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#183056] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#1F396D] focus-visible:ring-offset-2 sm:w-auto sm:text-base"
+              >
+                {copy.hero.ctaLabel}
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <SectionContainer className="bg-white">
+          <div
+            className={cn(
+              'mx-auto grid max-w-5xl gap-6',
+              programCards.length > 1 ? 'md:grid-cols-2' : 'max-w-xl',
+            )}
+          >
+            {programCards.map((card) => (
+              <AcademicSeoStaticProgramCard key={card.id} card={card} />
+            ))}
+          </div>
+        </SectionContainer>
+
+        <SectionContainer className="border-y border-slate-100 bg-slate-50/80">
+          <ul
+            className="mx-auto flex max-w-4xl flex-wrap justify-center gap-2"
+            aria-label="Program highlights"
+          >
+            {copy.keyDetails.map((pill) => (
+              <li
+                key={pill}
+                className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 md:text-sm"
+              >
+                {pill}
+              </li>
+            ))}
+          </ul>
+        </SectionContainer>
+
+        {copy.summerCampCallout ? (
+          <SectionContainer className="bg-white py-10 sm:py-12">
+            <aside className="mx-auto max-w-3xl overflow-hidden rounded-lg border-[1.5px] border-[#F16112]/40 bg-gradient-to-br from-[#fff7ed] via-white to-[#eff6ff] px-5 py-4">
+              <p className="text-sm leading-relaxed text-slate-700">{copy.summerCampCallout.text}</p>
+              <Link
+                href={createLocaleUrl(copy.summerCampCallout.href, locale)}
+                className="mt-3 inline-flex min-h-[44px] items-center text-sm font-semibold text-[#F16112] hover:text-[#d54f0a]"
+              >
+                {copy.summerCampCallout.linkLabel}
+              </Link>
+            </aside>
+          </SectionContainer>
+        ) : null}
+
+        <AcademicSeoBodySectionsBlock sections={copy.bodySections} />
+
+        <SectionContainer className="bg-white">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="font-heading text-xl font-bold text-[#1F396D] sm:text-2xl">
+              {copy.relatedPrograms.heading}
+            </h2>
+            <ul className="mt-4 space-y-3">
+              {config.relatedPageOrder.map((relatedId) => {
+                const related = ACADEMIC_SEO_LANDING_PAGES[relatedId];
+                const item = copy.relatedPrograms.items[relatedId];
+                if (!item) return null;
+                return (
+                  <li key={relatedId} className="flex items-start gap-2">
+                    <span className="mt-0.5 font-bold text-[#F16112]" aria-hidden>
+                      →
+                    </span>
+                    <span className="text-sm text-slate-700 sm:text-base">
+                      <Link
+                        href={createLocaleUrl(related.path, locale)}
+                        className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+                      >
+                        {item.label}
+                      </Link>{' '}
+                      — {item.description}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="mt-5 text-sm text-slate-600">
+              <Link
+                href={hubAllHref}
+                className="font-semibold text-[#1F396D] underline hover:text-[#F16112]"
+              >
+                {copy.relatedPrograms.hubLinkLabel}
+              </Link>
+            </p>
+          </div>
+        </SectionContainer>
+
+        {valueAnchorText ? (
+          <SectionContainer className="border-t border-slate-100 bg-slate-50/60 py-8">
+            <p className="mx-auto max-w-2xl text-center text-sm text-slate-500">{valueAnchorText}</p>
+          </SectionContainer>
+        ) : null}
+
+        <SectionContainer className="bg-white">
+          <div className="mx-auto max-w-xl text-center">
+            <h2 className="font-heading text-2xl font-bold text-slate-900 md:text-3xl">{copy.mainCta.headline}</h2>
+            <p className="mt-3 text-sm text-slate-600 md:text-base">{copy.mainCta.subtext}</p>
+            <Link
+              href={hubCtaHref}
+              className="mt-6 inline-flex min-h-[48px] w-full items-center justify-center rounded-lg bg-[#F16112] px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#d54f0a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F16112] focus-visible:ring-offset-2 sm:text-base"
+            >
+              {copy.mainCta.button}
+            </Link>
+          </div>
+        </SectionContainer>
+
+        <SectionContainer id="faq" className="border-t border-slate-100 bg-slate-50/60">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="text-center font-heading text-2xl font-bold text-slate-900 md:text-3xl">
+              Frequently Asked <span className="text-[#F16112]">Questions</span>
+            </h2>
+            <div className="mt-10 space-y-3">
+              <Accordion type="multiple" className="w-full" defaultValue={defaultOpenFaqs}>
+                {copy.faq.map((item, idx) => (
+                  <AccordionItem
+                    key={item.question}
+                    value={`faq-${idx}`}
+                    className="overflow-hidden rounded-xl border-0 bg-white shadow-sm ring-1 ring-slate-200/90"
+                  >
+                    <AccordionTrigger className="px-4 py-4 text-left hover:no-underline sm:px-5">
+                      <span className="flex items-center gap-3">
+                        <span
+                          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#F16112]/10 ring-1 ring-[#F16112]/15"
+                          aria-hidden
+                        >
+                          <HelpCircle className="h-4 w-4 text-[#F16112]" />
+                        </span>
+                        <span className="text-sm font-semibold text-slate-900 sm:text-base">{item.question}</span>
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="px-4 pb-5 text-sm leading-relaxed text-slate-600 sm:px-5 sm:text-base">
+                      {item.answer}
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </div>
+          </div>
+        </SectionContainer>
+      </main>
+    </div>
+  );
+}

--- a/src/components/camps/AcademicSummerProgramsPage.tsx
+++ b/src/components/camps/AcademicSummerProgramsPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { HelpCircle } from 'lucide-react';
 import { AcademicEnrollmentPanel } from '@/components/camps/AcademicEnrollmentPanel';
 import { AcademicProgramList } from '@/components/camps/AcademicProgramList';
@@ -24,6 +24,7 @@ import {
 import {
   ACADEMIC_PROGRAM_FILTER_ORDER,
   filterAcademicProgramsByChip,
+  resolveAcademicHubFilterFromQuery,
   type AcademicProgramFilterId,
 } from '@/lib/academic-summer-program-filters';
 import { ACADEMIC_SUMMER_PROGRAMS_HUB_FAQS } from '@/lib/schema/academic-summer-programs-hub-jsonld-faqs';
@@ -75,6 +76,8 @@ function resolveProgramFromHash(hash: string): Program | null {
 
 export function AcademicSummerProgramsPage() {
   const params = useParams();
+  const searchParams = useSearchParams();
+  const filterParam = searchParams.get('filter');
   const locale = typeof params?.locale === 'string' ? params.locale : 'en';
   const { openChatbot } = useChatbot();
   const slotsSectionRef = useRef<HTMLElement>(null);
@@ -110,6 +113,18 @@ export function AcademicSummerProgramsPage() {
     },
     [openChatbot],
   );
+
+  useEffect(() => {
+    const resolved = resolveAcademicHubFilterFromQuery(filterParam);
+    if (!resolved) return;
+    setProgramFilter(resolved);
+    const nextPrograms = filterAcademicProgramsByChip(PROGRAMS, resolved);
+    setSelectedProgram(nextPrograms[0] ?? getDefaultAcademicHubProgram());
+    const scrollTimer = window.setTimeout(() => {
+      document.getElementById('program-grid')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 300);
+    return () => window.clearTimeout(scrollTimer);
+  }, [filterParam]);
 
   useEffect(() => {
     const applyHash = () => {
@@ -255,7 +270,7 @@ export function AcademicSummerProgramsPage() {
             </div>
 
             <div className="relative grid items-start gap-8 lg:grid-cols-12">
-              <div className="max-[768px]:overflow-x-hidden lg:col-span-7">
+              <div id="program-grid" className="scroll-mt-24 max-[768px]:overflow-x-hidden lg:col-span-7">
                 <AcademicProgramList
                   programs={filteredPrograms}
                   selectedProgramId={selectedProgram?.id ?? null}

--- a/src/components/camps/CampInquiryForm.tsx
+++ b/src/components/camps/CampInquiryForm.tsx
@@ -143,7 +143,7 @@ export function CampInquiryForm({ page }: CampInquiryFormProps) {
           <div className="mt-8">
             <Link
               href={page.formConfig.enrollCta.href}
-              className="inline-flex justify-center items-center rounded-md bg-[#F16112] px-6 py-3 text-base font-semibold text-white shadow-sm hover:bg-[#d54f0a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#F16112]"
+              className="inline-flex justify-center items-center rounded-md bg-[#1F396D] px-6 py-3 text-base font-semibold text-white shadow-sm hover:bg-[#183056] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#1F396D]"
             >
               {page.formConfig.enrollCta.label}
             </Link>

--- a/src/components/camps/__tests__/AcademicSeoBodySectionsBlock.test.tsx
+++ b/src/components/camps/__tests__/AcademicSeoBodySectionsBlock.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@/test-utils';
+import { AcademicSeoBodySectionsBlock } from '@/components/camps/AcademicSeoLandingPage';
+import { getAcademicSeoLandingCopy } from '@/lib/academic-seo-landing-copy';
+
+describe('AcademicSeoBodySectionsBlock', () => {
+  it('renders all four section H2 headings from copy', () => {
+    const sections = getAcademicSeoLandingCopy('readingWriting').bodySections;
+
+    render(<AcademicSeoBodySectionsBlock sections={sections} />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: sections.whatYourChildWillWorkOn.heading }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: sections.whoTeaches.heading })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: sections.whoIsRightFor.heading })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: sections.whyGrowWise.heading })).toBeInTheDocument();
+  });
+
+  it.each(['readingWriting', 'mathFoundations', 'algebra', 'geometry'] as const)(
+    'renders four H2 headings for %s',
+    (pageId) => {
+      const sections = getAcademicSeoLandingCopy(pageId).bodySections;
+
+      render(<AcademicSeoBodySectionsBlock sections={sections} />);
+
+      expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(4);
+    },
+  );
+
+  it('renders week-by-week subsection headings and notRightFor when present', () => {
+    const sections = getAcademicSeoLandingCopy('mathFoundations').bodySections;
+
+    render(<AcademicSeoBodySectionsBlock sections={sections} />);
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: sections.whatYourChildWillWorkOn.subsections[0]!.h3 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(sections.whoIsRightFor.notRightFor!.label)).toBeInTheDocument();
+  });
+});

--- a/src/components/camps/academic-problem-section.module.css
+++ b/src/components/camps/academic-problem-section.module.css
@@ -13,13 +13,10 @@
 }
 
 .bannerBreakout {
-  width: 100vw;
-  max-width: 100vw;
-  position: relative;
-  left: 50%;
-  transform: translateX(-50%);
   box-sizing: border-box;
   margin-top: 2rem;
+  margin-left: 40px;
+  margin-right: 40px;
 }
 
 .banner {
@@ -28,7 +25,9 @@
   align-items: stretch;
   width: 100%;
   box-sizing: border-box;
-  background: #1f396d;
+  background: #fef3f0;
+  border: 1px solid #f5c4b8;
+  border-radius: 12px;
   padding: 32px 40px;
 }
 
@@ -39,13 +38,31 @@
   width: 100%;
 }
 
+.bannerMeta {
+  margin-top: 16px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #9a8a87;
+  text-align: center;
+}
+
+.bannerMetaLink {
+  color: #e86040;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.bannerMetaLink:hover {
+  color: #c94e32;
+}
+
 .bannerTransition {
-  padding-top: 20px;
+  padding-top: 16px;
   margin-top: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  margin-bottom: 0;
   font-size: 13px;
   line-height: 1.6;
-  color: #9fb3c8;
+  color: #5a4a47;
   text-align: center;
 }
 
@@ -59,48 +76,44 @@
   font-size: 38px;
   font-weight: 700;
   line-height: 1;
-  color: #ffffff;
+  color: #2d3480;
 }
 
 .statLabel {
   margin-bottom: 10px;
   font-size: 12px;
   line-height: 1.5;
-  color: #c5d4e8;
+  color: #5a4a47;
 }
 
 .statSource {
   margin-bottom: 2px;
   font-size: 10px;
   font-style: italic;
-  color: #8fa3bc;
+  color: #9a8a87;
 }
 
 .statLink {
   display: block;
   font-size: 10px;
-  color: #7dddb8;
+  color: #e86040;
   text-decoration: underline;
 }
 
 .statLink:hover {
-  color: #9ee8cc;
+  color: #c94e32;
 }
 
 .divider {
   width: 1px;
   height: 60px;
-  background: rgba(255, 255, 255, 0.2);
+  background: #f5c4b8;
 }
 
 @media (max-width: 639px) {
   .bannerBreakout {
-    width: calc(100% + 2rem);
-    max-width: calc(100% + 2rem);
-    margin-left: -1rem;
-    margin-right: -1rem;
-    left: 0;
-    transform: none;
+    margin-left: 16px;
+    margin-right: 16px;
   }
 
   .banner {

--- a/src/components/courses/IntegratedMath1TutoringPage.tsx
+++ b/src/components/courses/IntegratedMath1TutoringPage.tsx
@@ -1,0 +1,260 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { HelpCircle, MapPin, Phone } from 'lucide-react'
+import { useLocale } from 'next-intl'
+import FreeAssessmentModal from '@/components/FreeAssessmentModal'
+import { RelatedContent } from '@/components/seo/RelatedContent'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { Button } from '@/components/ui/button'
+import { INTEGRATED_MATH_1_DUBLIN_CA_COPY } from '@/data/integrated-math-1-dublin-ca-copy'
+import { INTEGRATED_MATH_1_DUBLIN_CA_FAQS } from '@/data/integrated-math-1-dublin-ca-faqs'
+import { getDefaultOpenFaqValues } from '@/lib/faq-accordion'
+import { cn } from '@/lib/utils'
+
+const copy = INTEGRATED_MATH_1_DUBLIN_CA_COPY
+const phoneHref = `tel:${copy.hero.phone.replace(/\D/g, '')}`
+
+const sectionClass = 'mx-auto max-w-3xl px-4 sm:px-6'
+const h2Class = 'font-heading text-2xl font-bold text-[#1F396D] sm:text-3xl'
+
+function BulletList({ items }: { items: readonly string[] }) {
+  return (
+    <ul className="mt-4 space-y-2" role="list">
+      {items.map((item) => (
+        <li key={item} className="flex items-start gap-2 text-sm leading-relaxed text-slate-700 sm:text-base">
+          <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-[#1F396D]" aria-hidden />
+          {item}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function ContactStrip({ variant }: { variant: 'hero' | 'footer' }) {
+  const isHero = variant === 'hero'
+  return (
+    <div
+      className={cn(
+        'mt-6 flex flex-col gap-3 text-sm sm:flex-row sm:flex-wrap sm:gap-6',
+        isHero ? 'text-slate-700' : 'text-white/90',
+      )}
+    >
+      <p className="flex items-center gap-2">
+        <Phone className={cn('h-4 w-4 shrink-0', isHero ? 'text-[#1F396D]' : 'text-[#F16112]')} aria-hidden />
+        <span className="font-semibold">{copy.hero.phoneLabel}:</span>{' '}
+        <Link
+          href={phoneHref}
+          className={cn(
+            'font-semibold underline-offset-2 hover:underline',
+            isHero ? 'text-[#1F396D]' : 'text-white',
+          )}
+        >
+          {copy.hero.phone}
+        </Link>
+      </p>
+      <p className="flex items-start gap-2">
+        <MapPin className={cn('mt-0.5 h-4 w-4 shrink-0', isHero ? 'text-[#1F396D]' : 'text-[#F16112]')} aria-hidden />
+        <span>
+          <span className="font-semibold">{copy.hero.locationLabel}:</span>{' '}
+          {isHero ? copy.hero.location : copy.cta.location}
+        </span>
+      </p>
+    </div>
+  )
+}
+
+export function IntegratedMath1TutoringPage() {
+  const locale = useLocale()
+  const [isAssessmentModalOpen, setIsAssessmentModalOpen] = useState(false)
+  const defaultOpenFaqs = getDefaultOpenFaqValues(
+    INTEGRATED_MATH_1_DUBLIN_CA_FAQS.length,
+    (idx) => `im1-faq-${idx}`,
+  )
+
+  return (
+    <main data-integrated-math-1-tutoring className="min-h-screen bg-background font-sans">
+      <section className="border-b border-slate-200/80 bg-white pb-14 pt-12 sm:pb-20 sm:pt-16" aria-labelledby="im1-hero-title">
+        <div className={cn(sectionClass, 'max-w-4xl')}>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 sm:text-sm">
+            Dublin, CA · Integrated Math 1
+          </p>
+          <h1 id="im1-hero-title" className="font-heading mt-3 text-3xl font-bold leading-tight text-[#1F396D] sm:text-4xl md:text-5xl">
+            {copy.hero.h1}
+          </h1>
+          <p className="mt-4 text-lg font-medium text-slate-800 sm:text-xl">{copy.hero.subtext}</p>
+          <div className="mt-6 space-y-4 text-sm leading-relaxed text-slate-700 sm:text-base">
+            {copy.hero.intro.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+          <ContactStrip variant="hero" />
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button
+              type="button"
+              onClick={() => setIsAssessmentModalOpen(true)}
+              className="min-h-[48px] rounded-lg bg-[#F16112] px-6 text-sm font-semibold text-white hover:bg-[#d54f0a] sm:text-base"
+            >
+              {copy.hero.assessmentCta}
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="min-h-[48px] rounded-lg border-[#1F396D] px-6 text-sm font-semibold text-[#1F396D] hover:bg-[#1F396D]/5 sm:text-base"
+            >
+              <Link href={phoneHref}>{copy.hero.phoneLabel}: {copy.hero.phone}</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-50/80 py-12 sm:py-16" aria-labelledby="im1-struggle-signs">
+        <div className={sectionClass}>
+          <h2 id="im1-struggle-signs" className={h2Class}>
+            {copy.struggleSigns.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.struggleSigns.intro}</p>
+          <p className="mt-4 text-sm font-semibold text-slate-900 sm:text-base">{copy.struggleSigns.subheading}</p>
+          <BulletList items={copy.struggleSigns.items} />
+          <p className="mt-6 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.struggleSigns.closing}</p>
+        </div>
+      </section>
+
+      <section className="bg-white py-12 sm:py-16" aria-labelledby="im1-coverage">
+        <div className={sectionClass}>
+          <h2 id="im1-coverage" className={h2Class}>
+            {copy.coverage.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.coverage.intro}</p>
+          <div className="mt-8 space-y-10">
+            {copy.coverage.topics.map((topic) => (
+              <div key={topic.title}>
+                <h3 className="font-heading text-lg font-semibold text-[#1F396D] sm:text-xl">{topic.title}</h3>
+                <p className="mt-2 text-sm font-medium text-slate-800 sm:text-base">{topic.leadIn}</p>
+                <BulletList items={topic.items} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-50/80 py-12 sm:py-16" aria-labelledby="im1-approach">
+        <div className={sectionClass}>
+          <h2 id="im1-approach" className={h2Class}>
+            {copy.approach.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.approach.intro}</p>
+          <p className="mt-4 text-sm font-semibold text-slate-900 sm:text-base">{copy.approach.subheading}</p>
+          <p className="mt-2 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.approach.body}</p>
+          <BulletList items={copy.approach.patterns} />
+          <p className="mt-6 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.approach.closing}</p>
+        </div>
+      </section>
+
+      <section className="bg-white py-12 sm:py-16" aria-labelledby="im1-audience">
+        <div className={sectionClass}>
+          <h2 id="im1-audience" className={h2Class}>
+            {copy.audience.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.audience.intro}</p>
+          <BulletList items={copy.audience.items} />
+          <p className="mt-6 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.audience.closing}</p>
+        </div>
+      </section>
+
+      <section className="bg-slate-50/80 py-12 sm:py-16" aria-labelledby="im1-why-growwise">
+        <div className={sectionClass}>
+          <h2 id="im1-why-growwise" className={h2Class}>
+            {copy.whyGrowWise.heading}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.whyGrowWise.intro}</p>
+          <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">{copy.whyGrowWise.body}</p>
+          <p className="mt-4 text-sm font-semibold text-slate-900 sm:text-base">{copy.whyGrowWise.subheading}</p>
+          <BulletList items={copy.whyGrowWise.items} />
+        </div>
+      </section>
+
+      <section className="bg-[#1F396D] py-14 sm:py-16" aria-labelledby="im1-cta">
+        <div className={cn(sectionClass, 'text-center')}>
+          <h2 id="im1-cta" className="font-heading text-2xl font-bold text-white sm:text-3xl">
+            {copy.cta.heading}
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-white/90 sm:text-base">{copy.cta.subtext}</p>
+          <div className="mx-auto mt-6 max-w-xl text-left">
+            <ContactStrip variant="footer" />
+            <dl className="mt-4 space-y-2 text-sm text-white/90 sm:text-base">
+              <div>
+                <dt className="inline font-semibold text-white">{copy.cta.programLabel}: </dt>
+                <dd className="inline">{copy.cta.program}</dd>
+              </div>
+              <div>
+                <dt className="inline font-semibold text-white">{copy.cta.formatLabel}: </dt>
+                <dd className="inline">{copy.cta.format}</dd>
+              </div>
+            </dl>
+          </div>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Button
+              type="button"
+              onClick={() => setIsAssessmentModalOpen(true)}
+              className="min-h-[48px] w-full max-w-xs rounded-lg bg-[#F16112] px-6 text-sm font-semibold text-white hover:bg-[#d54f0a] sm:w-auto sm:text-base"
+            >
+              {copy.cta.assessmentCta}
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="min-h-[48px] w-full max-w-xs rounded-lg border-white bg-transparent px-6 text-sm font-semibold text-white hover:bg-white/10 sm:w-auto sm:text-base"
+            >
+              <Link href={phoneHref}>{copy.hero.phoneLabel}: {copy.hero.phone}</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section id="faq" className="border-t border-slate-100 bg-slate-50/60 py-14 sm:py-16">
+        <div className="mx-auto max-w-4xl px-4 sm:px-6">
+          <h2 className="text-center font-heading text-2xl font-bold text-slate-900 md:text-3xl">
+            Frequently Asked <span className="text-[#F16112]">Questions</span>
+          </h2>
+          <div className="mt-10 space-y-3">
+            <Accordion type="multiple" className="w-full" defaultValue={defaultOpenFaqs}>
+              {INTEGRATED_MATH_1_DUBLIN_CA_FAQS.map((item, idx) => (
+                <AccordionItem
+                  key={item.question}
+                  value={`im1-faq-${idx}`}
+                  className="overflow-hidden rounded-xl border-0 bg-white shadow-sm ring-1 ring-slate-200/90"
+                >
+                  <AccordionTrigger className="px-4 py-4 text-left hover:no-underline sm:px-5">
+                    <span className="flex items-center gap-3">
+                      <span
+                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#F16112]/10 ring-1 ring-[#F16112]/15"
+                        aria-hidden
+                      >
+                        <HelpCircle className="h-4 w-4 text-[#F16112]" />
+                      </span>
+                      <span className="text-sm font-semibold text-slate-900 sm:text-base">{item.question}</span>
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent className="px-4 pb-5 text-sm leading-relaxed text-slate-600 sm:px-5 sm:text-base">
+                    {item.answer}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </div>
+      </section>
+
+      <RelatedContent locale={locale} />
+
+      <FreeAssessmentModal isOpen={isAssessmentModalOpen} onClose={() => setIsAssessmentModalOpen(false)} />
+    </main>
+  )
+}

--- a/src/components/layout/Footer/FooterFindUsOn.tsx
+++ b/src/components/layout/Footer/FooterFindUsOn.tsx
@@ -34,6 +34,7 @@ export default function FooterFindUsOn() {
               alt={badge.imageAlt}
               width={120}
               height={60}
+              unoptimized={badge.unoptimized}
               sizes="(max-width: 768px) 33vw, 120px"
               className="h-[60px] w-auto max-w-full object-contain"
             />

--- a/src/components/layout/Header/MobileNavigation.tsx
+++ b/src/components/layout/Header/MobileNavigation.tsx
@@ -72,13 +72,14 @@ export default function MobileNavigation({
   const filteredMenuItems = usableMenuItems.filter(
     (item) => item.key !== 'enroll' && item.visible !== false
   );
-  const hideDrawerAskGrowy = isCampSeoLandingPath(pathname);
+  const isCampSeo = isCampSeoLandingPath(pathname);
+  const hideDrawerAskGrowy = isCampSeo;
 
   return (
     <>
       {/* Mobile menu button & cart icon */}
       <div className="lg:hidden flex items-center gap-2 z-[55] relative">
-        <HeaderChatbotTrigger variant="compact" />
+        {isCampSeo ? <HeaderChatbotTrigger variant="compact" /> : null}
         {showCart && (
           <Link
             href={createLocaleUrl('/cart')}

--- a/src/data/footerTrustBadges.ts
+++ b/src/data/footerTrustBadges.ts
@@ -4,6 +4,8 @@ export type TrustBadge = {
   imageSrc: string;
   imageAlt: string;
   showOnHome: boolean;
+  /** Remote SVG badges must bypass Next.js image optimization (returns 400 for SVG). */
+  unoptimized?: boolean;
 };
 
 export const FOOTER_TRUST_BADGES: TrustBadge[] = [
@@ -13,6 +15,7 @@ export const FOOTER_TRUST_BADGES: TrustBadge[] = [
     imageSrc: 'https://patch.com/api_v1/bizpost/526397/badge',
     imageAlt: 'GrowWise on Patch',
     showOnHome: true,
+    unoptimized: true,
   },
   {
     id: 'activityhero',

--- a/src/data/integrated-math-1-dublin-ca-copy.ts
+++ b/src/data/integrated-math-1-dublin-ca-copy.ts
@@ -1,0 +1,184 @@
+import { CONTACT_INFO } from '@/lib/constants'
+
+export type IntegratedMath1TopicSection = {
+  title: string
+  leadIn: string
+  items: readonly string[]
+}
+
+export const INTEGRATED_MATH_1_DUBLIN_CA_COPY = {
+  hero: {
+    h1: 'Integrated Math 1 Tutoring in Dublin, CA',
+    subtext: 'Help your student stop guessing and start understanding Math 1.',
+    intro: [
+      'Integrated Math 1 is a major shift for many students. It does not feel like one simple math class. Students are expected to connect algebra, functions, graphs, equations, geometry, data, and word problems — often in the same unit.',
+      'At GrowWise School in Dublin, we help students build the skills and reasoning needed for Integrated Math 1, not just finish homework.',
+      'Our focus is simple: find the pattern behind mistakes, fix the weak skill, and help students explain their work clearly.',
+    ],
+    phoneLabel: 'Call/Text',
+    phone: CONTACT_INFO.phone,
+    locationLabel: 'Location',
+    location: `GrowWise School, ${CONTACT_INFO.street}, ${CONTACT_INFO.city}`,
+    assessmentCta: 'Book a Free Assessment',
+  },
+  struggleSigns: {
+    heading: 'Is your child struggling with Integrated Math 1?',
+    intro:
+      'Many students do not struggle because they are “bad at math.” They struggle because Math 1 requires several skills to work together.',
+    subheading: 'Common signs include:',
+    items: [
+      'They can solve basic problems but struggle with word problems.',
+      'They understand steps in class but make repeated errors on tests.',
+      'They confuse slope, rate of change, and graph interpretation.',
+      'They make sign mistakes in equations or inequalities.',
+      'They struggle with systems of equations.',
+      'They cannot explain why an answer makes sense.',
+      'They rush and call everything a “silly mistake.”',
+      'They had gaps from pre-algebra, Algebra 1 foundations, or middle school math.',
+    ],
+    closing:
+      'When these patterns are not fixed early, Integrated Math 1 becomes harder as the course moves into functions, systems, exponential models, geometry, and proofs.',
+  },
+  coverage: {
+    heading: 'What we cover in Integrated Math 1 support',
+    intro: 'GrowWise Math 1 support is built around the real skill areas students need.',
+    topics: [
+      {
+        title: 'Algebra Foundations',
+        leadIn: 'Students strengthen:',
+        items: [
+          'Multi-step equations',
+          'Variables on both sides',
+          'Inequalities',
+          'Distributive property',
+          'Absolute value basics',
+          'Sign rules',
+          'Translating word problems into equations',
+        ],
+      },
+      {
+        title: 'Functions and Graphs',
+        leadIn: 'Students learn how to work with:',
+        items: [
+          'Function notation',
+          'Linear functions',
+          'Slope and rate of change',
+          'Slope-intercept form',
+          'Point-slope form',
+          'Standard form',
+          'Graph interpretation',
+          'Comparing tables, graphs, and equations',
+        ],
+      },
+      {
+        title: 'Systems of Equations',
+        leadIn: 'Students practice:',
+        items: [
+          'Solving by graphing',
+          'Solving by substitution',
+          'Solving by elimination',
+          'Word problems with systems',
+          'Checking whether an answer makes sense',
+        ],
+      },
+      {
+        title: 'Exponential Thinking',
+        leadIn: 'Students build understanding of:',
+        items: [
+          'Exponents',
+          'Growth and decay',
+          'Linear vs. exponential patterns',
+          'Geometric sequences',
+          'Real-world exponential models',
+        ],
+      },
+      {
+        title: 'Geometry and Reasoning',
+        leadIn: 'Students work on:',
+        items: [
+          'Transformations',
+          'Congruent triangles',
+          'Coordinate geometry',
+          'Distance and midpoint',
+          'Area and perimeter on the coordinate plane',
+          'Basic reasoning and proof-style explanations',
+        ],
+      },
+      {
+        title: 'Data and Word Problems',
+        leadIn: 'Students learn how to:',
+        items: [
+          'Read math problems carefully',
+          'Identify what is being asked',
+          'Choose the right operation or model',
+          'Interpret graphs and data',
+          'Explain their answer in complete mathematical reasoning',
+        ],
+      },
+    ] as const satisfies readonly IntegratedMath1TopicSection[],
+  },
+  approach: {
+    heading: 'Our approach: mistake-pattern correction',
+    intro: 'Most students do not need random extra worksheets.',
+    subheading: 'They need to know which mistake pattern is blocking them.',
+    body: 'At GrowWise, we look for patterns such as:',
+    patterns: [
+      'Rushing through steps',
+      'Skipping setup',
+      'Misreading the question',
+      'Weak number sense',
+      'Sign errors',
+      'Fraction or decimal confusion',
+      'Graph interpretation errors',
+      'Not checking the final answer',
+      'Weak explanation skills',
+    ],
+    closing:
+      'Once we identify the pattern, we teach students how to correct it with targeted practice.',
+  },
+  audience: {
+    heading: 'Who this program is for',
+    intro: 'This Integrated Math 1 support is a good fit for:',
+    items: [
+      'Students currently taking Integrated Math 1',
+      'Students entering Integrated Math 1 next school year',
+      'Advanced middle school students preparing for high school math',
+      'Students who need help before finals',
+      'Students who understand lessons but lose points on tests',
+      'Students who need stronger algebra, graphing, and word-problem skills',
+    ],
+    closing:
+      'This is especially useful for families in Dublin, Pleasanton, San Ramon, Livermore, and nearby Tri-Valley areas looking for structured math support.',
+  },
+  whyGrowWise: {
+    heading: 'Why GrowWise School',
+    intro:
+      'GrowWise School is a Dublin-based learning center focused on academic skill-building, reasoning, and clear explanations.',
+    body: 'We do not just help students get through homework. We help them understand the “why” behind each step.',
+    subheading: 'Students are guided to:',
+    items: [
+      'Show organized work',
+      'Explain reasoning clearly',
+      'Catch repeated mistakes',
+      'Connect graphs, equations, and word problems',
+      'Build stronger test-readiness habits',
+    ],
+  },
+  cta: {
+    heading: 'Get Integrated Math 1 support before small gaps become bigger problems.',
+    subtext: 'Call or text GrowWise School to discuss your child’s Math 1 needs.',
+    phoneLabel: 'Call/Text',
+    locationLabel: 'Location',
+    location: `${CONTACT_INFO.street}, ${CONTACT_INFO.city}`,
+    programLabel: 'Program',
+    program: 'Integrated Math 1 Tutoring / Math 1 Support',
+    formatLabel: 'Format',
+    format: 'Small-group or targeted academic support',
+    assessmentCta: 'Book a Free Assessment',
+  },
+} as const
+
+export const INTEGRATED_MATH_1_DUBLIN_CA_PATH = '/courses/integrated-math-1-dublin-ca' as const
+
+export const INTEGRATED_MATH_1_DUBLIN_CA_DESCRIPTION =
+  'Integrated Math 1 tutoring in Dublin, CA. Algebra, functions, systems, and word problems. Small groups. Book a free assessment.'

--- a/src/data/integrated-math-1-dublin-ca-faqs.ts
+++ b/src/data/integrated-math-1-dublin-ca-faqs.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared FAQ copy for Integrated Math 1 tutoring (visible accordion + JSON-LD).
+ */
+export const INTEGRATED_MATH_1_DUBLIN_CA_FAQS: ReadonlyArray<{
+  question: string
+  answer: string
+}> = [
+  {
+    question: 'What is Integrated Math 1?',
+    answer:
+      'Integrated Math 1 is a high school math course that combines algebra, functions, graphs, geometry, data, and problem-solving. Instead of teaching algebra and geometry as fully separate courses, Integrated Math connects topics across the year.',
+  },
+  {
+    question: 'Is Integrated Math 1 the same as Algebra 1?',
+    answer:
+      'Not exactly. Integrated Math 1 includes many Algebra 1 skills, such as equations, inequalities, functions, and systems, but it also includes geometry, data analysis, transformations, and reasoning.',
+  },
+  {
+    question: 'What grade is Integrated Math 1 usually for?',
+    answer:
+      'Many students take Integrated Math 1 around 8th or 9th grade, depending on their school district math pathway and placement.',
+  },
+  {
+    question: 'What topics are hardest in Integrated Math 1?',
+    answer:
+      'Common challenge areas include slope, functions, systems of equations, word problems, exponential patterns, graph interpretation, transformations, and proof-style reasoning.',
+  },
+  {
+    question: 'How do I know if my child needs Integrated Math 1 help?',
+    answer:
+      'Your child may need support if they understand class lessons but lose points on tests, make repeated mistakes, struggle with word problems, confuse graphs and equations, or cannot explain their work clearly.',
+  },
+  {
+    question: 'Does GrowWise help with school homework?',
+    answer:
+      'Yes, but the goal is not just homework completion. GrowWise uses homework and class topics to identify the real skill gaps and mistake patterns behind the struggle.',
+  },
+  {
+    question: 'Can GrowWise help before a Math 1 final?',
+    answer:
+      'Yes. Integrated Math 1 finals often require students to connect multiple topics, so review should focus on skill patterns, not just isolated questions.',
+  },
+  {
+    question: 'Is this only for Dublin students?',
+    answer:
+      'No. GrowWise School is located in Dublin, CA, and supports students from Dublin, Pleasanton, San Ramon, Livermore, and nearby Tri-Valley communities.',
+  },
+]

--- a/src/i18n/messages/academic-summer-programs-en.json
+++ b/src/i18n/messages/academic-summer-programs-en.json
@@ -75,9 +75,9 @@
     "seoLinks": {
       "readToProve": "Read to Prove program details →",
       "writeWithStructure": "Write to Explain program details →",
-      "mistakeProofMath": "Summer math foundations program in Dublin, CA",
-      "algebra1GetReady": "Summer algebra program in Dublin, CA",
-      "geometryGetReady": "Summer geometry program in Dublin, CA"
+      "mistakeProofMath": "Bridge the Gap Math program details →",
+      "algebra1GetReady": "Algebra Get Ready program details →",
+      "geometryGetReady": "Geometry Get Ready program details →"
     }
   },
   "howItWorks": {

--- a/src/i18n/messages/academic-summer-programs-en.json
+++ b/src/i18n/messages/academic-summer-programs-en.json
@@ -71,6 +71,12 @@
         "heading": "Math Get Ready programs",
         "subtext": "IM1, Algebra, and Geometry prep · Mon/Wed/Fri evenings · Starts July 20 · From $249"
       }
+    },
+    "seoLinks": {
+      "readingWritingPrograms": "Summer reading & writing program in Dublin, CA",
+      "mistakeProofMath": "Summer math foundations program in Dublin, CA",
+      "algebra1GetReady": "Summer algebra program in Dublin, CA",
+      "geometryGetReady": "Summer geometry program in Dublin, CA"
     }
   },
   "howItWorks": {

--- a/src/i18n/messages/academic-summer-programs-en.json
+++ b/src/i18n/messages/academic-summer-programs-en.json
@@ -73,7 +73,8 @@
       }
     },
     "seoLinks": {
-      "readingWritingPrograms": "Summer reading & writing program in Dublin, CA",
+      "readToProve": "Read to Prove program details →",
+      "writeWithStructure": "Write to Explain program details →",
       "mistakeProofMath": "Summer math foundations program in Dublin, CA",
       "algebra1GetReady": "Summer algebra program in Dublin, CA",
       "geometryGetReady": "Summer geometry program in Dublin, CA"

--- a/src/i18n/messages/summer-algebra-dublin-ca-en.json
+++ b/src/i18n/messages/summer-algebra-dublin-ca-en.json
@@ -1,0 +1,103 @@
+{
+  "hero": {
+    "eyebrow": "Summer 2026 · Dublin, CA · Grades 7–8",
+    "h1": "Summer Algebra Program in Dublin, CA",
+    "subtext": "Build Algebra 1 foundations before school starts. DUSD aligned, small groups of max 8 students, Mon/Wed/Fri evenings so it doesn't take over their summer.",
+    "ctaLabel": "View schedule & pricing →"
+  },
+  "keyDetails": [
+    "Mon/Wed/Fri evenings",
+    "5:00–6:30 PM",
+    "Max 8 students",
+    "100% DUSD aligned",
+    "Starts June 15"
+  ],
+  "bodySections": {
+    "whatYourChildWillWorkOn": {
+      "heading": "What your child will work on",
+      "subsections": [
+        {
+          "h3": "Algebra 1 Get Ready — Week by Week",
+          "weeks": [
+            {
+              "title": "Week 1 — Foundations of Algebra:",
+              "body": "The first week covers the conceptual shift from arithmetic to algebraic thinking — variables, expressions, and what an equation actually means. Students work through linear equations with one variable, learning to isolate the unknown using inverse operations. The instructor checks for common misconceptions (sign errors, distribution mistakes) and addresses them directly before they become habits."
+            },
+            {
+              "title": "Week 2 — Functions, graphing, and word problems:",
+              "body": "Week 2 introduces functions — what they are, how to identify them, and how to represent them as tables, graphs, and equations. Students practice translating word problems into algebraic expressions and equations, which is consistently the hardest skill for students entering Algebra 1. By the end of Week 2, students have a working familiarity with the core topics that appear in the first month of Algebra 1 class."
+            }
+          ]
+        }
+      ]
+    },
+    "whoTeaches": {
+      "heading": "Who teaches this program",
+      "body": "Algebra 1 Get Ready is led by a math instructor specifically trained in DUSD's Algebra 1 curriculum sequence. The instructor knows what DUSD teachers expect on Day 1 of Algebra 1 and structures the sprint to give students a meaningful head start on those exact expectations. With a maximum of 8 students, the instructor can identify and correct each student's specific misconceptions — not just deliver content to a group."
+    },
+    "whoIsRightFor": {
+      "heading": "Who this is right for",
+      "groups": [
+        {
+          "label": "Algebra 1 Get Ready is right for your child if:",
+          "items": [
+            "They are entering Algebra 1 (Grade 7 or 8) in the Dublin Unified or Pleasanton Unified school system",
+            "They completed pre-Algebra but are not confident in their foundations",
+            "They tend to make consistent errors on equations (sign errors, order of operations)",
+            "You want them to start the year ahead — not catching up in September",
+            "Their teacher recommended strengthening math before the next school year"
+          ]
+        }
+      ]
+    },
+    "whyGrowWise": {
+      "heading": "Why GrowWise for Algebra",
+      "body": "Algebra 1 is the course that sets a student's math trajectory through high school. Students who start strong tend to stay strong. Students who start behind tend to fall further behind as the year progresses. Dublin and Pleasanton families know this — and the demand for focused Algebra 1 prep in the Tri-Valley is exactly why GrowWise built this program. Small group, subject-trained instructor, DUSD aligned, evening format. Designed for the reality of a Tri-Valley summer — not a full-day commitment."
+    }
+  },
+  "mainCta": {
+    "headline": "Ready to reserve a spot?",
+    "subtext": "Select your cohort on the full program page.",
+    "button": "View full schedule & pricing →"
+  },
+  "relatedPrograms": {
+    "heading": "Related summer programs",
+    "hubLinkLabel": "View all programs & pricing →",
+    "items": {
+      "mathFoundations": {
+        "label": "Summer Math Foundations",
+        "description": "Fractions or word-problem gaps first?"
+      },
+      "geometry": {
+        "label": "Geometry Get Ready",
+        "description": "Next step after Algebra 1"
+      },
+      "readingWriting": {
+        "label": "Summer Reading & Writing",
+        "description": "Daily reading & writing sprints · Grades 1–8"
+      }
+    }
+  },
+  "faq": [
+    {
+      "question": "Is this program 100% DUSD aligned?",
+      "answer": "Yes. Algebra 1 Get Ready follows the Dublin Unified School District Algebra 1 curriculum sequence — equations, functions, graphing, and inequalities — so students enter the school year already familiar with what their teacher will cover."
+    },
+    {
+      "question": "Why evenings instead of mornings?",
+      "answer": "Evening sessions (5:00–6:30 PM) mean students keep their daytime free for other activities — and parents can drop off after work. The format is identical to morning sessions: 60 minutes of instruction plus 30 minutes guided practice lab."
+    },
+    {
+      "question": "What is the difference between Cohort 1 and Cohort 2?",
+      "answer": "Both cohorts cover the same Algebra 1 curriculum. Cohort 1 runs June 15–26. Cohort 2 runs June 30–July 11. Parents choose whichever 2-week slot fits their schedule. Enrolling in both cohorts gives 11 sessions of total practice (July 4 holiday observed)."
+    },
+    {
+      "question": "My child is in Grade 8 taking Algebra 1 — is this too easy for them?",
+      "answer": "Algebra 1 Get Ready is paced for students who have not yet taken Algebra 1 and want to prepare for it. If your child is currently in Algebra 1 and needs support with specific topics mid-course, contact us at (925) 456-4606 to discuss whether Bridge the Gap Math or a year-round tutoring program would be a better fit."
+    },
+    {
+      "question": "How does the evening format affect the quality of instruction?",
+      "answer": "The evening format (5:00–6:30 PM, Mon/Wed/Fri) is identical in structure and quality to our morning programs — 60 minutes of focused instruction followed by 30 minutes of guided practice. The evening time was chosen specifically so it does not compete with daytime summer activities and allows working parents to drop off after work."
+    }
+  ]
+}

--- a/src/i18n/messages/summer-geometry-precalculus-dublin-ca-en.json
+++ b/src/i18n/messages/summer-geometry-precalculus-dublin-ca-en.json
@@ -1,0 +1,115 @@
+{
+  "hero": {
+    "eyebrow": "Summer 2026 · Dublin, CA · Grades 9–10",
+    "h1": "Summer Geometry Program in Dublin, CA",
+    "subtext": "Prepare for Geometry before school starts. Proofs, triangles, coordinate geometry — DUSD aligned, small groups, Mon/Wed/Fri evenings.",
+    "ctaLabel": "View schedule & pricing →"
+  },
+  "keyDetails": [
+    "Mon/Wed/Fri evenings",
+    "5:00–6:30 PM",
+    "Max 8 students",
+    "100% DUSD aligned",
+    "Starts June 15"
+  ],
+  "bodySections": {
+    "whatYourChildWillWorkOn": {
+      "heading": "What your child will work on",
+      "subsections": [
+        {
+          "h3": "Geometry Get Ready — Week by Week",
+          "weeks": [
+            {
+              "title": "Week 1 — Proof-based thinking:",
+              "body": "Geometry is the first course most students encounter that requires formal logical reasoning. Week 1 introduces the language and structure of geometric proof — definitions, postulates, and theorems — and how to use them to justify conclusions. Students work through triangle congruence and basic angle relationships, learning to write two-column proofs with the instructor modeling each step before students attempt independently."
+            },
+            {
+              "title": "Week 2 — Similarity, circles, and coordinate geometry:",
+              "body": "Week 2 expands into similarity, the Pythagorean theorem in coordinate contexts, and basic circle properties. These are the topics that appear most frequently in the first month of a DUSD Geometry course. By the end of Week 2, students understand the logical structure of Geometry and have practiced the core proof types they will encounter on their first assessments."
+            }
+          ]
+        }
+      ]
+    },
+    "whoTeaches": {
+      "heading": "Who teaches this program",
+      "body": "Geometry Get Ready is led by a math instructor trained specifically in DUSD's Geometry curriculum. The instructor understands the shift from algebraic to geometric thinking that trips up even strong Algebra students — and structures the sprint to close that gap before school starts. With a maximum of 8 students, every session includes direct feedback on each student's proof writing, not just whole-group instruction."
+    },
+    "whoIsRightFor": {
+      "heading": "Who this is right for",
+      "groups": [
+        {
+          "label": "Geometry Get Ready is right for your child if:",
+          "items": [
+            "They completed Algebra 1 and are starting Geometry in the fall at a DUSD or PUSD school",
+            "They are strong in algebra but have never encountered proof-based reasoning",
+            "They tend to understand math procedurally but struggle when asked to explain their reasoning",
+            "You want them to start Geometry without the disorientation most students feel in the first few weeks"
+          ]
+        }
+      ],
+      "notRightFor": {
+        "label": "Geometry Get Ready is not the right fit if:",
+        "items": [
+          "Your child still needs Algebra 1 support — see our Algebra 1 Get Ready program",
+          "They are looking for a credit-bearing course — this is a prep sprint only"
+        ]
+      }
+    },
+    "whyGrowWise": {
+      "heading": "Why GrowWise for Geometry",
+      "body": "Geometry is consistently one of the courses Tri-Valley parents ask us about most — because it is the first time many strong math students struggle. The shift to proof-based reasoning is genuinely different from everything they have done before in math. GrowWise Geometry Get Ready was built specifically to ease that transition — with a DUSD-aligned curriculum, a subject-trained instructor, and a small-group format that gives every student real feedback on their proof writing before the grade counts."
+    }
+  },
+  "summerCampCallout": {
+    "text": "Also at GrowWise: Advanced Math (Algebra II + Precalculus) — weekly camp format for Grades 8–11.",
+    "linkLabel": "View summer STEAM camps →",
+    "href": "/camps/summer"
+  },
+  "valueAnchorPrefix": "District summer Geometry programs often cost significantly more. GrowWise Get Ready Sprint starts from",
+  "mainCta": {
+    "headline": "Ready to reserve a spot?",
+    "subtext": "Select your cohort on the full program page.",
+    "button": "View full schedule & pricing →"
+  },
+  "relatedPrograms": {
+    "heading": "Related summer programs",
+    "hubLinkLabel": "View all programs & pricing →",
+    "items": {
+      "algebra": {
+        "label": "Algebra 1 Get Ready",
+        "description": "Algebra 1 support before Geometry"
+      },
+      "mathFoundations": {
+        "label": "Summer Math Foundations",
+        "description": "Foundational math gaps · Grades 1–8"
+      },
+      "readingWriting": {
+        "label": "Summer Reading & Writing",
+        "description": "Daily reading & writing · Grades 1–8"
+      }
+    }
+  },
+  "faq": [
+    {
+      "question": "What Geometry topics does this program cover?",
+      "answer": "Geometry Get Ready covers proof-based reasoning, triangle congruence and similarity, coordinate geometry, circles, and spatial thinking — all aligned to the DUSD Geometry curriculum sequence."
+    },
+    {
+      "question": "Is this a credit-bearing course?",
+      "answer": "No. Geometry Get Ready is a focused prep sprint — not a credit-bearing course. It prepares students to start Geometry with confidence, not to replace the course itself. For credit-bearing options, contact Dublin Unified School District directly."
+    },
+    {
+      "question": "My child finished Algebra 1. Are they ready for this program?",
+      "answer": "Yes. Geometry Get Ready is designed for students who have completed Algebra 1 and are starting Geometry in the fall. If your child needs Algebra 1 support first, see our Algebra 1 Get Ready program at /camps/summer-algebra-dublin-ca."
+    },
+    {
+      "question": "My child is strong in math — will this be too easy?",
+      "answer": "Geometry Get Ready is designed to be substantive, not remedial. Proof-based reasoning is genuinely challenging for most students regardless of how strong they are in algebra. Even high-performing math students benefit from an introduction to geometric proof before they encounter it in a graded class environment. The small group format (max 8 students) means the instructor can calibrate to the group's level and push further when the group is ready."
+    },
+    {
+      "question": "Does this program also cover Pre-Calculus?",
+      "answer": "Geometry Get Ready focuses specifically on Geometry content — proofs, triangle congruence and similarity, coordinate geometry, and circles. GrowWise also offers Advanced Math (Algebra II + Precalculus) as a separate weekly summer camp program. See the Advanced Math camp on our summer programs page for details."
+    }
+  ]
+}

--- a/src/i18n/messages/summer-math-foundations-dublin-ca-en.json
+++ b/src/i18n/messages/summer-math-foundations-dublin-ca-en.json
@@ -1,0 +1,108 @@
+{
+  "hero": {
+    "eyebrow": "Summer 2026 · Dublin, CA · Grades 1–8",
+    "h1": "Summer Math Program in Dublin, CA",
+    "subtext": "Fix math gaps before school starts. Small-group daily instruction in fractions, word problems, and grade readiness — 90 min/day, max 8 students, DUSD aligned.",
+    "ctaLabel": "View schedule & pricing →"
+  },
+  "keyDetails": ["90 min/day", "Max 8 students", "Starts June 15", "DUSD aligned", "4564 Dublin Blvd"],
+  "bodySections": {
+    "whatYourChildWillWorkOn": {
+      "heading": "What your child will work on",
+      "subsections": [
+        {
+          "h3": "Bridge the Gap Math — Week by Week",
+          "weeks": [
+            {
+              "title": "Week 1 — Finding the gap:",
+              "body": "The first week begins with a structured diagnostic — not a test, but a set of problem types that reveal exactly where a student's math understanding breaks down. From there, the instructor builds daily lessons around the specific gaps most common to that group: fractions, decimals, multi-step operations, or place value. Students work through problems in class with instructor support before practicing independently in the 30-minute practice lab."
+            },
+            {
+              "title": "Week 2 — Building the next step:",
+              "body": "In Week 2, instruction shifts from identifying gaps to applying skills in context — particularly word problems, which require students to identify what operation is needed, set up the problem correctly, and check their work. By the end of Week 2, students have a clearer sense of where they were stuck and how to get unstuck independently."
+            }
+          ]
+        }
+      ]
+    },
+    "whoTeaches": {
+      "heading": "Who teaches this program",
+      "body": "Bridge the Gap Math is led by a subject-trained math instructor experienced with elementary and middle school curriculum. The instructor is familiar with DUSD and Common Core grade-level expectations and structures each session around the skills students most commonly lack entering the next grade. With a maximum of 8 students per group, instruction is specific — not one-size-fits-all."
+    },
+    "whoIsRightFor": {
+      "heading": "Who this is right for",
+      "groups": [
+        {
+          "label": "Bridge the Gap Math is right for your child if:",
+          "items": [
+            "They passed their grade level but you are not confident the skills are solid",
+            "Fractions, decimals, or word problems consistently cause frustration",
+            "Their teacher mentioned they are \"almost there\" but need more practice",
+            "They are entering a new school or grade level in the fall and you want them ready",
+            "They freeze when a math problem has more than one step"
+          ]
+        }
+      ],
+      "notRightFor": {
+        "label": "Bridge the Gap Math is not the right fit if:",
+        "items": [
+          "Your child needs support specifically with IM1, Algebra 1, or Geometry — those have dedicated Get Ready Sprint programs running in the evenings"
+        ]
+      }
+    },
+    "whyGrowWise": {
+      "heading": "Why GrowWise for math foundations",
+      "body": "For Tri-Valley families, the stakes of math gaps are real — DUSD's progression from elementary math into IM1 and Algebra 1 moves quickly, and small gaps compound year over year. Bridge the Gap Math is designed specifically to address those foundational gaps before they affect performance in middle school math. It is not a drill-and-repeat program. It is structured, instructor-led, small-group instruction — the same format used in GrowWise's year-round math programs serving Dublin, Pleasanton, San Ramon, and Livermore families."
+    }
+  },
+  "programCardOverrides": {
+    "bridge-the-gap-math": {
+      "tagline": "Find the missing skill. Build the next step."
+    }
+  },
+  "mainCta": {
+    "headline": "Ready to reserve a spot?",
+    "subtext": "Select your cohort and grade band on the full program page.",
+    "button": "View full schedule & pricing →"
+  },
+  "relatedPrograms": {
+    "heading": "Related summer programs",
+    "hubLinkLabel": "View all programs & pricing →",
+    "items": {
+      "readingWriting": {
+        "label": "Summer Reading & Writing",
+        "description": "Read to Prove & Write to Explain · Grades 1–8"
+      },
+      "algebra": {
+        "label": "Algebra 1 Get Ready",
+        "description": "Starting Algebra 1 in fall?"
+      },
+      "geometry": {
+        "label": "Geometry Get Ready",
+        "description": "Proofs & spatial reasoning prep · Grades 9–10"
+      }
+    }
+  },
+  "faq": [
+    {
+      "question": "What math topics does Bridge the Gap Math cover?",
+      "answer": "Bridge the Gap Math covers fractions, decimals, word problems, multi-step math, and grade-level readiness skills. The instructor identifies gaps specific to each student's grade and focuses instruction on the most critical missing skills."
+    },
+    {
+      "question": "How is this different from Mathnasium or a tutoring center?",
+      "answer": "Bridge the Gap Math is a structured 2-week sprint with a defined DUSD-aligned curriculum, a daily schedule, and a subject-trained instructor — not ongoing drop-in sessions. Max 8 students means your child gets real attention, not a worksheet in a crowded room."
+    },
+    {
+      "question": "My child is entering Grade 7. Should they take Bridge the Gap Math or IM1 Get Ready?",
+      "answer": "If your child has foundational gaps in fractions or multi-step math, start with Bridge the Gap Math (Grades 1–8, mornings). If they are specifically entering Grade 7 accelerated math (IM1), IM1 Get Ready is the right fit (evenings, DUSD aligned). Contact us if you are unsure."
+    },
+    {
+      "question": "What grade levels does Bridge the Gap Math actually serve?",
+      "answer": "Bridge the Gap Math serves Grades 1–8. Instruction is grouped by skill level within the session. A Grade 4 student working on fractions and a Grade 6 student working on ratios may be in the same group if their gaps are in a similar foundational area. The instructor differentiates within the group as needed."
+    },
+    {
+      "question": "Is there homework or take-home work after each session?",
+      "answer": "No homework is assigned. The 30-minute guided practice lab at the end of each session serves as the practice component — students complete it with the instructor still in the room so questions can be answered on the spot. Parents do not need to supervise math work at home."
+    }
+  ]
+}

--- a/src/i18n/messages/summer-reading-writing-dublin-ca-en.json
+++ b/src/i18n/messages/summer-reading-writing-dublin-ca-en.json
@@ -1,0 +1,118 @@
+{
+  "hero": {
+    "eyebrow": "Summer 2026 · Dublin, CA · Grades 1–8",
+    "h1": "Summer Reading & Writing Programs in Dublin, CA",
+    "subtext": "Focused daily instruction in reading comprehension and writing — not a camp, not tutoring. A 2-week academic sprint for Grades 1–8 in small groups of max 8 students.",
+    "ctaLabel": "View schedule & pricing →"
+  },
+  "keyDetails": ["90 min/day", "Max 8 students", "Starts June 15", "4564 Dublin Blvd"],
+  "bodySections": {
+    "whatYourChildWillWorkOn": {
+      "heading": "What your child will work on",
+      "subsections": [
+        {
+          "h3": "Read to Prove — Week by Week",
+          "weeks": [
+            {
+              "title": "Week 1 — Finding the evidence:",
+              "body": "Students learn to identify the main idea in a passage and locate the specific sentences that support it. The instructor models how to distinguish relevant evidence from detail — a skill most comprehension tests measure directly. Students practice with grade-level nonfiction and fiction texts, writing short written responses using the evidence they find."
+            },
+            {
+              "title": "Week 2 — Proving the answer:",
+              "body": "Students apply what they built in Week 1 to multi-paragraph texts and longer reading passages. Focus shifts to inference — answering questions the text doesn't state directly but implies. By the end of Week 2, students leave with a repeatable method for approaching any comprehension question."
+            }
+          ]
+        },
+        {
+          "h3": "Write to Explain — Week by Week",
+          "weeks": [
+            {
+              "title": "Week 1 — Building the sentence:",
+              "body": "Students work on the mechanics of clear writing — complete sentences, subject-verb agreement, and how to write a topic sentence that actually tells the reader something. The instructor identifies common errors in each student's writing and addresses them directly."
+            },
+            {
+              "title": "Week 2 — Building the paragraph and beyond:",
+              "body": "Students expand single sentences into structured paragraphs using a consistent format — topic sentence, supporting details, closing sentence. By the end of Week 2, students can write a short multi-paragraph response with a clear structure and minimal errors."
+            }
+          ]
+        }
+      ]
+    },
+    "whoTeaches": {
+      "heading": "Who teaches this program",
+      "body": "Read to Prove and Write to Explain are led by subject-trained reading and writing instructors — not general camp counselors. Each instructor has direct experience teaching literacy at the grade levels they cover. Groups are capped at 8 students so the instructor can give specific feedback to each student's work, not just general instruction to the group."
+    },
+    "whoIsRightFor": {
+      "heading": "Who this is right for",
+      "groups": [
+        {
+          "label": "Read to Prove is right for your child if:",
+          "items": [
+            "They score lower on reading comprehension than on vocabulary or fluency",
+            "They struggle to answer \"how do you know?\" questions",
+            "They read every word but still miss the main idea",
+            "Their teacher has flagged text evidence as a weakness"
+          ]
+        },
+        {
+          "label": "Write to Explain is right for your child if:",
+          "items": [
+            "They say \"I don't know what to write\" when given a prompt",
+            "Their writing is one or two sentences when a paragraph is expected",
+            "They write the ideas but not in a clear order",
+            "Their essays lack a clear beginning, middle, and end"
+          ]
+        }
+      ]
+    },
+    "whyGrowWise": {
+      "heading": "Why GrowWise for reading and writing",
+      "body": "Dublin and Pleasanton families have strong academic expectations — and summer reading and writing programs in the Tri-Valley tend to fall into one of two extremes: full-day camps with light academic content, or expensive one-on-one tutoring. GrowWise Academic Summer Sprint is neither. It is a structured 90-minute daily program designed specifically to close skill gaps in reading comprehension and writing before the next school year. Small enough to give your child real feedback. Focused enough to make a difference in two weeks."
+    }
+  },
+  "mainCta": {
+    "headline": "Ready to reserve a spot?",
+    "subtext": "Select your cohort and grade band on the full program page.",
+    "button": "View full schedule & pricing →"
+  },
+  "relatedPrograms": {
+    "heading": "Related summer programs",
+    "hubLinkLabel": "View all programs & pricing →",
+    "items": {
+      "mathFoundations": {
+        "label": "Summer Math Foundations",
+        "description": "Bridge the Gap Math · Grades 1–8 · mornings"
+      },
+      "algebra": {
+        "label": "Algebra 1 Get Ready",
+        "description": "Grades 7–8 · Mon/Wed/Fri evenings"
+      },
+      "geometry": {
+        "label": "Geometry Get Ready",
+        "description": "Grades 9–10 · proofs & spatial reasoning prep"
+      }
+    }
+  },
+  "faq": [
+    {
+      "question": "What is the difference between Read to Prove and Write to Explain?",
+      "answer": "Read to Prove focuses on reading comprehension — finding the main idea, making inferences, and using text evidence to support answers. Write to Explain focuses on writing — sentence structure, paragraph writing, essays, and revision. Both run at different morning times so students can enroll in one or both."
+    },
+    {
+      "question": "Are these programs DUSD aligned?",
+      "answer": "Both programs follow Common Core standards and are designed to prepare students for DUSD and PUSD grade-level reading and writing expectations in fall."
+    },
+    {
+      "question": "How many students are in each group?",
+      "answer": "Each group is capped at 8 students. Sessions run 90 minutes daily — 60 minutes of instruction plus a 30-minute guided practice lab included at no extra cost."
+    },
+    {
+      "question": "Can my child enroll in both Read to Prove and Write to Explain?",
+      "answer": "Yes. Both tracks run at different times — Read to Prove runs 10:00–11:30 AM and Write to Explain runs 10:30 AM–12:00 PM. The schedules overlap by 30 minutes so a student cannot attend both in the same session. However, a student can enroll in Read to Prove for Cohort 1 and Write to Explain for Cohort 2, or alternate based on which skill needs more support."
+    },
+    {
+      "question": "What if my child is in a different grade than listed?",
+      "answer": "The Grades 1–8 range covers a wide skill spectrum. The instructor groups students by skill level within the session, not strictly by grade. If your child is in Grade 9 but needs reading comprehension support, contact us at (925) 456-4606 to confirm fit before enrolling."
+    }
+  ]
+}

--- a/src/lib/__tests__/academic-seo-landing-copy.test.ts
+++ b/src/lib/__tests__/academic-seo-landing-copy.test.ts
@@ -1,0 +1,17 @@
+import { ACADEMIC_SEO_LANDING_PAGE_IDS } from '@/lib/academic-seo-landing-config';
+import {
+  countAcademicSeoLandingCopyWords,
+  getAcademicSeoLandingCopy,
+} from '@/lib/academic-seo-landing-copy';
+
+const MIN_VISIBLE_COPY_WORDS = 600;
+
+describe('academic-seo-landing-copy', () => {
+  it.each(ACADEMIC_SEO_LANDING_PAGE_IDS)(
+    '%s has at least %i words of visible copy',
+    (pageId) => {
+      const copy = getAcademicSeoLandingCopy(pageId);
+      expect(countAcademicSeoLandingCopyWords(copy)).toBeGreaterThanOrEqual(MIN_VISIBLE_COPY_WORDS);
+    },
+  );
+});

--- a/src/lib/__tests__/academic-summer-program-filters.test.ts
+++ b/src/lib/__tests__/academic-summer-program-filters.test.ts
@@ -1,4 +1,4 @@
-import { filterAcademicProgramsByChip } from '@/lib/academic-summer-program-filters';
+import { filterAcademicProgramsByChip, resolveAcademicHubFilterFromQuery } from '@/lib/academic-summer-program-filters';
 import { buildAllAcademicSummerPrograms } from '@/lib/academic-summer-programs-hub-data';
 
 describe('filterAcademicProgramsByChip', () => {
@@ -21,5 +21,15 @@ describe('filterAcademicProgramsByChip', () => {
   it('filters get-ready math tracks', () => {
     const filtered = filterAcademicProgramsByChip(programs, 'getReadyMath');
     expect(filtered.map((p) => p.id)).toEqual(['im1', 'algebra-1', 'geometry']);
+  });
+});
+
+describe('resolveAcademicHubFilterFromQuery', () => {
+  it('maps SEO query params to filter chip ids', () => {
+    expect(resolveAcademicHubFilterFromQuery('reading-writing')).toBe('readingWriting');
+    expect(resolveAcademicHubFilterFromQuery('bridge-the-gap')).toBe('bridgeTheGap');
+    expect(resolveAcademicHubFilterFromQuery('get-ready-math')).toBe('getReadyMath');
+    expect(resolveAcademicHubFilterFromQuery(null)).toBeNull();
+    expect(resolveAcademicHubFilterFromQuery('invalid')).toBeNull();
   });
 });

--- a/src/lib/__tests__/academic-summer-seo-links.test.ts
+++ b/src/lib/__tests__/academic-summer-seo-links.test.ts
@@ -1,0 +1,17 @@
+import { getAcademicProgramSeoLink } from '@/lib/academic-summer-seo-links';
+
+describe('academic-summer-seo-links', () => {
+  it.each([
+    ['read-to-prove', 'summer-reading-writing-dublin-ca'],
+    ['write-to-explain', 'summer-reading-writing-dublin-ca'],
+    ['bridge-the-gap-math', 'summer-math-foundations-dublin-ca'],
+    ['algebra-1', 'summer-algebra-dublin-ca'],
+    ['geometry', 'summer-geometry-precalculus-dublin-ca'],
+  ] as const)('maps %s to /camps/%s', (programId, slug) => {
+    expect(getAcademicProgramSeoLink(programId)?.slug).toBe(slug);
+  });
+
+  it('does not link IM1 until a dedicated SEO page exists', () => {
+    expect(getAcademicProgramSeoLink('im1')).toBeUndefined();
+  });
+});

--- a/src/lib/academic-seo-landing-config.ts
+++ b/src/lib/academic-seo-landing-config.ts
@@ -1,0 +1,90 @@
+import type { AcademicProgramFilterId } from '@/lib/academic-summer-program-filters';
+import type {
+  AcademicGetReadyTrackId,
+  AcademicSummerSprintTrackId,
+} from '@/lib/academic-summer-programs-hub-data';
+
+export type AcademicSeoLandingPageId =
+  | 'readingWriting'
+  | 'mathFoundations'
+  | 'algebra'
+  | 'geometry';
+
+export type AcademicSeoLandingVariant = 'sprint-multi' | 'sprint-single' | 'get-ready-single';
+
+export type AcademicSeoLandingPageConfig = {
+  readonly id: AcademicSeoLandingPageId;
+  readonly slug: string;
+  readonly path: `/camps/${string}`;
+  readonly variant: AcademicSeoLandingVariant;
+  readonly trackIds: readonly (AcademicSummerSprintTrackId | AcademicGetReadyTrackId)[];
+  readonly hubFilter: Exclude<AcademicProgramFilterId, 'all'>;
+  readonly breadcrumbLabel: string;
+  readonly relatedPageOrder: readonly AcademicSeoLandingPageId[];
+};
+
+export const ACADEMIC_SEO_HUB_PATH = '/camps/academic-summer-programs-dublin-ca' as const;
+
+export const ACADEMIC_SEO_LANDING_PAGES: Record<
+  AcademicSeoLandingPageId,
+  AcademicSeoLandingPageConfig
+> = {
+  readingWriting: {
+    id: 'readingWriting',
+    slug: 'summer-reading-writing-dublin-ca',
+    path: '/camps/summer-reading-writing-dublin-ca',
+    variant: 'sprint-multi',
+    trackIds: ['read-to-prove', 'write-to-explain'],
+    hubFilter: 'readingWriting',
+    breadcrumbLabel: 'Summer Reading & Writing',
+    relatedPageOrder: ['mathFoundations', 'algebra', 'geometry'],
+  },
+  mathFoundations: {
+    id: 'mathFoundations',
+    slug: 'summer-math-foundations-dublin-ca',
+    path: '/camps/summer-math-foundations-dublin-ca',
+    variant: 'sprint-single',
+    trackIds: ['bridge-the-gap-math'],
+    hubFilter: 'bridgeTheGap',
+    breadcrumbLabel: 'Summer Math Foundations',
+    relatedPageOrder: ['readingWriting', 'algebra', 'geometry'],
+  },
+  algebra: {
+    id: 'algebra',
+    slug: 'summer-algebra-dublin-ca',
+    path: '/camps/summer-algebra-dublin-ca',
+    variant: 'get-ready-single',
+    trackIds: ['algebra-1'],
+    hubFilter: 'getReadyMath',
+    breadcrumbLabel: 'Summer Algebra',
+    relatedPageOrder: ['mathFoundations', 'geometry', 'readingWriting'],
+  },
+  geometry: {
+    id: 'geometry',
+    slug: 'summer-geometry-precalculus-dublin-ca',
+    path: '/camps/summer-geometry-precalculus-dublin-ca',
+    variant: 'get-ready-single',
+    trackIds: ['geometry'],
+    hubFilter: 'getReadyMath',
+    breadcrumbLabel: 'Summer Geometry',
+    relatedPageOrder: ['algebra', 'mathFoundations', 'readingWriting'],
+  },
+};
+
+export const ACADEMIC_SEO_LANDING_PAGE_IDS = Object.keys(
+  ACADEMIC_SEO_LANDING_PAGES,
+) as AcademicSeoLandingPageId[];
+
+export function getAcademicSeoLandingPageConfig(
+  pageId: AcademicSeoLandingPageId,
+): AcademicSeoLandingPageConfig {
+  return ACADEMIC_SEO_LANDING_PAGES[pageId];
+}
+
+export function getAcademicSeoLandingPageBySlug(
+  slug: string,
+): AcademicSeoLandingPageConfig | undefined {
+  return ACADEMIC_SEO_LANDING_PAGE_IDS.map((id) => ACADEMIC_SEO_LANDING_PAGES[id]).find(
+    (page) => page.slug === slug,
+  );
+}

--- a/src/lib/academic-seo-landing-copy.ts
+++ b/src/lib/academic-seo-landing-copy.ts
@@ -1,0 +1,137 @@
+import type { AcademicSeoLandingPageId } from '@/lib/academic-seo-landing-config';
+import readingWritingCopy from '@/i18n/messages/summer-reading-writing-dublin-ca-en.json';
+import mathFoundationsCopy from '@/i18n/messages/summer-math-foundations-dublin-ca-en.json';
+import algebraCopy from '@/i18n/messages/summer-algebra-dublin-ca-en.json';
+import geometryCopy from '@/i18n/messages/summer-geometry-precalculus-dublin-ca-en.json';
+import type { AcademicSeoFaqItem } from '@/lib/schema/academic-seo-landing-jsonld';
+
+export type AcademicSeoBodyWeekBlock = {
+  title: string;
+  body: string;
+};
+
+export type AcademicSeoBodyWorkOnSubsection = {
+  h3: string;
+  weeks: readonly AcademicSeoBodyWeekBlock[];
+};
+
+export type AcademicSeoFitGroup = {
+  label: string;
+  items: readonly string[];
+};
+
+export type AcademicSeoBodySections = {
+  whatYourChildWillWorkOn: {
+    heading: string;
+    subsections: readonly AcademicSeoBodyWorkOnSubsection[];
+  };
+  whoTeaches: {
+    heading: string;
+    body: string;
+  };
+  whoIsRightFor: {
+    heading: string;
+    groups: readonly AcademicSeoFitGroup[];
+    notRightFor?: AcademicSeoFitGroup;
+  };
+  whyGrowWise: {
+    heading: string;
+    body: string;
+  };
+};
+
+export type AcademicSeoLandingCopy = {
+  hero: {
+    eyebrow: string;
+    h1: string;
+    subtext: string;
+    ctaLabel: string;
+  };
+  keyDetails: readonly string[];
+  bodySections: AcademicSeoBodySections;
+  programCardOverrides?: Record<string, { tagline?: string; title?: string }>;
+  summerCampCallout?: {
+    text: string;
+    linkLabel: string;
+    href: string;
+  };
+  valueAnchorPrefix?: string;
+  mainCta: {
+    headline: string;
+    subtext: string;
+    button: string;
+  };
+  relatedPrograms: {
+    heading: string;
+    hubLinkLabel: string;
+    items: Record<
+      string,
+      {
+        label: string;
+        description: string;
+      }
+    >;
+  };
+  faq: readonly AcademicSeoFaqItem[];
+};
+
+const COPY_BY_PAGE: Record<AcademicSeoLandingPageId, AcademicSeoLandingCopy> = {
+  readingWriting: readingWritingCopy as AcademicSeoLandingCopy,
+  mathFoundations: mathFoundationsCopy as AcademicSeoLandingCopy,
+  algebra: algebraCopy as AcademicSeoLandingCopy,
+  geometry: geometryCopy as AcademicSeoLandingCopy,
+};
+
+export function getAcademicSeoLandingCopy(pageId: AcademicSeoLandingPageId): AcademicSeoLandingCopy {
+  return COPY_BY_PAGE[pageId];
+}
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/** Counts user-visible copy from JSON (body sections, FAQ, hero, related links, etc.). */
+export function countAcademicSeoLandingCopyWords(copy: AcademicSeoLandingCopy): number {
+  const parts: string[] = [
+    copy.hero.eyebrow,
+    copy.hero.h1,
+    copy.hero.subtext,
+    copy.hero.ctaLabel,
+    ...copy.keyDetails,
+    copy.bodySections.whatYourChildWillWorkOn.heading,
+    ...copy.bodySections.whatYourChildWillWorkOn.subsections.flatMap((subsection) => [
+      subsection.h3,
+      ...subsection.weeks.flatMap((week) => [week.title, week.body]),
+    ]),
+    copy.bodySections.whoTeaches.heading,
+    copy.bodySections.whoTeaches.body,
+    copy.bodySections.whoIsRightFor.heading,
+    ...copy.bodySections.whoIsRightFor.groups.flatMap((group) => [group.label, ...group.items]),
+    copy.bodySections.whyGrowWise.heading,
+    copy.bodySections.whyGrowWise.body,
+    copy.mainCta.headline,
+    copy.mainCta.subtext,
+    copy.mainCta.button,
+    copy.relatedPrograms.heading,
+    copy.relatedPrograms.hubLinkLabel,
+    ...Object.values(copy.relatedPrograms.items).flatMap((item) => [item.label, item.description]),
+    ...copy.faq.flatMap((item) => [item.question, item.answer]),
+  ];
+
+  if (copy.bodySections.whoIsRightFor.notRightFor) {
+    parts.push(
+      copy.bodySections.whoIsRightFor.notRightFor.label,
+      ...copy.bodySections.whoIsRightFor.notRightFor.items,
+    );
+  }
+
+  if (copy.summerCampCallout) {
+    parts.push(copy.summerCampCallout.text, copy.summerCampCallout.linkLabel);
+  }
+
+  if (copy.valueAnchorPrefix) {
+    parts.push(copy.valueAnchorPrefix);
+  }
+
+  return parts.reduce((sum, text) => sum + countWords(text), 0);
+}

--- a/src/lib/academic-seo-landing-program-cards.ts
+++ b/src/lib/academic-seo-landing-program-cards.ts
@@ -1,0 +1,94 @@
+import hubCopy from '@/i18n/messages/academic-summer-programs-hub-en.json';
+import {
+  formatAcademicSprintUsd,
+  getAcademicGetReadyPickCardMeta,
+  getAcademicSprintById,
+  getAcademicSprintPickCardMeta,
+  getAcademicSummerProgramsHubData,
+  getGetReadyPanelMeta,
+  isAcademicGetReadyProgram,
+  isAcademicSummerSprintProgram,
+  type AcademicGetReadyTrackId,
+  type AcademicSummerSprintTrackId,
+} from '@/lib/academic-summer-programs-hub-data';
+
+export type AcademicSeoStaticProgramCardModel = {
+  id: string;
+  title: string;
+  tagline: string;
+  gradeBadge: string;
+  scheduleLine: string;
+  bestFor: readonly string[];
+  bestForLabel: string;
+  pricingRows: readonly { label: string; amount: string }[];
+};
+
+function sprintPricingRows(): AcademicSeoStaticProgramCardModel['pricingRows'] {
+  const sprint = getAcademicSprintById('academic-summer-sprint');
+  const tierLabels = hubCopy.sprintCards.sprints['academic-summer-sprint'].pricingTiers;
+  if (!sprint?.pricing) return [];
+  return sprint.pricing.tiers.map((tier) => ({
+    label: tierLabels[tier.id]?.label ?? tier.id,
+    amount: formatAcademicSprintUsd(tier.perCohortPrice),
+  }));
+}
+
+function getReadyPricingRows(
+  trackId: AcademicGetReadyTrackId,
+): AcademicSeoStaticProgramCardModel['pricingRows'] {
+  const panelMeta = getGetReadyPanelMeta(trackId);
+  const hub = getAcademicSummerProgramsHubData();
+  const groupId = hub.getReadyPricingGroups[trackId];
+  const prices = hub.getReadyPricing[groupId];
+  if (!panelMeta || !prices) return [];
+
+  return [
+    { label: panelMeta.cohort1.title, amount: formatAcademicSprintUsd(prices.twoWeek) },
+    { label: panelMeta.cohort2.title, amount: formatAcademicSprintUsd(prices.twoWeek) },
+    { label: panelMeta.both.title, amount: formatAcademicSprintUsd(prices.fourWeek) },
+  ];
+}
+
+function displayTitle(trackId: string, fallback: string): string {
+  if (trackId === 'algebra-1') return 'Algebra 1 Get Ready';
+  return fallback;
+}
+
+export function buildAcademicSeoStaticProgramCard(
+  trackId: string,
+  overrides?: { tagline?: string; title?: string },
+): AcademicSeoStaticProgramCardModel | null {
+  const trackCopy = hubCopy.tracks[trackId as keyof typeof hubCopy.tracks];
+
+  if (isAcademicSummerSprintProgram(trackId)) {
+    const cardMeta = getAcademicSprintPickCardMeta(trackId as AcademicSummerSprintTrackId);
+    if (!cardMeta || !trackCopy) return null;
+    return {
+      id: trackId,
+      title: overrides?.title ?? displayTitle(trackId, trackCopy.name),
+      tagline: overrides?.tagline ?? trackCopy.tagline,
+      gradeBadge: cardMeta.gradeBadge,
+      scheduleLine: cardMeta.scheduleLine,
+      bestFor: cardMeta.bestFor,
+      bestForLabel: cardMeta.bestForLabel,
+      pricingRows: sprintPricingRows(),
+    };
+  }
+
+  if (isAcademicGetReadyProgram(trackId)) {
+    const cardMeta = getAcademicGetReadyPickCardMeta(trackId as AcademicGetReadyTrackId);
+    if (!cardMeta || !trackCopy) return null;
+    return {
+      id: trackId,
+      title: overrides?.title ?? displayTitle(trackId, trackCopy.name),
+      tagline: overrides?.tagline ?? trackCopy.tagline,
+      gradeBadge: cardMeta.gradeBadge,
+      scheduleLine: cardMeta.scheduleLine,
+      bestFor: cardMeta.bestFor,
+      bestForLabel: cardMeta.bestForLabel,
+      pricingRows: getReadyPricingRows(trackId as AcademicGetReadyTrackId),
+    };
+  }
+
+  return null;
+}

--- a/src/lib/academic-summer-program-filters.ts
+++ b/src/lib/academic-summer-program-filters.ts
@@ -30,3 +30,25 @@ export function filterAcademicProgramsByChip(
   const allowed = new Set(FILTER_PROGRAM_IDS[filter]);
   return programs.filter((program) => allowed.has(program.id));
 }
+
+/** URL query values for ?filter= on the academic summer programs hub (SEO deep links). */
+export const ACADEMIC_HUB_FILTER_QUERY_VALUES: Record<
+  Exclude<AcademicProgramFilterId, 'all'>,
+  string
+> = {
+  readingWriting: 'reading-writing',
+  bridgeTheGap: 'bridge-the-gap',
+  getReadyMath: 'get-ready-math',
+};
+
+export function resolveAcademicHubFilterFromQuery(
+  param: string | null,
+): Exclude<AcademicProgramFilterId, 'all'> | null {
+  if (!param) return null;
+  const entry = Object.entries(ACADEMIC_HUB_FILTER_QUERY_VALUES).find(([, value]) => value === param);
+  return entry ? (entry[0] as Exclude<AcademicProgramFilterId, 'all'>) : null;
+}
+
+export function academicHubUrlWithFilter(filter: Exclude<AcademicProgramFilterId, 'all'>): string {
+  return `/camps/academic-summer-programs-dublin-ca?filter=${ACADEMIC_HUB_FILTER_QUERY_VALUES[filter]}`;
+}

--- a/src/lib/academic-summer-seo-links.ts
+++ b/src/lib/academic-summer-seo-links.ts
@@ -21,11 +21,11 @@ export type AcademicProgramSeoLink = {
 const PROGRAM_ID_TO_SEO: Partial<Record<string, AcademicProgramSeoLink | null>> = {
   'read-to-prove': {
     slug: 'summer-reading-writing-dublin-ca',
-    labelKey: 'readingWritingPrograms',
+    labelKey: 'readToProve',
   },
   'write-to-explain': {
     slug: 'summer-reading-writing-dublin-ca',
-    labelKey: 'readingWritingPrograms',
+    labelKey: 'writeWithStructure',
   },
   'bridge-the-gap-math': {
     slug: 'summer-math-foundations-dublin-ca',

--- a/src/lib/academic-summer-seo-links.ts
+++ b/src/lib/academic-summer-seo-links.ts
@@ -1,5 +1,5 @@
 /**
- * Maps academic hub program ids to future `/camps/[slug]` detail pages.
+ * Maps academic hub program ids to `/camps/[slug]` SEO detail pages.
  * Set `slug` when a landing page is published; links stay hidden until then.
  */
 
@@ -17,14 +17,29 @@ export type AcademicProgramSeoLink = {
   labelKey: AcademicProgramSeoSlugKey;
 };
 
-/** Enable slugs here as program landing pages ship (same pattern as summer-camp-seo-links). */
+/** Published program landing pages (pillar → detail). */
 const PROGRAM_ID_TO_SEO: Partial<Record<string, AcademicProgramSeoLink | null>> = {
-  'read-to-prove': null,
-  'write-to-explain': null,
-  'bridge-the-gap-math': null,
+  'read-to-prove': {
+    slug: 'summer-reading-writing-dublin-ca',
+    labelKey: 'readingWritingPrograms',
+  },
+  'write-to-explain': {
+    slug: 'summer-reading-writing-dublin-ca',
+    labelKey: 'readingWritingPrograms',
+  },
+  'bridge-the-gap-math': {
+    slug: 'summer-math-foundations-dublin-ca',
+    labelKey: 'mistakeProofMath',
+  },
   im1: null,
-  'algebra-1': null,
-  geometry: null,
+  'algebra-1': {
+    slug: 'summer-algebra-dublin-ca',
+    labelKey: 'algebra1GetReady',
+  },
+  geometry: {
+    slug: 'summer-geometry-precalculus-dublin-ca',
+    labelKey: 'geometryGetReady',
+  },
 };
 
 export function getAcademicProgramSeoLink(programId: string): AcademicProgramSeoLink | undefined {

--- a/src/lib/camps/__tests__/camp-pages-registry.test.ts
+++ b/src/lib/camps/__tests__/camp-pages-registry.test.ts
@@ -1,0 +1,117 @@
+import {
+  ACADEMIC_HUB_FILTER_SMOKE_CASES,
+  ACADEMIC_SEO_CAMP_PATHS,
+  CAMP_REDIRECT_PATHS,
+  CAMP_STATIC_HUB_PATHS,
+  getAcademicSeoPageSmokeExpectations,
+  getAllCampsSmokePaths,
+  getCampLandingPaths,
+} from '@/lib/camps/camp-pages-registry';
+import { CAMPS_STATIC_PATH_SEGMENTS } from '@/lib/camps/camp-routes';
+import { getCampSlugs } from '@/lib/camps/get-camp-page';
+import { getMetadataConfig } from '@/lib/seo/metadataConfig';
+import { buildPagesUrls } from '@/lib/seo/sitemapData';
+import { buildAcademicSeoLandingCourseSchema } from '@/lib/schema/academic-seo-landing-jsonld';
+import { ACADEMIC_SEO_LANDING_PAGE_IDS } from '@/lib/academic-seo-landing-config';
+import { getAcademicSeoLandingCopy } from '@/lib/academic-seo-landing-copy';
+
+describe('camp-pages-registry', () => {
+  it('lists all static camp hubs and SEO landing paths without duplicates', () => {
+    const all = getAllCampsSmokePaths();
+    expect(all.length).toBe(new Set(all).size);
+    expect(all).not.toContain('/camps/academic-summer-sprint-dublin-ca');
+    expect(all.length).toBeGreaterThanOrEqual(
+      (CAMP_STATIC_HUB_PATHS.length - CAMP_REDIRECT_PATHS.length) +
+        ACADEMIC_SEO_CAMP_PATHS.length +
+        getCampSlugs().length,
+    );
+  });
+
+  it('includes every academic SEO path in static route guard', () => {
+    for (const path of ACADEMIC_SEO_CAMP_PATHS) {
+      const segment = path.replace('/camps/', '');
+      expect(CAMPS_STATIC_PATH_SEGMENTS.has(segment)).toBe(true);
+    }
+  });
+
+  it('defines hub filter smoke cases for all SEO filter query values', () => {
+    expect(ACADEMIC_HUB_FILTER_SMOKE_CASES).toHaveLength(4);
+    const queries = ACADEMIC_HUB_FILTER_SMOKE_CASES.map((c) => c.query).filter(Boolean);
+    expect(queries).toEqual(['reading-writing', 'bridge-the-gap', 'get-ready-math']);
+  });
+
+  it('maps each SEO page to hub filter and three related paths', () => {
+    const expectations = getAcademicSeoPageSmokeExpectations();
+    expect(expectations).toHaveLength(4);
+    for (const page of expectations) {
+      expect(page.h1.length).toBeGreaterThan(10);
+      expect(page.hubFilterQuery).toMatch(/^(reading-writing|bridge-the-gap|get-ready-math)$/);
+      expect(page.relatedPaths).toHaveLength(3);
+      expect(page.relatedPaths).not.toContain(page.path);
+    }
+  });
+});
+
+describe('camp pages metadata', () => {
+  it.each(ACADEMIC_SEO_CAMP_PATHS)('has metadata config for %s', (path) => {
+    const config = getMetadataConfig(path);
+    expect(config).not.toBeNull();
+    expect(config!.title.length).toBeLessThanOrEqual(60);
+    expect(config!.description.length).toBeLessThanOrEqual(155);
+  });
+});
+
+describe('camp pages sitemap', () => {
+  it('includes academic SEO landing pages and core camp hubs', () => {
+    const urls = buildPagesUrls('https://growwiseschool.org', '2026-05-22');
+    const locs = urls.map((u) => u.loc);
+    for (const path of [
+      '/camps/summer',
+      '/camps/academic-summer-programs-dublin-ca',
+      ...ACADEMIC_SEO_CAMP_PATHS,
+    ]) {
+      expect(locs).toContain(`https://growwiseschool.org${path}`);
+    }
+  });
+});
+
+describe('academic SEO landing copy', () => {
+  it.each(ACADEMIC_SEO_LANDING_PAGE_IDS)('%s has body sections and five FAQ items', (pageId) => {
+    const copy = getAcademicSeoLandingCopy(pageId);
+    expect(copy.bodySections.whatYourChildWillWorkOn.subsections.length).toBeGreaterThan(0);
+    expect(copy.bodySections.whoTeaches.body.length).toBeGreaterThan(50);
+    expect(copy.bodySections.whoIsRightFor.groups.length).toBeGreaterThan(0);
+    expect(copy.bodySections.whyGrowWise.body.length).toBeGreaterThan(50);
+    expect(copy.faq).toHaveLength(5);
+  });
+});
+
+describe('academic SEO JSON-LD', () => {
+  it.each(ACADEMIC_SEO_LANDING_PAGE_IDS)('builds course schema for %s', (pageId) => {
+    const schema = buildAcademicSeoLandingCourseSchema(pageId) as Record<string, unknown>;
+    expect(schema['@context']).toBe('https://schema.org');
+    if (pageId === 'readingWriting') {
+      expect(schema['@type']).toBe('ItemList');
+    } else {
+      expect(schema['@type']).toBe('Course');
+    }
+  });
+});
+
+describe('camp landing slug coverage', () => {
+  it('includes expected STEAM camp landing slugs', () => {
+    expect(getCampLandingPaths()).toEqual(
+      expect.arrayContaining([
+        '/camps/ai-studio-dublin-ca',
+        '/camps/robotics-camp-dublin-ca',
+        '/camps/math-olympiad-camp-dublin-ca',
+      ]),
+    );
+  });
+});
+
+describe('camp redirect registry', () => {
+  it('documents legacy academic sprint redirect', () => {
+    expect(CAMP_REDIRECT_PATHS[0]?.from).toBe('/camps/academic-summer-sprint-dublin-ca');
+  });
+});

--- a/src/lib/camps/__tests__/camp-routes.test.ts
+++ b/src/lib/camps/__tests__/camp-routes.test.ts
@@ -7,6 +7,10 @@ describe('camp-routes', () => {
   it('reserves academic hub segments from dynamic slug routes', () => {
     expect(CAMPS_STATIC_PATH_SEGMENTS.has('academic-summer-programs-dublin-ca')).toBe(true);
     expect(CAMPS_STATIC_PATH_SEGMENTS.has('academic-summer-sprint-dublin-ca')).toBe(true);
+    expect(CAMPS_STATIC_PATH_SEGMENTS.has('summer-reading-writing-dublin-ca')).toBe(true);
+    expect(CAMPS_STATIC_PATH_SEGMENTS.has('summer-math-foundations-dublin-ca')).toBe(true);
+    expect(CAMPS_STATIC_PATH_SEGMENTS.has('summer-algebra-dublin-ca')).toBe(true);
+    expect(CAMPS_STATIC_PATH_SEGMENTS.has('summer-geometry-precalculus-dublin-ca')).toBe(true);
     expect(CAMPS_STATIC_PATH_SEGMENTS.has('summer')).toBe(true);
     expect(CAMPS_STATIC_PATH_SEGMENTS.has('winter')).toBe(true);
   });
@@ -15,6 +19,10 @@ describe('camp-routes', () => {
     const slugs = getCampLandingStaticParams().map((p) => p.slug);
     expect(slugs).not.toContain('academic-summer-programs-dublin-ca');
     expect(slugs).not.toContain('academic-summer-sprint-dublin-ca');
+    expect(slugs).not.toContain('summer-reading-writing-dublin-ca');
+    expect(slugs).not.toContain('summer-math-foundations-dublin-ca');
+    expect(slugs).not.toContain('summer-algebra-dublin-ca');
+    expect(slugs).not.toContain('summer-geometry-precalculus-dublin-ca');
     expect(slugs).not.toContain('summer');
     expect(slugs).not.toContain('winter');
   });

--- a/src/lib/camps/camp-data.ts
+++ b/src/lib/camps/camp-data.ts
@@ -48,7 +48,7 @@ const SUMMER_STEAM_HALF_DAY_SCHEDULE = [
   },
   {
     label: "Enrollment",
-    primary: "Select a week on the camps page and add to cart",
+    primary: "Select a week at /camps/summer and add to cart",
   },
 ] as const;
 
@@ -274,7 +274,7 @@ export const CAMP_LANDING_PAGES: readonly CampLandingPage[] = [
     metaDescription:
       "Math Olympiad prep camp in Dublin, CA. AMC8-ready problem solving for grades 5–8. Small groups, expert instruction at GrowWise School.",
     metaKeywords:
-      "math olympiad camp Dublin CA, AMC8 prep Dublin, MOEMS camp Tri-Valley, math competition camp Dublin CA",
+      "math olympiad camp Dublin CA, AMC8 prep Dublin, MOEMS camp Tri-Valley, math competition camp Dublin CA 2026",
     scheduleIntro: null,
     h1: "Math Olympiad Summer Camp (Dublin, CA)",
     eyebrow: "GrowWise School · Summer · Dublin campus",

--- a/src/lib/camps/camp-pages-registry.ts
+++ b/src/lib/camps/camp-pages-registry.ts
@@ -1,0 +1,113 @@
+import { getCampSlugs } from '@/lib/camps/get-camp-page';
+import {
+  ACADEMIC_SEO_LANDING_PAGE_IDS,
+  ACADEMIC_SEO_LANDING_PAGES,
+} from '@/lib/academic-seo-landing-config';
+import { ACADEMIC_HUB_FILTER_QUERY_VALUES } from '@/lib/academic-summer-program-filters';
+import { getAcademicSeoLandingCopy } from '@/lib/academic-seo-landing-copy';
+
+/** Static camp hub routes (not dynamic `[slug]` landings). */
+export const CAMP_STATIC_HUB_PATHS = [
+  '/camps',
+  '/camps/summer',
+  '/camps/winter',
+  '/camps/winter/calendar',
+  '/camps/academic-summer-programs-dublin-ca',
+  '/camps/academic-summer-sprint-dublin-ca',
+] as const;
+
+export type CampStaticHubPath = (typeof CAMP_STATIC_HUB_PATHS)[number];
+
+/** Published academic SEO landing pages under `/camps/summer-*-dublin-ca`. */
+export const ACADEMIC_SEO_CAMP_PATHS = ACADEMIC_SEO_LANDING_PAGE_IDS.map(
+  (id) => ACADEMIC_SEO_LANDING_PAGES[id].path,
+);
+
+export type AcademicSeoCampPath = (typeof ACADEMIC_SEO_CAMP_PATHS)[number];
+
+/** Data-driven STEAM camp SEO pages at `/camps/[slug]`. */
+export function getCampLandingPaths(): string[] {
+  return getCampSlugs().map((slug) => `/camps/${slug}`);
+}
+
+/** Every camps-related path that should return 200 in smoke tests. */
+export function getAllCampsSmokePaths(): string[] {
+  const redirectFrom = new Set(CAMP_REDIRECT_PATHS.map((entry) => entry.from));
+  return [...CAMP_STATIC_HUB_PATHS, ...ACADEMIC_SEO_CAMP_PATHS, ...getCampLandingPaths()].filter(
+    (path) => !redirectFrom.has(path),
+  );
+}
+
+export type HubFilterSmokeCase = {
+  query: string | null;
+  activeChipLabel: string;
+  visibleProgramTitles: readonly string[];
+  hiddenProgramTitles: readonly string[];
+};
+
+export const ACADEMIC_HUB_FILTER_SMOKE_CASES: readonly HubFilterSmokeCase[] = [
+  {
+    query: null,
+    activeChipLabel: 'All Programs',
+    visibleProgramTitles: [
+      'Read to Prove',
+      'Write to Explain',
+      'Bridge the Gap Math',
+      'IM1 Get Ready',
+      'Algebra Get Ready',
+      'Geometry Get Ready',
+    ],
+    hiddenProgramTitles: [],
+  },
+  {
+    query: ACADEMIC_HUB_FILTER_QUERY_VALUES.readingWriting,
+    activeChipLabel: 'Reading & Writing',
+    visibleProgramTitles: ['Read to Prove', 'Write to Explain'],
+    hiddenProgramTitles: ['Bridge the Gap Math', 'Algebra Get Ready'],
+  },
+  {
+    query: ACADEMIC_HUB_FILTER_QUERY_VALUES.bridgeTheGap,
+    activeChipLabel: 'Bridge the Gap',
+    visibleProgramTitles: ['Bridge the Gap Math'],
+    hiddenProgramTitles: ['Read to Prove', 'Algebra Get Ready'],
+  },
+  {
+    query: ACADEMIC_HUB_FILTER_QUERY_VALUES.getReadyMath,
+    activeChipLabel: 'Get Ready Math',
+    visibleProgramTitles: ['IM1 Get Ready', 'Algebra Get Ready', 'Geometry Get Ready'],
+    hiddenProgramTitles: ['Read to Prove', 'Bridge the Gap Math'],
+  },
+];
+
+export type AcademicSeoPageSmokeExpectation = {
+  path: AcademicSeoCampPath;
+  h1: string;
+  hubFilterQuery: string;
+  relatedPaths: readonly AcademicSeoCampPath[];
+};
+
+export function getAcademicSeoPageSmokeExpectations(): AcademicSeoPageSmokeExpectation[] {
+  return ACADEMIC_SEO_LANDING_PAGE_IDS.map((id) => {
+    const config = ACADEMIC_SEO_LANDING_PAGES[id];
+    const copy = getAcademicSeoLandingCopy(id);
+    return {
+      path: config.path as AcademicSeoCampPath,
+      h1: copy.hero.h1,
+      hubFilterQuery: ACADEMIC_HUB_FILTER_QUERY_VALUES[config.hubFilter],
+      relatedPaths: config.relatedPageOrder.map(
+        (relatedId) => ACADEMIC_SEO_LANDING_PAGES[relatedId].path as AcademicSeoCampPath,
+      ),
+    };
+  });
+}
+
+/** Paths that should redirect (legacy → hub). */
+export const CAMP_REDIRECT_PATHS: ReadonlyArray<{
+  from: string;
+  toPattern: RegExp;
+}> = [
+  {
+    from: '/camps/academic-summer-sprint-dublin-ca',
+    toPattern: /\/camps\/academic-summer-programs-dublin-ca/,
+  },
+];

--- a/src/lib/camps/camp-routes.ts
+++ b/src/lib/camps/camp-routes.ts
@@ -14,6 +14,10 @@ export const CAMPS_STATIC_PATH_SEGMENTS: ReadonlySet<string> = new Set([
   "winter",
   "academic-summer-programs-dublin-ca",
   "academic-summer-sprint-dublin-ca",
+  "summer-reading-writing-dublin-ca",
+  "summer-math-foundations-dublin-ca",
+  "summer-algebra-dublin-ca",
+  "summer-geometry-precalculus-dublin-ca",
 ]);
 
 /** Params for `src/app/[locale]/camps/[slug]/page.tsx` — excludes static camp hubs. */

--- a/src/lib/schema/academic-seo-landing-jsonld.ts
+++ b/src/lib/schema/academic-seo-landing-jsonld.ts
@@ -1,0 +1,152 @@
+import { CONTACT_INFO } from '@/lib/constants';
+import type { AcademicSeoLandingPageId } from '@/lib/academic-seo-landing-config';
+import { ACADEMIC_SEO_LANDING_PAGES } from '@/lib/academic-seo-landing-config';
+
+const ORG_NAME = 'GrowWise School';
+const PROVIDER_ADDRESS = `${CONTACT_INFO.street}, Dublin, CA ${CONTACT_INFO.zipCode}`;
+const SCHEMA_PHONE = '+19254564606';
+
+const WEEKDAY_SCHEDULE = {
+  startDate: '2026-06-15',
+  endDate: '2026-07-11',
+  repeatFrequency: 'P1D',
+  byDay: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'] as const,
+};
+
+const MWF_SCHEDULE_JUNE = {
+  startDate: '2026-06-15',
+  endDate: '2026-07-11',
+  byDay: ['Monday', 'Wednesday', 'Friday'] as const,
+};
+
+function courseProviderWithPhone() {
+  return {
+    '@type': 'EducationalOrganization' as const,
+    name: ORG_NAME,
+    address: PROVIDER_ADDRESS,
+    telephone: SCHEMA_PHONE,
+  };
+}
+
+function courseSchedule(schedule: {
+  startDate: string;
+  endDate: string;
+  byDay: readonly string[];
+  repeatFrequency?: string;
+}) {
+  return {
+    '@type': 'Schedule' as const,
+    startDate: schedule.startDate,
+    endDate: schedule.endDate,
+    ...(schedule.repeatFrequency ? { repeatFrequency: schedule.repeatFrequency } : {}),
+    byDay: [...schedule.byDay],
+  };
+}
+
+function courseOffer(offer: { price: string; priceCurrency: string; name: string }) {
+  return {
+    '@type': 'Offer' as const,
+    price: offer.price,
+    priceCurrency: offer.priceCurrency,
+    name: offer.name,
+  };
+}
+
+const READ_TO_PROVE_COURSE = {
+  '@type': 'Course' as const,
+  name: 'Read to Prove — Summer Reading Program Dublin CA',
+  description:
+    'Summer reading comprehension sprint in Dublin, CA. Main idea, inference, vocabulary, text evidence. Grades 1–8. 90 min/day. Starts June 15.',
+  provider: courseProviderWithPhone(),
+  courseSchedule: courseSchedule(WEEKDAY_SCHEDULE),
+  offers: [
+    courseOffer({ price: '249', priceCurrency: 'USD', name: 'Grades 1–5' }),
+    courseOffer({ price: '349', priceCurrency: 'USD', name: 'Grades 6–8' }),
+  ],
+};
+
+const WRITE_TO_EXPLAIN_COURSE = {
+  '@type': 'Course' as const,
+  name: 'Write to Explain — Summer Writing Program Dublin CA',
+  description:
+    'Summer writing sprint in Dublin, CA. Sentence structure, paragraph writing, essays, revision. Grades 1–8. 90 min/day. Starts June 15.',
+  provider: courseProviderWithPhone(),
+  courseSchedule: courseSchedule(WEEKDAY_SCHEDULE),
+  offers: [
+    courseOffer({ price: '249', priceCurrency: 'USD', name: 'Grades 1–5' }),
+    courseOffer({ price: '349', priceCurrency: 'USD', name: 'Grades 6–8' }),
+  ],
+};
+
+const BRIDGE_THE_GAP_COURSE = {
+  '@type': 'Course' as const,
+  name: 'Bridge the Gap Math — Summer Math Program Dublin CA',
+  description:
+    'Summer math foundations program in Dublin, CA. Fractions, word problems, multi-step math, grade readiness. Grades 1–8. 90 min/day. Starts June 15. DUSD aligned.',
+  provider: courseProviderWithPhone(),
+  courseSchedule: courseSchedule(WEEKDAY_SCHEDULE),
+  offers: [
+    courseOffer({ price: '249', priceCurrency: 'USD', name: 'Grades 1–5' }),
+    courseOffer({ price: '349', priceCurrency: 'USD', name: 'Grades 6–8' }),
+  ],
+};
+
+const ALGEBRA_COURSE = {
+  '@type': 'Course' as const,
+  name: 'Algebra 1 Get Ready — Summer Algebra Program Dublin CA',
+  description:
+    'DUSD-aligned Algebra 1 summer program in Dublin, CA. Equations, functions, graphing, inequalities. Grades 7–8. Mon/Wed/Fri evenings 5–6:30 PM. Starts June 15.',
+  provider: courseProviderWithPhone(),
+  courseSchedule: courseSchedule(MWF_SCHEDULE_JUNE),
+  offers: [
+    courseOffer({ price: '249', priceCurrency: 'USD', name: '2-week sprint' }),
+    courseOffer({ price: '449', priceCurrency: 'USD', name: 'Both cohorts' }),
+  ],
+};
+
+const GEOMETRY_COURSE = {
+  '@type': 'Course' as const,
+  name: 'Geometry Get Ready — Summer Geometry Program Dublin CA',
+  description:
+    'DUSD-aligned Geometry summer program in Dublin, CA. Proofs, triangles, similarity, coordinate geometry. Grades 9–10. Mon/Wed/Fri evenings 5–6:30 PM. Starts June 15.',
+  provider: courseProviderWithPhone(),
+  courseSchedule: courseSchedule(MWF_SCHEDULE_JUNE),
+  offers: [
+    courseOffer({ price: '279', priceCurrency: 'USD', name: '2-week sprint' }),
+    courseOffer({ price: '499', priceCurrency: 'USD', name: 'Both cohorts' }),
+  ],
+};
+
+export type AcademicSeoFaqItem = {
+  question: string;
+  answer: string;
+};
+
+export function buildAcademicSeoLandingCourseSchema(pageId: AcademicSeoLandingPageId): object {
+  switch (pageId) {
+    case 'readingWriting':
+      return {
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        name: 'Summer Reading & Writing Programs Dublin CA',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, item: READ_TO_PROVE_COURSE },
+          { '@type': 'ListItem', position: 2, item: WRITE_TO_EXPLAIN_COURSE },
+        ],
+      };
+    case 'mathFoundations':
+      return { '@context': 'https://schema.org', ...BRIDGE_THE_GAP_COURSE };
+    case 'algebra':
+      return { '@context': 'https://schema.org', ...ALGEBRA_COURSE };
+    case 'geometry':
+      return { '@context': 'https://schema.org', ...GEOMETRY_COURSE };
+    default: {
+      const _exhaustive: never = pageId;
+      return _exhaustive;
+    }
+  }
+}
+
+export function buildAcademicSeoLandingWebPageName(pageId: AcademicSeoLandingPageId): string {
+  return ACADEMIC_SEO_LANDING_PAGES[pageId].breadcrumbLabel;
+}

--- a/src/lib/seo/__tests__/metadata-length-limits.test.ts
+++ b/src/lib/seo/__tests__/metadata-length-limits.test.ts
@@ -25,6 +25,7 @@ describe('Metadata length limits — TC-05 / TC-06', () => {
       ['/camps/summer-math-foundations-dublin-ca'],
       ['/camps/summer-algebra-dublin-ca'],
       ['/camps/summer-geometry-precalculus-dublin-ca'],
+      ['/courses/integrated-math-1-dublin-ca'],
       ['/enroll'],
     ] as const)('title + description for %s', (path) => {
       const config = getMetadataConfig(path)

--- a/src/lib/seo/__tests__/metadata-length-limits.test.ts
+++ b/src/lib/seo/__tests__/metadata-length-limits.test.ts
@@ -21,6 +21,10 @@ describe('Metadata length limits — TC-05 / TC-06', () => {
     it.each([
       ['/camps/summer'],
       ['/camps/academic-summer-programs-dublin-ca'],
+      ['/camps/summer-reading-writing-dublin-ca'],
+      ['/camps/summer-math-foundations-dublin-ca'],
+      ['/camps/summer-algebra-dublin-ca'],
+      ['/camps/summer-geometry-precalculus-dublin-ca'],
       ['/enroll'],
     ] as const)('title + description for %s', (path) => {
       const config = getMetadataConfig(path)

--- a/src/lib/seo/__tests__/sitemapData.test.ts
+++ b/src/lib/seo/__tests__/sitemapData.test.ts
@@ -8,5 +8,15 @@ describe('sitemapData', () => {
       'https://www.growwiseschool.org/camps/academic-summer-programs-dublin-ca',
     );
     expect(locs).toContain('https://www.growwiseschool.org/camps/summer');
+    expect(locs).toContain(
+      'https://www.growwiseschool.org/camps/summer-reading-writing-dublin-ca',
+    );
+    expect(locs).toContain(
+      'https://www.growwiseschool.org/camps/summer-math-foundations-dublin-ca',
+    );
+    expect(locs).toContain('https://www.growwiseschool.org/camps/summer-algebra-dublin-ca');
+    expect(locs).toContain(
+      'https://www.growwiseschool.org/camps/summer-geometry-precalculus-dublin-ca',
+    );
   });
 });

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -102,6 +102,15 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
     path: '/courses/high-school-math',
   },
 
+  '/courses/integrated-math-1-dublin-ca': {
+    title: 'Integrated Math 1 Tutoring Dublin CA | GrowWise',
+    description:
+      'Integrated Math 1 tutoring in Dublin, CA. Algebra, functions, systems, and word problems. Small groups. Book a free assessment.',
+    keywords:
+      'integrated math 1 tutoring Dublin CA, IM1 tutor Dublin, integrated math tutor Tri-Valley, DUSD math tutoring, algebra functions graphs tutoring, systems of equations help Dublin CA',
+    path: '/courses/integrated-math-1-dublin-ca',
+  },
+
   '/coding': {
     title: 'Coding Classes Kids | Dublin CA | GrowWise',
     description:

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -288,6 +288,46 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
     image: 'https://growwiseschool.org/assets/camps/acabanner.webp',
   },
 
+  '/camps/summer-reading-writing-dublin-ca': {
+    title: 'Summer Reading & Writing Programs Dublin CA | GrowWise',
+    description:
+      'Small-group summer reading comprehension and writing programs in Dublin, CA. Grades 1–8. 90 min/day. Starts June 15. Max 8 students. DUSD aligned.',
+    keywords:
+      'summer reading program Dublin CA, summer writing program Dublin, Read to Prove Dublin, Write to Explain summer, DUSD reading writing summer',
+    path: '/camps/summer-reading-writing-dublin-ca',
+    image: 'https://growwiseschool.org/assets/camps/acabanner.webp',
+  },
+
+  '/camps/summer-math-foundations-dublin-ca': {
+    title: 'Summer Math Program Dublin CA | GrowWise',
+    description:
+      'Small-group summer math program in Dublin, CA. Fractions, word problems, grade readiness. Grades 1–8. 90 min/day. Starts June 15. Max 8 students.',
+    keywords:
+      'summer math program Dublin CA, Bridge the Gap Math, math foundations summer Dublin, DUSD math summer program',
+    path: '/camps/summer-math-foundations-dublin-ca',
+    image: 'https://growwiseschool.org/assets/camps/acabanner.webp',
+  },
+
+  '/camps/summer-algebra-dublin-ca': {
+    title: 'Algebra 1 Summer Program Dublin CA | GrowWise',
+    description:
+      'Small-group Algebra 1 summer program in Dublin, CA. DUSD aligned. Grades 7–8. Mon/Wed/Fri evenings. Starts June 15. Max 8 students. From $249.',
+    keywords:
+      'summer algebra program Dublin CA, Algebra 1 Get Ready Dublin, DUSD algebra summer prep, algebra summer camp Tri-Valley',
+    path: '/camps/summer-algebra-dublin-ca',
+    image: 'https://growwiseschool.org/assets/camps/acabanner.webp',
+  },
+
+  '/camps/summer-geometry-precalculus-dublin-ca': {
+    title: 'Summer Geometry Program Dublin CA | GrowWise',
+    description:
+      'Small-group Geometry summer program in Dublin, CA. Proofs, reasoning, DUSD aligned. Grades 9–10. Mon/Wed/Fri evenings. Starts June 15. From $279.',
+    keywords:
+      'summer geometry program Dublin CA, Geometry Get Ready Dublin, DUSD geometry summer prep, geometry summer Dublin CA',
+    path: '/camps/summer-geometry-precalculus-dublin-ca',
+    image: 'https://growwiseschool.org/assets/camps/acabanner.webp',
+  },
+
   '/growwise-blogs': {
     title: 'GrowWise Blog | Math, English & Coding Tips',
     description:

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -78,6 +78,10 @@ const legalPages: SitemapEntry[] = [
 const campPages: SitemapEntry[] = [
   { path: '/camps/summer', priority: 1.0, changefreq: 'weekly' },
   { path: '/camps/academic-summer-programs-dublin-ca', priority: 0.95, changefreq: 'weekly' },
+  { path: '/camps/summer-reading-writing-dublin-ca', priority: 0.9, changefreq: 'weekly' },
+  { path: '/camps/summer-math-foundations-dublin-ca', priority: 0.9, changefreq: 'weekly' },
+  { path: '/camps/summer-algebra-dublin-ca', priority: 0.9, changefreq: 'weekly' },
+  { path: '/camps/summer-geometry-precalculus-dublin-ca', priority: 0.9, changefreq: 'weekly' },
   { path: '/camps/winter', priority: 0.7, changefreq: 'weekly' },
   { path: '/camps/winter/calendar', priority: 0.6, changefreq: 'weekly' },
 ]

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -60,6 +60,7 @@ const coursePages: SitemapEntry[] = [
   { path: '/courses/english', priority: 0.95, changefreq: 'weekly' },
   { path: '/courses/sat-prep', priority: 0.9, changefreq: 'weekly' },
   { path: '/courses/high-school-math', priority: 0.85, changefreq: 'monthly' },
+  { path: '/courses/integrated-math-1-dublin-ca', priority: 0.85, changefreq: 'monthly' },
 ]
 
 const steamPages: SitemapEntry[] = [


### PR DESCRIPTION
## Summary
- Adds the Academic Summer Programs hub at `/camps/academic-summer-programs-dublin-ca` with enrollment panel, filter chips, FAQ/schema, and hub deep links via `?filter=` query params.
- Ships four SEO landing pages (reading/writing, math foundations, algebra, geometry) with 600+ words of body copy, related-program cross-links, FAQ JSON-LD, and CTAs that funnel to the hub (no checkout on SEO pages).
- Adds camps regression coverage: Jest (`test:camps`) for copy word count, metadata/sitemap/registry, and component tests; Playwright (`test:e2e:camps`) for smoke, section headings, 5 FAQ items, hub filters, and JSON-LD.

## Test plan
- [x] `npm run test:camps` (52 tests)
- [x] `npm run test:ci`
- [x] `npm run test:e2e:camps` (49 tests)
- [x] `npm run build`
- [ ] Manual: open each SEO page and confirm four body sections + 5 FAQ items render
- [ ] Manual: SEO CTA → hub with correct filter chip active (`reading-writing`, `bridge-the-gap`, `get-ready-math`)
- [ ] Manual: related-program links cross-link between the four SEO pages


Made with [Cursor](https://cursor.com)