### PR TITLE
fix(hubspot): CRM lead sync for all form routes + suppress duplicate chat widget

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -23,7 +23,8 @@ NEXT_PUBLIC_META_PIXEL_ID=
 # Lighthouse "Uses deprecated APIs" → AttributionReporting often traces to Meta's fbevents.js, not app code.
 NEXT_PUBLIC_META_PIXEL_DISABLE_APP=
 # HubSpot CRM (server-only Forms API — lead capture without exposing form GUID to the client)
-# Create a HubSpot form; map fields: firstname, lastname, email, phone, message (used by /api/contact and /api/hubspot-submit).
+# Required for ALL lead routes (/api/contact, /api/enroll, /api/assessment, /api/chat/email-lead, etc.).
+# Create a HubSpot form; map fields: firstname, lastname, email, phone, message (used by lead API routes).
 # Portal ID: HubSpot Settings → Account & Billing → Account Information (Hub ID).
 # Form GUID: form editor URL or form embed code.
 HUBSPOT_PORTAL_ID=

--- a/env.local.example
+++ b/env.local.example
@@ -29,8 +29,8 @@ NEXT_PUBLIC_META_PIXEL_DISABLE_APP=
 HUBSPOT_PORTAL_ID=
 HUBSPOT_FORM_GUID=
 # HubSpot client tracking — page views + SPA navigation (consent-gated; loads js.hs-scripts.com).
-# Use the same numeric Hub ID as HUBSPOT_PORTAL_ID. Keep HubSpot chat widget OFF in the HubSpot portal
-# (Ask Growy is the site chatbot — enabling HubSpot chat would show a duplicate widget).
+# Use the same numeric Hub ID as HUBSPOT_PORTAL_ID. The app suppresses HubSpot's chat launcher in code
+# (Ask Growy is the site chatbot). Also disable HubSpot chat in the portal if you see a duplicate widget.
 NEXT_PUBLIC_HUBSPOT_HUB_ID=
 
 # Microsoft Clarity — session replay / heatmaps (consent-gated; public pages only — excludes login, checkout, dashboard).

--- a/src/app/api/assessment/route.ts
+++ b/src/app/api/assessment/route.ts
@@ -6,6 +6,7 @@ import {
   isBrevoTransactionalReady,
   sendBrevoTransactionalEmail,
 } from '@/lib/brevo';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 import { clientIpFrom, isAllowed } from '@/lib/chatRateLimit';
 import { clip, exceedsMax, FIELD_MAX, isValidEmailShape } from '@/lib/inputLimits';
 import { honeypotTriggered, isOriginAllowed } from '@/lib/requestGuard';
@@ -176,6 +177,38 @@ export async function POST(request: Request) {
         emailIds: emailResult.emailIds,
         userConfirmationSent: process.env.ENABLE_USER_CONFIRMATION_EMAIL === 'true',
       });
