### PR TITLE
feat(analytics): consent-gated HubSpot tracking and Microsoft Clarity

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -22,13 +22,20 @@ NEXT_PUBLIC_META_PIXEL_ID=
 # (Tags → Facebook/Meta/Custom HTML). Duplicate Pixel = duplicate PageView and wasted bandwidth.
 # Lighthouse "Uses deprecated APIs" → AttributionReporting often traces to Meta's fbevents.js, not app code.
 NEXT_PUBLIC_META_PIXEL_DISABLE_APP=
-# HubSpot CRM (server-only — no js.hs-scripts.com, so no HubSpot chat widget on the site)
+# HubSpot CRM (server-only Forms API — lead capture without exposing form GUID to the client)
 # Create a HubSpot form; map fields: firstname, lastname, email, phone, message (used by /api/contact and /api/hubspot-submit).
 # Portal ID: HubSpot Settings → Account & Billing → Account Information (Hub ID).
 # Form GUID: form editor URL or form embed code.
 HUBSPOT_PORTAL_ID=
 HUBSPOT_FORM_GUID=
-# Do not set NEXT_PUBLIC_HUBSPOT_HUB_ID in production — the app does not load HubSpot tracking/chat (avoid duplicate chatbot).
+# HubSpot client tracking — page views + SPA navigation (consent-gated; loads js.hs-scripts.com).
+# Use the same numeric Hub ID as HUBSPOT_PORTAL_ID. Keep HubSpot chat widget OFF in the HubSpot portal
+# (Ask Growy is the site chatbot — enabling HubSpot chat would show a duplicate widget).
+NEXT_PUBLIC_HUBSPOT_HUB_ID=
+
+# Microsoft Clarity — session replay / heatmaps (consent-gated; public pages only — excludes login, checkout, dashboard).
+# Project ID: Clarity dashboard → Settings → Overview.
+NEXT_PUBLIC_CLARITY_PROJECT_ID=
 
 # If you use GTM, the app will push `virtual_page_view` events to dataLayer on client route changes.
 # Recommended GTM setup:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "newgrowwise",
       "version": "0.1.0",
       "dependencies": {
+        "@microsoft/clarity": "^1.0.2",
         "@next/third-parties": "^16.0.0",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -2645,6 +2646,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
+      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "perf:locust:headless": "bash performance-testing/load/run-locust-headless.sh"
   },
   "dependencies": {
+    "@microsoft/clarity": "^1.0.2",
     "@next/third-parties": "^16.0.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/src/components/analytics/AnalyticsAfterConsent.tsx
+++ b/src/components/analytics/AnalyticsAfterConsent.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Script from 'next/script';
+import { usePathname } from 'next/navigation';
 import { GTMHead, GTMNoScript } from '@/components/analytics/GTM';
 import MetaPixel from '@/components/analytics/MetaPixel';
+import HubSpotSpaTracker from '@/components/analytics/HubSpotSpaTracker';
+import { MicrosoftClarity } from '@/components/analytics/MicrosoftClarity';
 import {
   getStoredCookieConsent,
   isAutomatedAuditEnvironment,
@@ -21,6 +24,7 @@ gtag('config', '${gaId}', { send_page_view: true });
 }
 
 export function AnalyticsAfterConsent() {
+  const pathname = usePathname();
   const [consent, setConsent] = useState<CookieConsentState | null>(null);
   const [ready, setReady] = useState(false);
 
@@ -41,6 +45,8 @@ export function AnalyticsAfterConsent() {
       gtmId: process.env.NEXT_PUBLIC_GTM_ID?.trim() || null,
       pixelId: process.env.NEXT_PUBLIC_META_PIXEL_ID?.trim() || null,
       gaId: process.env.NEXT_PUBLIC_GA_ID?.trim() || null,
+      hubspotHubId: process.env.NEXT_PUBLIC_HUBSPOT_HUB_ID?.trim() || null,
+      clarityProjectId: process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID?.trim() || null,
     };
   }, []);
 
@@ -75,6 +81,11 @@ export function AnalyticsAfterConsent() {
               <Script src={`https://www.googletagmanager.com/gtag/js?id=${env.gaId}`} strategy="lazyOnload" />
               <Script id="gtag-inline" strategy="lazyOnload" dangerouslySetInnerHTML={{ __html: buildGtagInline(env.gaId) }} />
             </>
+          ) : null}
+
+          {env.hubspotHubId ? <HubSpotSpaTracker hubId={env.hubspotHubId} /> : null}
+          {env.clarityProjectId ? (
+            <MicrosoftClarity projectId={env.clarityProjectId} pathname={pathname} />
           ) : null}
         </>
       ) : null}

