### PR TITLE
fix(hubspot): CRM sync for all lead forms + smoke E2E coverage

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -233,4 +233,4 @@ Before finishing a change:
 | New routes / sitemap | defer to morning CI (`mobile-404-audit`); do not run unless user requests |
 
 4. Local E2E auto-starts the app: `next start` if `.next/BUILD_ID` exists, otherwise `next dev`. For CI-like runs: `npm run build && E2E_USE_PROD=1 npm run test:e2e:smoke`.
-5. Tag new E2E specs: `@critical` for enrollment/checkout/ad-route regressions; `@nightly` for bulk SEO, camps sweeps, or mobile audits.
+5. Tag new E2E specs: `@critical` for enrollment, checkout, **all lead-form submissions** (contact, assessment, summer camp guide, self-check, math finals), and ad-route regressions; `@nightly` for bulk SEO, camps sweeps, or mobile audits.

--- a/.github/CICD_RUNBOOK.md
+++ b/.github/CICD_RUNBOOK.md
@@ -18,7 +18,7 @@ You open a PR  dev → main
         ▼
 GitHub Actions runs tests automatically (pr-gate.yml)
   ├── Jest unit tests
-  └── Playwright smoke E2E (@critical — checkout, enrollment, ad routes)
+  └── Playwright smoke E2E (@critical — checkout, enrollment, all lead forms, ad routes)
         │
    pass? ──► merge is allowed
    fail? ──► merge is BLOCKED until fixed

