### PR TITLE
fix(analytics): resolve Clarity prod crash and header 404 noise

### DIFF
--- a/src/components/analytics/AnalyticsAfterConsent.tsx
+++ b/src/components/analytics/AnalyticsAfterConsent.tsx
@@ -7,6 +7,7 @@ import { GTMHead, GTMNoScript } from '@/components/analytics/GTM';
 import MetaPixel from '@/components/analytics/MetaPixel';
 import HubSpotSpaTracker from '@/components/analytics/HubSpotSpaTracker';
 import { MicrosoftClarity } from '@/components/analytics/MicrosoftClarity';
+import { isClarityExcludedPath } from '@/lib/analytics/clarityPaths';
 import {
   getStoredCookieConsent,
   isAutomatedAuditEnvironment,
@@ -84,7 +85,7 @@ export function AnalyticsAfterConsent() {
           ) : null}
 
           {env.hubspotHubId ? <HubSpotSpaTracker hubId={env.hubspotHubId} /> : null}
-          {env.clarityProjectId ? (
+          {env.clarityProjectId && !isClarityExcludedPath(pathname) ? (
             <MicrosoftClarity projectId={env.clarityProjectId} pathname={pathname} />
           ) : null}
         </>

--- a/src/components/analytics/MicrosoftClarity.tsx
+++ b/src/components/analytics/MicrosoftClarity.tsx
@@ -12,6 +12,12 @@ interface MicrosoftClarityProps {
 
 const PROJECT_ID_PATTERN = /^[a-z0-9]+$/i;
 
+function stopClarityRecording() {
+  if (typeof window !== 'undefined' && typeof window.clarity === 'function') {
+    window.clarity('stop');
+  }
+}
+
 /**
  * Microsoft Clarity — session replay / heatmaps.
  * Loads only on public pages after analytics cookie consent (parent gate).
@@ -27,12 +33,32 @@ export function MicrosoftClarity({ projectId, pathname }: MicrosoftClarityProps)
     isClarityExcludedPath(pathname);
 
   useEffect(() => {
-    if (shouldSkip || initializedRef.current) return;
+    if (shouldSkip) {
+      if (initializedRef.current) {
+        stopClarityRecording();
+        initializedRef.current = false;
+      }
+      return;
+    }
 
-    Clarity.consentV2({ ad_Storage: 'denied', analytics_Storage: 'granted' });
+    if (initializedRef.current) return;
+
+    // init() creates the window.clarity queue stub; consentV2 requires it.
     Clarity.init(id);
+    if (typeof window.clarity === 'function') {
+      Clarity.consentV2({ ad_Storage: 'denied', analytics_Storage: 'granted' });
+    }
     initializedRef.current = true;
   }, [id, shouldSkip]);
+
+  useEffect(() => {
+    return () => {
+      if (initializedRef.current) {
+        stopClarityRecording();
+        initializedRef.current = false;
+      }
+    };
+  }, []);
 
   return null;
 }

--- a/src/components/analytics/__tests__/MicrosoftClarity.test.tsx
+++ b/src/components/analytics/__tests__/MicrosoftClarity.test.tsx
@@ -4,6 +4,7 @@ import { MicrosoftClarity } from '../MicrosoftClarity';
 
 const mockConsentV2 = jest.fn();
 const mockInit = jest.fn();
+const mockClarityStop = jest.fn();
 
 jest.mock('@microsoft/clarity', () => ({
   __esModule: true,
@@ -25,17 +26,28 @@ describe('MicrosoftClarity', () => {
   beforeEach(() => {
     mockConsentV2.mockClear();
     mockInit.mockClear();
+    mockClarityStop.mockClear();
     isAutomatedAuditEnvironment.mockReturnValue(false);
+    mockInit.mockImplementation(() => {
+      (window as Window & { clarity?: (...args: unknown[]) => void }).clarity = mockClarityStop;
+    });
+  });
+
+  afterEach(() => {
+    delete (window as Window & { clarity?: (...args: unknown[]) => void }).clarity;
   });
 
   it('initializes Clarity on allowed public paths', () => {
     render(<MicrosoftClarity projectId="abc123" pathname="/en/camps/summer" />);
 
+    expect(mockInit).toHaveBeenCalledWith('abc123');
     expect(mockConsentV2).toHaveBeenCalledWith({
       ad_Storage: 'denied',
       analytics_Storage: 'granted',
     });
-    expect(mockInit).toHaveBeenCalledWith('abc123');
+    expect(mockInit.mock.invocationCallOrder[0]).toBeLessThan(
+      mockConsentV2.mock.invocationCallOrder[0],
+    );
   });
 
   it('skips init on excluded checkout paths', () => {
@@ -43,6 +55,18 @@ describe('MicrosoftClarity', () => {
 
     expect(mockConsentV2).not.toHaveBeenCalled();
     expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('stops recording when navigating to an excluded route', () => {
+    const { rerender } = render(
+      <MicrosoftClarity projectId="abc123" pathname="/en/camps/summer" />,
+    );
+
+    expect(mockInit).toHaveBeenCalledTimes(1);
+
+    rerender(<MicrosoftClarity projectId="abc123" pathname="/en/checkout" />);
+
+    expect(mockClarityStop).toHaveBeenCalledWith('stop');
   });
 
   it('skips init in automated audit environments', () => {
@@ -59,5 +83,25 @@ describe('MicrosoftClarity', () => {
 
     expect(mockConsentV2).not.toHaveBeenCalled();
     expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('skips init when project id format is invalid', () => {
+    render(<MicrosoftClarity projectId="bad id!" pathname="/en/camps/summer" />);
+
+    expect(mockConsentV2).not.toHaveBeenCalled();
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when window.clarity is unavailable after init', () => {
+    mockInit.mockImplementation(() => {
+      delete (window as Window & { clarity?: (...args: unknown[]) => void }).clarity;
+    });
+
+    expect(() => {
+      render(<MicrosoftClarity projectId="abc123" pathname="/en/camps/summer" />);
+    }).not.toThrow();
+
+    expect(mockInit).toHaveBeenCalledWith('abc123');
+    expect(mockConsentV2).not.toHaveBeenCalled();
   });
 });

--- a/src/store/sagas/headerSaga.ts
+++ b/src/store/sagas/headerSaga.ts
@@ -3,12 +3,8 @@ import { fetchHeaderRequested, fetchHeaderSucceeded, fetchHeaderFailed } from '.
 import { fetchJsonWithLocale } from '@/lib/api';
 
 async function fetchHeaderApi() {
-  try {
-    return await fetchJsonWithLocale<any>('header.json', '/header');
-  } catch {
-    // growwise_backend may not expose GET /header — fall back to committed mock JSON.
-    return fetchJsonWithLocale<any>('header.json', undefined);
-  }
+  // growwise_backend does not expose GET /header — use committed mock JSON only.
+  return fetchJsonWithLocale<any>('header.json', undefined);
 }
 
 function* handleFetchHeader() {


### PR DESCRIPTION
## Summary
- Fix production crash `window.clarity is not a function` by calling `Clarity.init()` before `consentV2()` (the npm SDK requires the init stub on `window.clarity`).
- Stop Clarity recording when users navigate to excluded routes (checkout, login, dashboard) and unmount the tracker on sensitive paths.
- Remove doomed `GET /header` API call that always 404'd in prod; header menu loads from committed mock JSON (same fallback behavior, no console noise).

## Regression coverage
- All 335 Jest tests pass (`npm run test:ci`)
- Added tests for init order, SPA route stop, invalid project ID, and missing `window.clarity` guard
- Verified `PageTrackingWrapper`, `ChatbotContext`, and `clarityPaths` suites unchanged

## Test plan
- [ ] Hard refresh prod, accept cookies → no `window.clarity is not a function` in console
- [ ] Decline cookies → no requests to `clarity.ms`
- [ ] Accept cookies on `/en/camps/summer` → Clarity loads
- [ ] Navigate to `/en/checkout` → Clarity stops / does not record
- [ ] Header nav renders correctly with no `GET /header` 404
- [ ] Ask Growy chat still works; GTM/HubSpot unaffected


Made with [Cursor](https://cursor.com)