--- a/src/components/analytics/CookieConsentBanner.tsx
+++ b/src/components/analytics/CookieConsentBanner.tsx
@@ -40,7 +40,7 @@ export function CookieConsentBanner() {
       <div className="mx-auto max-w-4xl rounded-2xl border border-gray-200 bg-white/95 shadow-xl backdrop-blur">
         <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
           <div className="text-sm text-gray-700">
-            <span className="font-semibold text-gray-900">Cookies:</span> We use analytics cookies to understand usage and improve your experience.
+            <span className="font-semibold text-gray-900">Cookies:</span> We use analytics cookies to understand usage and improve your experience. With your consent, we may also record anonymized sessions on public pages.
           </div>
           <div className="flex shrink-0 gap-2">
             <Button

--- a/src/components/analytics/MicrosoftClarity.tsx
+++ b/src/components/analytics/MicrosoftClarity.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Clarity from '@microsoft/clarity';
+import { isAutomatedAuditEnvironment } from '@/lib/consent';
+import { isClarityExcludedPath } from '@/lib/analytics/clarityPaths';
+
+interface MicrosoftClarityProps {
+  projectId: string;
+  pathname: string;
+}
+
+const PROJECT_ID_PATTERN = /^[a-z0-9]+$/i;
+
+/**
+ * Microsoft Clarity — session replay / heatmaps.
+ * Loads only on public pages after analytics cookie consent (parent gate).
+ */
+export function MicrosoftClarity({ projectId, pathname }: MicrosoftClarityProps) {
+  const id = projectId.trim();
+  const initializedRef = useRef(false);
+
+  const shouldSkip =
+    !id ||
+    !PROJECT_ID_PATTERN.test(id) ||
+    isAutomatedAuditEnvironment() ||
+    isClarityExcludedPath(pathname);
+
+  useEffect(() => {
+    if (shouldSkip || initializedRef.current) return;
+
+    Clarity.consentV2({ ad_Storage: 'denied', analytics_Storage: 'granted' });
+    Clarity.init(id);
+    initializedRef.current = true;
+  }, [id, shouldSkip]);
+
+  return null;
+}

--- a/src/components/analytics/__tests__/MicrosoftClarity.test.tsx
+++ b/src/components/analytics/__tests__/MicrosoftClarity.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@/test-utils';
+import { MicrosoftClarity } from '../MicrosoftClarity';
+
+const mockConsentV2 = jest.fn();
+const mockInit = jest.fn();
+
+jest.mock('@microsoft/clarity', () => ({
+  __esModule: true,
+  default: {
+    consentV2: (...args: unknown[]) => mockConsentV2(...args),
+    init: (...args: unknown[]) => mockInit(...args),
+  },
+}));
+
+jest.mock('@/lib/consent', () => ({
+  isAutomatedAuditEnvironment: jest.fn(() => false),
+}));
+
+const { isAutomatedAuditEnvironment } = require('@/lib/consent') as {
+  isAutomatedAuditEnvironment: jest.Mock;
+};
+
+describe('MicrosoftClarity', () => {
+  beforeEach(() => {
+    mockConsentV2.mockClear();
+    mockInit.mockClear();
+    isAutomatedAuditEnvironment.mockReturnValue(false);
+  });
+
+  it('initializes Clarity on allowed public paths', () => {
+    render(<MicrosoftClarity projectId="abc123" pathname="/en/camps/summer" />);
+
+    expect(mockConsentV2).toHaveBeenCalledWith({
+      ad_Storage: 'denied',
+      analytics_Storage: 'granted',
+    });
+    expect(mockInit).toHaveBeenCalledWith('abc123');
+  });
+
+  it('skips init on excluded checkout paths', () => {
+    render(<MicrosoftClarity projectId="abc123" pathname="/en/checkout" />);
+
+    expect(mockConsentV2).not.toHaveBeenCalled();
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('skips init in automated audit environments', () => {
+    isAutomatedAuditEnvironment.mockReturnValue(true);
+
+    render(<MicrosoftClarity projectId="abc123" pathname="/en/camps/summer" />);
+
+    expect(mockConsentV2).not.toHaveBeenCalled();
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('skips init when project id is missing', () => {
+    render(<MicrosoftClarity projectId="" pathname="/en/camps/summer" />);
+
+    expect(mockConsentV2).not.toHaveBeenCalled();
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chatbot/ContactForm.tsx
+++ b/src/components/chatbot/ContactForm.tsx
@@ -130,7 +130,7 @@ export default function ContactForm({
   }
 
   return (
-    <Card className="relative bg-white/95 backdrop-blur-sm border-2 border-white/50">
+    <Card className="relative bg-white/95 backdrop-blur-sm border-2 border-white/50" data-clarity-mask="true">
       <CardContent className="p-4">
         <div className="text-center mb-3">
           <h3 className="text-sm font-semibold text-gray-900 mb-1">Get Personalized Information</h3>

--- a/src/components/form/FormPrivacyConsent.tsx
+++ b/src/components/form/FormPrivacyConsent.tsx
@@ -52,7 +52,7 @@ export default function FormPrivacyConsent({
 
   if (alignPrivacyWithConsent) {
     return (
-      <div className={cn('space-y-3', className)}>
+      <div className={cn('space-y-3', className)} data-clarity-mask="true">
         <div className={blockClass}>
           <div className="flex items-start gap-2.5">
             <div className={colIcon}>
@@ -112,7 +112,7 @@ export default function FormPrivacyConsent({
   }
 
   return (
-    <div className={cn('space-y-4', className)}>
+    <div className={cn('space-y-4', className)} data-clarity-mask="true">
       {/* Privacy & Data Protection */}
       <div className={blockClass}>
         <div className="flex items-start gap-3 sm:gap-4">

--- a/src/lib/analytics/__tests__/clarityPaths.test.ts
+++ b/src/lib/analytics/__tests__/clarityPaths.test.ts
@@ -1,0 +1,36 @@
+import { isClarityExcludedPath, stripLocalePrefix } from '@/lib/analytics/clarityPaths';
+
+describe('stripLocalePrefix', () => {
+  it('strips en locale prefix', () => {
+    expect(stripLocalePrefix('/en/camps/summer')).toBe('/camps/summer');
+  });
+
+  it('leaves paths without locale unchanged', () => {
+    expect(stripLocalePrefix('/camps/summer')).toBe('/camps/summer');
+  });
+
+  it('returns root for locale-only path', () => {
+    expect(stripLocalePrefix('/en')).toBe('/');
+  });
+});
+
+describe('isClarityExcludedPath', () => {
+  it('excludes auth and payment routes with locale', () => {
+    expect(isClarityExcludedPath('/en/login')).toBe(true);
+    expect(isClarityExcludedPath('/en/student-login')).toBe(true);
+    expect(isClarityExcludedPath('/en/dashboard')).toBe(true);
+    expect(isClarityExcludedPath('/en/checkout')).toBe(true);
+    expect(isClarityExcludedPath('/en/checkout/success')).toBe(true);
+  });
+
+  it('excludes auth and payment routes without locale', () => {
+    expect(isClarityExcludedPath('/login')).toBe(true);
+    expect(isClarityExcludedPath('/checkout')).toBe(true);
+  });
+
+  it('allows public marketing routes', () => {
+    expect(isClarityExcludedPath('/en/camps/summer')).toBe(false);
+    expect(isClarityExcludedPath('/en/enroll')).toBe(false);
+    expect(isClarityExcludedPath('/en/contact')).toBe(false);
+  });
+});

--- a/src/lib/analytics/clarityPaths.ts
+++ b/src/lib/analytics/clarityPaths.ts
@@ -1,0 +1,34 @@
+import { AVAILABLE_LOCALES } from '@/i18n/localeConfig';
+
+/** Path prefixes where Clarity session recording must not run. */
+const CLARITY_EXCLUDED_PREFIXES = [
+  '/login',
+  '/student-login',
+  '/dashboard',
+  '/checkout',
+] as const;
+
+const LOCALE_PREFIXES = new Set<string>(AVAILABLE_LOCALES);
+
+/**
+ * Strip an optional locale segment (e.g. `/en/camps` → `/camps`).
+ */
+export function stripLocalePrefix(pathname: string): string {
+  const normalized = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const segments = normalized.split('/').filter(Boolean);
+  if (segments.length === 0) return '/';
+
+  if (LOCALE_PREFIXES.has(segments[0])) {
+    segments.shift();
+  }
+
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
+}
+
+/** True when Clarity must not initialize on this pathname. */
+export function isClarityExcludedPath(pathname: string): boolean {
+  const path = stripLocalePrefix(pathname);
+  return CLARITY_EXCLUDED_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}


### PR DESCRIPTION
## Summary
- Add Microsoft Clarity (`@microsoft/clarity`) for session replay and heatmaps on public pages, gated behind cookie consent with path exclusions for login, student-login, dashboard, and checkout.
- Mount existing `HubSpotSpaTracker` in `AnalyticsAfterConsent` for consent-gated page views and SPA navigation (tracking only — no HubSpot chat embed).
- Mask PII on contact/enrollment form wrappers via `data-clarity-mask` and document new env vars in `env.local.example`.

## What did NOT change
- Ask Growy chatbot / OpenAI `/api/chat`
- Server-side HubSpot Forms API (`submitHubSpotForm`)
- GTM, GA4, Meta Pixel, Firebase analytics, checkout purchase event

## Deploy prerequisites
- Set `NEXT_PUBLIC_CLARITY_PROJECT_ID` and `NEXT_PUBLIC_HUBSPOT_HUB_ID` in Vercel (Preview + Production)
- Disable HubSpot chat widget in HubSpot portal (Ask Growy remains the site chatbot)
- Enable cookie consent required in Clarity dashboard

## Test plan
- [ ] Decline cookies → no requests to `clarity.ms` or `js.hs-scripts.com`
- [ ] Accept cookies → both load on public pages (e.g. `/en/camps/summer`)
- [ ] Visit `/en/checkout` → Clarity does not init
- [ ] Ask Growy chat opens and responds; only one chat widget visible
- [ ] Contact form / chat email gate still sync leads server-side to HubSpot (if configured)
- [ ] GTM `virtual_page_view` still fires on client navigation
- [ ] `npm test -- --testPathPatterns="clarityPaths|MicrosoftClarity|PageTrackingWrapper|ChatbotContext"` passes


Made with [Cursor](https://cursor.com)