--- a/e2e/specs/book-assessment.spec.ts
+++ b/e2e/specs/book-assessment.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { localePath } from '../localePath';
+import { stubRecaptcha } from '../helpers';
 
 /** Click a Radix SelectTrigger reliably — scroll it into view first to avoid sticky-header interception. */
 async function clickTrigger(page: Page, testId: string) {
@@ -23,6 +24,8 @@ async function selectOption(
 
 test.describe('Book assessment form', { tag: '@critical' }, () => {
   test('submits free assessment booking with mocked backend', async ({ page }) => {
+    await stubRecaptcha(page);
+
     await page.route('**/api/assessment', async (route) => {
       if (route.request().method() === 'POST') {
         await route.fulfill({

--- a/e2e/specs/book-assessment.spec.ts
+++ b/e2e/specs/book-assessment.spec.ts
@@ -21,7 +21,7 @@ async function selectOption(
   await expect(page.getByTestId(triggerTestId)).toContainText(expectedTriggerText, { timeout: 8000 });
 }
 
-test.describe('Book assessment form', { tag: '@nightly' }, () => {
+test.describe('Book assessment form', { tag: '@critical' }, () => {
   test('submits free assessment booking with mocked backend', async ({ page }) => {
     await page.route('**/api/assessment', async (route) => {
       if (route.request().method() === 'POST') {

--- a/e2e/specs/contact.spec.ts
+++ b/e2e/specs/contact.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { localePath } from '../localePath';
 
-test.describe('Contact form', { tag: '@nightly' }, () => {
+test.describe('Contact form', { tag: '@critical' }, () => {
   test('submits contact form successfully with mocked backend', async ({ page }) => {
     await page.route('**/api/contact', async (route) => {
       const body = await route.request().postDataJSON();

--- a/e2e/specs/math-finals-practice.spec.ts
+++ b/e2e/specs/math-finals-practice.spec.ts
@@ -1,15 +1,5 @@
 import { test, expect } from '@playwright/test';
-import type { Page } from '@playwright/test';
 import { localePath } from '../localePath';
-import { fillStable } from '../helpers';
-
-async function selectRadixOption(page: Page, triggerId: string, optionName: RegExp | string) {
-  const trigger = page.locator(`#${triggerId}`);
-  await expect(trigger).toBeVisible({ timeout: 15_000 });
-  await trigger.scrollIntoViewIfNeeded();
-  await trigger.click({ force: true });
-  await page.getByRole('option', { name: optionName }).click();
-}
 
 test.describe('Math finals practice form', { tag: '@critical' }, () => {
   test('submits math finals request with mocked backend', async ({ page }) => {
@@ -25,22 +15,25 @@ test.describe('Math finals practice form', { tag: '@critical' }, () => {
       });
     });
 
-    await page.goto(localePath('/math-finals-practice-session'), {
+    const res = await page.goto(`${localePath('/math-finals-practice-session')}#signup`, {
       waitUntil: 'domcontentloaded',
     });
+    expect(res?.status(), 'math-finals page status').not.toBe(404);
 
-    const parentName = page.locator('#parentName');
+    const parentName = page.getByRole('textbox', { name: /^Parent name/i });
     await expect(parentName).toBeVisible({ timeout: 20_000 });
-    await parentName.scrollIntoViewIfNeeded();
 
-    await fillStable(page, /Parent name/i, 'E2E Parent');
-    await fillStable(page, /Parent email/i, 'math-finals.e2e@example.com');
-    await fillStable(page, /Student name/i, 'E2E Student');
-    await fillStable(page, /Parent phone/i, '5551234567');
-    await page.locator('#school').fill('Dublin High');
+    await parentName.fill('E2E Parent');
+    await page.getByRole('textbox', { name: /^Parent email/i }).fill('math-finals.e2e@example.com');
+    await page.getByRole('textbox', { name: /^Student name/i }).fill('E2E Student');
+    await page.getByRole('textbox', { name: /^Parent phone/i }).fill('5551234567');
+    await page.getByRole('textbox', { name: /^School/i }).fill('Dublin High');
 
-    await selectRadixOption(page, 'grade-select', /^Grade 10$/i);
-    await selectRadixOption(page, 'subject-select', /Algebra 1/i);
+    await page.getByRole('combobox', { name: /^Grade/i }).click({ force: true });
+    await page.getByRole('option', { name: /^Grade 10$/i }).click();
+
+    await page.getByRole('combobox', { name: /Current math course/i }).click({ force: true });
+    await page.getByRole('option', { name: /Algebra 1/i }).click();
 
     await page.getByRole('button', { name: /^Submit$/i }).click();
 

--- a/e2e/specs/math-finals-practice.spec.ts
+++ b/e2e/specs/math-finals-practice.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { localePath } from '../localePath';
+import { fillStable } from '../helpers';
+
+async function selectRadixOption(page: Page, triggerId: string, optionName: RegExp | string) {
+  const trigger = page.locator(`#${triggerId}`);
+  await trigger.scrollIntoViewIfNeeded();
+  await trigger.click({ force: true });
+  await page.getByRole('option', { name: optionName }).click();
+}
+
+test.describe('Math finals practice form', { tag: '@critical' }, () => {
+  test('submits math finals request with mocked backend', async ({ page }) => {
+    await page.route('**/api/math-finals-practice', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, message: 'OK' }),
+      });
+    });
+
+    await page.goto(localePath('/math-finals-practice-session'));
+    await page.locator('#signup').scrollIntoViewIfNeeded();
+
+    await fillStable(page, /Parent name/i, 'E2E Parent');
+    await fillStable(page, /Parent email/i, 'math-finals.e2e@example.com');
+    await fillStable(page, /Student name/i, 'E2E Student');
+    await fillStable(page, /Parent phone/i, '5551234567');
+    await fillStable(page, /^School/i, 'Dublin High');
+
+    await selectRadixOption(page, 'grade-select', /^Grade 10$/i);
+    await selectRadixOption(page, 'subject-select', /Algebra 1/i);
+
+    await page.getByRole('button', { name: /^Submit$/i }).click();
+
+    const thankYouPath = localePath('/math-finals-practice-session/thank-you').replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&',
+    );
+    await expect(page).toHaveURL(new RegExp(`${thankYouPath}(\\?|$)`), { timeout: 20_000 });
+  });
+});

--- a/e2e/specs/math-finals-practice.spec.ts
+++ b/e2e/specs/math-finals-practice.spec.ts
@@ -5,6 +5,7 @@ import { fillStable } from '../helpers';
 
 async function selectRadixOption(page: Page, triggerId: string, optionName: RegExp | string) {
   const trigger = page.locator(`#${triggerId}`);
+  await expect(trigger).toBeVisible({ timeout: 15_000 });
   await trigger.scrollIntoViewIfNeeded();
   await trigger.click({ force: true });
   await page.getByRole('option', { name: optionName }).click();
@@ -24,14 +25,19 @@ test.describe('Math finals practice form', { tag: '@critical' }, () => {
       });
     });
 
-    await page.goto(localePath('/math-finals-practice-session'));
-    await page.locator('#signup').scrollIntoViewIfNeeded();
+    await page.goto(localePath('/math-finals-practice-session'), {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const parentName = page.locator('#parentName');
+    await expect(parentName).toBeVisible({ timeout: 20_000 });
+    await parentName.scrollIntoViewIfNeeded();
 
     await fillStable(page, /Parent name/i, 'E2E Parent');
     await fillStable(page, /Parent email/i, 'math-finals.e2e@example.com');
     await fillStable(page, /Student name/i, 'E2E Student');
     await fillStable(page, /Parent phone/i, '5551234567');
-    await fillStable(page, /^School/i, 'Dublin High');
+    await page.locator('#school').fill('Dublin High');
 
     await selectRadixOption(page, 'grade-select', /^Grade 10$/i);
     await selectRadixOption(page, 'subject-select', /Algebra 1/i);

--- a/e2e/specs/self-check-detective.spec.ts
+++ b/e2e/specs/self-check-detective.spec.ts
@@ -169,7 +169,7 @@ test.describe('Self-Check funnel', { tag: '@nightly' }, () => {
   });
 
   // ── 6. Happy path — magic link card appears after submit ──────────────────
-  test('successful submission shows magic link card', async ({ page }) => {
+  test('successful submission shows magic link card', { tag: '@critical' }, async ({ page }) => {
     await mockSelfCheckSuccess(page);
     await goto(page, localePath('/self-check'));
     await fillAndSubmitForm(page, 'Grade 3');

--- a/e2e/specs/summer-camp-lottery.spec.ts
+++ b/e2e/specs/summer-camp-lottery.spec.ts
@@ -9,7 +9,7 @@ async function openSummerCampGuideModal(page: Page): Promise<void> {
 }
 
 test.describe('Summer camp lottery form (UI)', { tag: '@nightly' }, () => {
-  test('submits lottery form and navigates to thank-you page with mocked API', async ({ page }) => {
+  test('submits lottery form and navigates to thank-you page with mocked API', { tag: '@critical' }, async ({ page }) => {
     // The guide modal form posts to /api/summer-camp-summercamp (not /api/summer-camp-lottery).
     await page.route('**/api/summer-camp-summercamp', async (route) => {
       if (route.request().method() !== 'POST') {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ import { defineConfig, devices } from '@playwright/test';
  * - Otherwise defaults to http://localhost:3000
  *
  * Test tiers (see `.cursor/rules.md` §17):
- * - @critical — enrollment, checkout, ad landing routes; run on every PR (`npm run test:e2e:smoke`)
+ * - @critical — enrollment, checkout, all lead forms, ad landing routes; run on every PR (`npm run test:e2e:smoke`)
  * - @nightly — bulk SEO/camps/mobile audit; run on morning schedule only (`npm run test:e2e:full`)
  *
  * Stripe:

--- a/src/app/api/leads/meta/route.ts
+++ b/src/app/api/leads/meta/route.ts
@@ -1,6 +1,7 @@
 import { after, NextResponse } from 'next/server';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { upsertMetaLeadContactInBrevo } from '@/lib/brevo';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 import {
   extractLeadgenWebhookEvents,
   fetchMetaLeadFromGraph,
@@ -50,6 +51,46 @@ async function processLeadgenEvents(
         });
       } else {
         console.log(`${LOG_PREFIX} Brevo sync ok`, { leadgenId: evt.leadgenId });
+
+        if (normalized.email) {
+          let firstname = normalized.firstName ?? '';
+          let lastname = normalized.lastName ?? '';
+          if (!firstname && !lastname && normalized.fullName) {
+            const split = splitFullName(normalized.fullName);
+            firstname = split.firstname;
+            lastname = split.lastname;
+          }
+
+          const rawFields = Object.entries(normalized.rawFieldData)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join('\n');
+          const hubspotMessage = [
+            normalized.formId ? `Form ID: ${normalized.formId}` : '',
+            normalized.pageId ? `Page ID: ${normalized.pageId}` : '',
+            normalized.adId ? `Ad ID: ${normalized.adId}` : '',
+            normalized.submittedAt ? `Submitted: ${normalized.submittedAt}` : '',
+            rawFields,
+            'Source: meta-lead-ads',
+          ]
+            .filter(Boolean)
+            .join('\n');
+
+          const hubspotFields = [
+            { name: 'firstname', value: firstname },
+            { name: 'lastname', value: lastname },
+            { name: 'email', value: normalized.email },
+            { name: 'message', value: hubspotMessage },
+          ];
+          if (normalized.phone) {
+            hubspotFields.push({ name: 'phone', value: normalized.phone });
+          }
+
+          await syncHubSpotLeadIfConfigured(
+            hubspotFields,
+            { pageUri: '', pageName: 'Meta Lead Ads' },
+            'meta-leads',
+          );
+        }
       }
     } catch (err) {
       console.error(`${LOG_PREFIX} leadgen pipeline error`, {

--- a/src/app/api/math-finals-practice/route.ts
+++ b/src/app/api/math-finals-practice/route.ts
@@ -6,6 +6,7 @@ import {
   upsertMathFinalsLeadInBrevo,
 } from '@/lib/brevo'
 import { sendEmail, type EmailAttachment, type SendEmailResult } from '@/lib/email'
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm'
 import { isMathFinalsPracticeInterest, MATH_FINALS_INTEREST_LABELS, type MathFinalsPracticeInterest } from '@/data/math-finals-practice-interest'
 import { MATH_FINALS_PRACTICE_SUBJECTS, type MathFinalsPracticeSubject } from '@/data/math-finals-practice-subjects'
 
@@ -385,6 +386,35 @@ export async function POST(request: Request) {
         businessResult.error
       )
     }
+
+    const { firstname, lastname } = splitFullName(pName)
+    const hubspotMessage = [
+      `Interest: ${interestLabel} (${interest})`,
+      `Student: ${sName}`,
+      `Grade: ${g}`,
+      sch ? `School: ${sch}` : '',
+      `Current math course: ${subj}`,
+      `Q4 topics / outline: ${agendaAttachment ? `attached (${agendaAttachment.filename})` : 'not uploaded'}`,
+      notesVal ? `Notes: ${notesVal}` : '',
+      'Source: math-finals-practice',
+    ]
+      .filter(Boolean)
+      .join('\n')
+
+    await syncHubSpotLeadIfConfigured(
+      [
+        { name: 'firstname', value: firstname },
+        { name: 'lastname', value: lastname },
+        { name: 'email', value: pEmail },
+        { name: 'phone', value: pPhone },
+        { name: 'message', value: hubspotMessage },
+      ],
+      {
+        pageUri: request.headers.get('referer') ?? '',
+        pageName: 'Math finals practice',
+      },
+      'math-finals-practice',
+    )
 
     let brevoListResult: SendEmailResult | undefined
     if (brevoReady) {

--- a/src/app/api/self-check/route.ts
+++ b/src/app/api/self-check/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { clip, exceedsMax, FIELD_MAX, isValidEmailShape } from '@/lib/inputLimits';
 import { honeypotTriggered, isOriginAllowed } from '@/lib/requestGuard';
 import { clientIpFrom, isAllowed } from '@/lib/chatRateLimit';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 
 export const maxDuration = 30;
 
@@ -300,6 +301,29 @@ export async function POST(request: Request) {
     } catch (adminEmailErr) {
       console.error('[self-check] Admin notification error:', adminEmailErr);
     }
+
+    const { firstname, lastname } = splitFullName(parentName);
+    const hubspotMessage = [
+      `Student: ${studentName}`,
+      `Grade: ${grade}`,
+      `Subject: ${subject}`,
+      `Parent prediction: ${parentPrediction.join(', ')}`,
+      'Source: self-check-mistake-detective',
+    ].join('\n');
+
+    await syncHubSpotLeadIfConfigured(
+      [
+        { name: 'firstname', value: firstname },
+        { name: 'lastname', value: lastname },
+        { name: 'email', value: parentEmail },
+        { name: 'message', value: hubspotMessage },
+      ],
+      {
+        pageUri: request.headers.get('referer') ?? '',
+        pageName: 'Mistake Detective self-check',
+      },
+      'self-check',
+    );
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/webinar-workshop/route.ts
+++ b/src/app/api/webinar-workshop/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { CONTACT_INFO } from '@/lib/constants';
 import { sendEmail } from '@/lib/email';
+import { splitFullName, syncHubSpotLeadIfConfigured } from '@/lib/hubspot/submitForm';
 
 export interface WebinarWorkshopFormData {
   parentName: string;
@@ -173,6 +174,35 @@ export async function POST(request: Request) {
     if (!businessResult.success) {
       console.warn('Workshop registration: business notification email skipped.', businessResult.error);
     }
+
+    const { firstname, lastname } = splitFullName(payload.parentName);
+    const hubspotMessage = [
+      `Student: ${payload.studentName} (Grade ${payload.grade})`,
+      `School district: ${payload.schoolDistrict}`,
+      `How they heard: ${payload.howDidYouHear}`,
+      `Event type: ${payload.eventType}`,
+      payload.eventTitle ? `Event: ${payload.eventTitle}` : '',
+      payload.eventDate ? `Date: ${payload.eventDate}` : '',
+      payload.eventTime ? `Time: ${payload.eventTime}` : '',
+      'Source: webinar-workshop',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    await syncHubSpotLeadIfConfigured(
+      [
+        { name: 'firstname', value: firstname },
+        { name: 'lastname', value: lastname },
+        { name: 'email', value: payload.email },
+        ...(payload.phone ? [{ name: 'phone', value: payload.phone }] : []),
+        { name: 'message', value: hubspotMessage },
+      ],
+      {
+        pageUri: request.headers.get('referer') ?? '',
+        pageName: 'Webinar/workshop registration',
+      },
+      'webinar-workshop',
+    );
 
     return NextResponse.json({
       success: true,

--- a/src/lib/hubspot/submitForm.test.ts
+++ b/src/lib/hubspot/submitForm.test.ts
@@ -1,4 +1,149 @@
-import { splitFullName } from './submitForm';
+import {
+  isHubSpotFormsConfigured,
+  splitFullName,
+  submitHubSpotForm,
+  syncHubSpotLeadIfConfigured,
+} from './submitForm';
+
+const ORIGINAL_ENV = process.env;
+const ORIGINAL_FETCH = global.fetch;
+
+describe('isHubSpotFormsConfigured', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns false when portal or form guid is missing', () => {
+    delete process.env.HUBSPOT_PORTAL_ID;
+    delete process.env.HUBSPOT_FORM_GUID;
+    expect(isHubSpotFormsConfigured()).toBe(false);
+  });
+
+  it('returns true when both env vars are set', () => {
+    process.env.HUBSPOT_PORTAL_ID = '49050588';
+    process.env.HUBSPOT_FORM_GUID = '8bb212e9-e59a-4b4f-a416-a23f1de1cefa';
+    expect(isHubSpotFormsConfigured()).toBe(true);
+  });
+});
+
+describe('submitHubSpotForm', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.HUBSPOT_PORTAL_ID = '49050588';
+    process.env.HUBSPOT_FORM_GUID = '8bb212e9-e59a-4b4f-a416-a23f1de1cefa';
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns not configured when env is missing', async () => {
+    delete process.env.HUBSPOT_PORTAL_ID;
+    const result = await submitHubSpotForm([{ name: 'email', value: 'a@b.com' }]);
+    expect(result).toEqual({ ok: false, message: 'HubSpot Forms API is not configured' });
+  });
+
+  it('posts fields to HubSpot Forms API and returns ok on success', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '{"inlineMessage":""}',
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const fields = [
+      { name: 'firstname', value: 'Test' },
+      { name: 'email', value: 'test@example.com' },
+    ];
+    const result = await submitHubSpotForm(fields, {
+      pageUri: 'https://growwiseschool.org/contact',
+      pageName: 'Contact',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.hsforms.com/submissions/v3/integration/submit/49050588/8bb212e9-e59a-4b4f-a416-a23f1de1cefa',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fields,
+          context: {
+            pageUri: 'https://growwiseschool.org/contact',
+            pageName: 'Contact',
+          },
+        }),
+      }),
+    );
+  });
+
+  it('returns failure when HubSpot rejects the submission', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => '{"message":"Invalid field"}',
+    }) as typeof fetch;
+
+    const result = await submitHubSpotForm([{ name: 'email', value: 'bad' }]);
+    expect(result).toEqual({
+      ok: false,
+      message: 'HubSpot submission failed',
+      status: 400,
+    });
+  });
+});
+
+describe('syncHubSpotLeadIfConfigured', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    process.env = ORIGINAL_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it('skips sync when HubSpot env is not configured', async () => {
+    delete process.env.HUBSPOT_PORTAL_ID;
+    delete process.env.HUBSPOT_FORM_GUID;
+    process.env.NODE_ENV = 'production';
+
+    await syncHubSpotLeadIfConfigured(
+      [{ name: 'email', value: 'test@example.com' }],
+      { pageName: 'Test' },
+      'self-check',
+    );
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[self-check] HubSpot CRM skipped — set HUBSPOT_PORTAL_ID and HUBSPOT_FORM_GUID on the server',
+    );
+  });
+
+  it('logs success when HubSpot accepts the lead', async () => {
+    process.env.HUBSPOT_PORTAL_ID = '49050588';
+    process.env.HUBSPOT_FORM_GUID = '8bb212e9-e59a-4b4f-a416-a23f1de1cefa';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '{"inlineMessage":""}',
+    }) as typeof fetch;
+
+    await syncHubSpotLeadIfConfigured(
+      [{ name: 'email', value: 'test@example.com' }],
+      { pageName: 'Math finals practice' },
+      'math-finals-practice',
+    );
+
+    expect(console.log).toHaveBeenCalledWith('[math-finals-practice] HubSpot CRM sync ok');
+  });
+});
 
 describe('splitFullName', () => {
   it('splits first and last', () => {


### PR DESCRIPTION
## Summary
- **HubSpot CRM sync** — extend server-side `syncHubSpotLeadIfConfigured()` to the four routes still missing it: math-finals-practice, self-check, webinar-workshop, and Meta Lead Ads webhook (alongside enroll, contact, assessment, summer camp, chat email gate already on main).
- **Smoke E2E** — promote all lead-form submission tests to `@critical` so they run on every PR gate; add new `math-finals-practice.spec.ts`.
- **Unit tests** — expand `submitForm.test.ts` to cover env detection, Forms API POST success/failure, and sync helper skip/success paths.

## HubSpot routes (9 total)
| Route | Source tag |
|-------|------------|
| `/api/enroll` | enroll-form *(main)* |
| `/api/contact` | varies *(main)* |
| `/api/assessment` | book-assessment-form *(main)* |
| `/api/summer-camp-summercamp` | summer-camp-guide *(main)* |
| `/api/chat/email-lead` | chatbot-email-gate *(main)* |
| `/api/math-finals-practice` | math-finals-practice **(new)** |
| `/api/self-check` | self-check-mistake-detective **(new)** |
| `/api/webinar-workshop` | webinar-workshop **(new)** |
| `/api/leads/meta` | meta-lead-ads **(new)** |

## Test coverage (PR gate)
| Layer | What runs |
|-------|-----------|
| **Jest** | Full suite (`npm run test:ci`) including expanded HubSpot `submitForm` tests |
| **Playwright smoke** | All `@critical` tests (~14): nav, checkout, enroll ×2, **contact**, **book assessment**, **summer camp guide**, **self-check submit**, **math finals** |
| **Lighthouse parser** | Unchanged |

All form E2E tests mock API responses — no live HubSpot/Brevo calls in CI.

## Test plan
- [ ] PR gate: Jest + Playwright smoke pass
- [ ] Confirm Vercel Production has `HUBSPOT_PORTAL_ID` + `HUBSPOT_FORM_GUID`; redeploy after merge
- [ ] Prod smoke: submit math-finals + self-check with unique emails → HubSpot Contacts + Vercel logs `[route] HubSpot CRM sync ok`

Closes combined work from former #282.