+
+      const { firstname, lastname } = splitFullName(assessmentData.parentName);
+      const messageBlock = [
+        `Student: ${assessmentData.studentName}`,
+        `Grade: ${assessmentData.grade}`,
+        `Assessment type: ${assessmentData.assessmentType}`,
+        `Mode: ${assessmentData.mode}`,
+        `Schedule: ${assessmentData.schedule}`,
+        assessmentData.hearAboutUs ? `Heard about us: ${assessmentData.hearAboutUs}` : '',
+        assessmentData.notes ? `Notes: ${assessmentData.notes}` : '',
+        assessmentData.subjects?.length
+          ? `Subjects: ${assessmentData.subjects.join(', ')}`
+          : '',
+        'Source: book-assessment-form',
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      await syncHubSpotLeadIfConfigured(
+        [
+          { name: 'firstname', value: firstname },
+          { name: 'lastname', value: lastname },
+          { name: 'email', value: assessmentData.email },
+          { name: 'phone', value: assessmentData.phone },
+          { name: 'message', value: messageBlock },
+        ],
+        {
+          pageUri: request.headers.get('referer') ?? '',
+          pageName: 'Book assessment form',
+        },
+        'assessment',
+      );
 
       const payload: Record<string, unknown> = {
         success: true,

--- a/src/app/api/chat/email-lead/route.ts
+++ b/src/app/api/chat/email-lead/route.ts
@@ -5,10 +5,7 @@ import { sendEmail, type SendEmailResult } from '@/lib/email';
 import { clientIpFrom, isAllowed } from '@/lib/chatRateLimit';
 import { clip, exceedsMax, FIELD_MAX, isValidEmailShape } from '@/lib/inputLimits';
 import { honeypotTriggered, isOriginAllowed } from '@/lib/requestGuard';
-import {
-  isHubSpotFormsConfigured,
-  submitHubSpotForm,
-} from '@/lib/hubspot/submitForm';
+import { syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 
 const MAX_BODY_BYTES = 4 * 1024;
 
@@ -176,34 +173,29 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (isHubSpotFormsConfigured()) {
-      const messageBlock = [
-        'Growy chat email gate — conversation unlocked.',
-        pageContextId !== 'default' ? `Page context: ${pageContextId}` : '',
-        referer ? `Page: ${referer}` : '',
-        queuedMessage ? `Queued first message: ${queuedMessage}` : '',
-        'Source: chatbot-email-gate',
-      ]
-        .filter(Boolean)
-        .join('\n');
+    const messageBlock = [
+      'Growy chat email gate — conversation unlocked.',
+      pageContextId !== 'default' ? `Page context: ${pageContextId}` : '',
+      referer ? `Page: ${referer}` : '',
+      queuedMessage ? `Queued first message: ${queuedMessage}` : '',
+      'Source: chatbot-email-gate',
+    ]
+      .filter(Boolean)
+      .join('\n');
 
-      const hubResult = await submitHubSpotForm(
-        [
-          { name: 'firstname', value: 'Growy' },
-          { name: 'lastname', value: 'Chat lead' },
-          { name: 'email', value: email },
-          { name: 'message', value: messageBlock },
-        ],
-        {
-          pageUri: referer,
-          pageName: 'Growy chat email gate',
-        },
-      );
-
-      if (!hubResult.ok) {
-        console.error('[chat/email-lead] HubSpot sync failed:', hubResult.message);
-      }
-    }
+    await syncHubSpotLeadIfConfigured(
+      [
+        { name: 'firstname', value: 'Growy' },
+        { name: 'lastname', value: 'Chat lead' },
+        { name: 'email', value: email },
+        { name: 'message', value: messageBlock },
+      ],
+      {
+        pageUri: referer,
+        pageName: 'Growy chat email gate',
+      },
+      'chat/email-lead',
+    );
 
     console.log('[chat/email-lead] ok', {
       emailDomain: email.slice(email.indexOf('@') + 1),

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -4,11 +4,7 @@ import { CONTACT_INFO } from '@/lib/constants';
 import { isBrevoTransactionalReady, sendBrevoTransactionalEmail } from '@/lib/brevo';
 import { sendEmail, type SendEmailResult } from '@/lib/email';
 import { validatePhoneSimple } from '@/lib/phoneValidation';
-import {
-  isHubSpotFormsConfigured,
-  splitFullName,
-  submitHubSpotForm,
-} from '@/lib/hubspot/submitForm';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 import { clientIpFrom, isAllowed } from '@/lib/chatRateLimit';
 import { clip, exceedsMax, FIELD_MAX, isValidEmailShape } from '@/lib/inputLimits';
 import { honeypotTriggered, isOriginAllowed } from '@/lib/requestGuard';
@@ -193,33 +189,28 @@ export async function POST(request: Request) {
         messageId: emailResult.messageId,
       });
 
-      // HubSpot CRM (server-only Forms API — same env as /api/hubspot-submit; does not load chat widget)
-      if (isHubSpotFormsConfigured()) {
-        const { firstname, lastname } = splitFullName(contactData.name);
-        const messageBlock = [
-          contactData.message?.trim(),
-          `Source: ${contactData.source}`,
-        ]
-          .filter((s) => typeof s === 'string' && s.length > 0)
-          .join('\n\n');
+      const { firstname, lastname } = splitFullName(contactData.name);
+      const messageBlock = [
+        contactData.message?.trim(),
+        `Source: ${contactData.source}`,
+      ]
+        .filter((s) => typeof s === 'string' && s.length > 0)
+        .join('\n\n');
 
-        const hubResult = await submitHubSpotForm(
-          [
-            { name: 'firstname', value: firstname },
-            { name: 'lastname', value: lastname },
-            { name: 'email', value: contactData.email },
-            { name: 'phone', value: contactData.phone },
-            { name: 'message', value: messageBlock },
-          ],
-          {
-            pageUri: request.headers.get('referer') ?? '',
-            pageName: 'Website contact (chatbot)',
-          }
-        );
-        if (!hubResult.ok) {
-          console.error('[contact] HubSpot CRM sync failed:', hubResult.message);
-        }
-      }
+      await syncHubSpotLeadIfConfigured(
+        [
+          { name: 'firstname', value: firstname },
+          { name: 'lastname', value: lastname },
+          { name: 'email', value: contactData.email },
+          { name: 'phone', value: contactData.phone },
+          { name: 'message', value: messageBlock },
+        ],
+        {
+          pageUri: request.headers.get('referer') ?? '',
+          pageName: 'Website contact',
+        },
+        'contact',
+      );
 
       return NextResponse.json({
         success: true,

--- a/src/app/api/enroll/route.ts
+++ b/src/app/api/enroll/route.ts
@@ -7,6 +7,7 @@ import {
   isBrevoTransactionalReady,
   sendBrevoTransactionalEmail,
 } from '@/lib/brevo';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 import { clientIpFrom, isAllowed } from '@/lib/chatRateLimit';
 import { clip, exceedsMax, FIELD_MAX, isValidEmailShape } from '@/lib/inputLimits';
 import { honeypotTriggered, isOriginAllowed } from '@/lib/requestGuard';
@@ -218,6 +219,31 @@ export async function POST(request: Request) {
         emailIds: emailResult.emailIds,
         userConfirmationSent: process.env.ENABLE_USER_CONFIRMATION_EMAIL === 'true',
       });
+
+      const { firstname, lastname } = splitFullName(enrollmentData.fullName);
+      const messageBlock = [
+        `Level: ${enrollmentData.level}`,
+        `Bootcamp: ${enrollmentData.bootcamp}`,
+        `Course: ${enrollmentData.course}`,
+        `City: ${enrollmentData.city}`,
+        `Postal: ${enrollmentData.postal}`,
+        'Source: enroll-form',
+      ].join('\n');
+
+      await syncHubSpotLeadIfConfigured(
+        [
+          { name: 'firstname', value: firstname },
+          { name: 'lastname', value: lastname },
+          { name: 'email', value: enrollmentData.email },
+          { name: 'phone', value: enrollmentData.mobile },
+          { name: 'message', value: messageBlock },
+        ],
+        {
+          pageUri: request.headers.get('referer') ?? '',
+          pageName: 'Enrollment form',
+        },
+        'enroll',
+      );
 
       const payload: Record<string, unknown> = {
         success: true,

--- a/src/app/api/summer-camp-summercamp/route.ts
+++ b/src/app/api/summer-camp-summercamp/route.ts
@@ -8,6 +8,7 @@ import {
   sendBrevoTransactionalEmail,
 } from '@/lib/brevo';
 import { sendEmail, type EmailAttachment, type SendEmailResult } from '@/lib/email';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
 import {
   buildCampGuidePdfUrl,
@@ -339,6 +340,32 @@ export async function POST(request: Request) {
     if (!businessResult.success) {
       console.warn('[summer-camp-guide] Business notification failed (user email already sent):', businessResult.error);
     }
+
+    const leadName = parentNameRaw || 'Summer camp lead';
+    const { firstname, lastname } = splitFullName(leadName);
+    await syncHubSpotLeadIfConfigured(
+      [
+        { name: 'firstname', value: firstname },
+        { name: 'lastname', value: lastname },
+        { name: 'email', value: email },
+        {
+          name: 'message',
+          value: [
+            `Camp interest: ${interestLabel}`,
+            `Child grade: ${gradeLabel}`,
+            locale ? `Locale: ${locale}` : '',
+            'Source: summer-camp-guide',
+          ]
+            .filter(Boolean)
+            .join('\n'),
+        },
+      ],
+      {
+        pageUri: request.headers.get('referer') ?? '',
+        pageName: 'Summer camp guide',
+      },
+      'summer-camp-summercamp',
+    );
 
     let listAddResult: SendEmailResult | undefined;
     if (brevoReady) {

--- a/src/components/analytics/HubSpotSpaTracker.tsx
+++ b/src/components/analytics/HubSpotSpaTracker.tsx
@@ -9,7 +9,23 @@ const HUB_ID_PATTERN = /^\d{5,12}$/;
 /** HubSpot command queue — commands are string tuples consumed by the tracking script. */
 type HubSpotWindow = Window & {
   _hsq?: unknown[][];
+  hsConversationsSettings?: { loadImmediately?: boolean };
+  hsConversationsOnReady?: Array<() => void>;
+  HubSpotConversations?: {
+    widget?: { remove: () => void };
+  };
 };
+
+/** Ask Growy is the site chatbot — block HubSpot's duplicate launcher if the portal has chat enabled. */
+const HUBSPOT_CHAT_SUPPRESS_INLINE = `
+window.hsConversationsSettings = Object.assign({}, window.hsConversationsSettings, { loadImmediately: false });
+window.hsConversationsOnReady = window.hsConversationsOnReady || [];
+window.hsConversationsOnReady.push(function () {
+  try {
+    window.HubSpotConversations && window.HubSpotConversations.widget && window.HubSpotConversations.widget.remove();
+  } catch (e) {}
+});
+`.trim();
 
 function HubSpotSpaRouteSync() {
   const pathname = usePathname();
@@ -38,13 +54,33 @@ interface HubSpotSpaTrackerProps {
   hubId: string;
 }
 
-/** HubSpot — loads tracking once; fires setPath + trackPageView on client navigations (not the first render). */
+/** HubSpot page views + SPA navigation only — no chat widget (Ask Growy handles chat). */
 export default function HubSpotSpaTracker({ hubId }: HubSpotSpaTrackerProps) {
   const id = hubId.trim();
   if (!id || !HUB_ID_PATTERN.test(id)) return null;
 
+  useEffect(() => {
+    const w = window as HubSpotWindow;
+    w.hsConversationsSettings = { ...w.hsConversationsSettings, loadImmediately: false };
+    const removeWidget = () => {
+      try {
+        w.HubSpotConversations?.widget?.remove();
+      } catch {
+        // ignore
+      }
+    };
+    w.hsConversationsOnReady = w.hsConversationsOnReady || [];
+    w.hsConversationsOnReady.push(removeWidget);
+    removeWidget();
+  }, []);
+
   return (
     <>
+      <Script
+        id="hs-chat-suppress"
+        strategy="beforeInteractive"
+        dangerouslySetInnerHTML={{ __html: HUBSPOT_CHAT_SUPPRESS_INLINE }}
+      />
       <Script
         id="hs-script-loader"
         strategy="afterInteractive"

--- a/src/lib/hubspot/submitForm.ts
+++ b/src/lib/hubspot/submitForm.ts
@@ -76,3 +76,34 @@ export function splitFullName(fullName: string): { firstname: string; lastname: 
   if (i === -1) return { firstname: t, lastname: '' };
   return { firstname: t.slice(0, i), lastname: t.slice(i + 1).trim() };
 }
+
+/**
+ * Sync a lead to HubSpot CRM when server env is configured.
+ * Failures are logged only — callers should still return success to the user if email delivery worked.
+ */
+export async function syncHubSpotLeadIfConfigured(
+  fields: HubSpotFieldRow[],
+  context: { pageUri?: string; pageName?: string },
+  logTag: string,
+): Promise<void> {
+  if (!isHubSpotFormsConfigured()) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(
+        `[${logTag}] HubSpot CRM skipped — set HUBSPOT_PORTAL_ID and HUBSPOT_FORM_GUID on the server`,
+      );
+    }
+    return;
+  }
+
+  const hubResult = await submitHubSpotForm(fields, context);
+  if (!hubResult.ok) {
+    console.error(
+      `[${logTag}] HubSpot CRM sync failed:`,
+      hubResult.message,
+      hubResult.status ?? '',
+    );
+    return;
+  }
+
+  console.log(`[${logTag}] HubSpot CRM sync ok`);
+}


### PR DESCRIPTION
## Summary
- Sync HubSpot CRM leads from `/api/enroll`, `/api/assessment`, and `/api/summer-camp-summercamp` (previously only `/api/contact` and `/api/chat/email-lead` used the server Forms API).
- Add shared `syncHubSpotLeadIfConfigured()` with a production warning when `HUBSPOT_PORTAL_ID` or `HUBSPOT_FORM_GUID` are unset.
- Suppress HubSpot's duplicate chat launcher so Ask Growy remains the only on-site chat widget.

## Context
PR #279 merged the Clarity/header hotfix only. These two HubSpot commits were pushed to the same branch afterward and were never merged to `main`.

## Prerequisites (Production)
- Set `HUBSPOT_PORTAL_ID` and `HUBSPOT_FORM_GUID` in Vercel Production.
- HubSpot form must map fields: `firstname`, `lastname`, `email`, `phone`, `message`.

## Test plan
- [ ] Merge PR and deploy to Production
- [ ] Submit test enrollment → Vercel logs show `[enroll] HubSpot CRM sync ok`
- [ ] Submit book-assessment form → logs show `[assessment] HubSpot CRM sync ok`
- [ ] Accept cookies on site → no duplicate blue HubSpot chat bubble; Ask Growy header button only
- [ ] Confirm contact form still syncs to HubSpot


Made with [Cursor](https://cursor.com)