### PR TITLE
test(e2e): add all lead-form submissions to PR smoke suite

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -233,4 +233,4 @@ Before finishing a change:
 | New routes / sitemap | defer to morning CI (`mobile-404-audit`); do not run unless user requests |
 
 4. Local E2E auto-starts the app: `next start` if `.next/BUILD_ID` exists, otherwise `next dev`. For CI-like runs: `npm run build && E2E_USE_PROD=1 npm run test:e2e:smoke`.
-5. Tag new E2E specs: `@critical` for enrollment/checkout/ad-route regressions; `@nightly` for bulk SEO, camps sweeps, or mobile audits.
+5. Tag new E2E specs: `@critical` for enrollment, checkout, **all lead-form submissions** (contact, assessment, summer camp guide, self-check, math finals), and ad-route regressions; `@nightly` for bulk SEO, camps sweeps, or mobile audits.

--- a/.github/CICD_RUNBOOK.md
+++ b/.github/CICD_RUNBOOK.md
@@ -18,7 +18,7 @@ You open a PR  dev → main
         ▼
 GitHub Actions runs tests automatically (pr-gate.yml)
   ├── Jest unit tests
-  └── Playwright smoke E2E (@critical — checkout, enrollment, ad routes)
+  └── Playwright smoke E2E (@critical — checkout, enrollment, all lead forms, ad routes)
         │
    pass? ──► merge is allowed
    fail? ──► merge is BLOCKED until fixed

--- a/e2e/specs/book-assessment.spec.ts
+++ b/e2e/specs/book-assessment.spec.ts
@@ -21,7 +21,7 @@ async function selectOption(
   await expect(page.getByTestId(triggerTestId)).toContainText(expectedTriggerText, { timeout: 8000 });
 }
 
-test.describe('Book assessment form', { tag: '@nightly' }, () => {
+test.describe('Book assessment form', { tag: '@critical' }, () => {
   test('submits free assessment booking with mocked backend', async ({ page }) => {
     await page.route('**/api/assessment', async (route) => {
       if (route.request().method() === 'POST') {

--- a/e2e/specs/contact.spec.ts
+++ b/e2e/specs/contact.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { localePath } from '../localePath';
 
-test.describe('Contact form', { tag: '@nightly' }, () => {
+test.describe('Contact form', { tag: '@critical' }, () => {
   test('submits contact form successfully with mocked backend', async ({ page }) => {
     await page.route('**/api/contact', async (route) => {
       const body = await route.request().postDataJSON();

--- a/e2e/specs/math-finals-practice.spec.ts
+++ b/e2e/specs/math-finals-practice.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { localePath } from '../localePath';
+import { fillStable } from '../helpers';
+
+async function selectRadixOption(page: Page, triggerId: string, optionName: RegExp | string) {
+  const trigger = page.locator(`#${triggerId}`);
+  await trigger.scrollIntoViewIfNeeded();
+  await trigger.click({ force: true });
+  await page.getByRole('option', { name: optionName }).click();
+}
+
+test.describe('Math finals practice form', { tag: '@critical' }, () => {
+  test('submits math finals request with mocked backend', async ({ page }) => {
+    await page.route('**/api/math-finals-practice', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, message: 'OK' }),
+      });
+    });
+
+    await page.goto(localePath('/math-finals-practice-session'));
+    await page.locator('#signup').scrollIntoViewIfNeeded();
+
+    await fillStable(page, /Parent name/i, 'E2E Parent');
+    await fillStable(page, /Parent email/i, 'math-finals.e2e@example.com');
+    await fillStable(page, /Student name/i, 'E2E Student');
+    await fillStable(page, /Parent phone/i, '5551234567');
+    await fillStable(page, /^School/i, 'Dublin High');
+
+    await selectRadixOption(page, 'grade-select', /^Grade 10$/i);
+    await selectRadixOption(page, 'subject-select', /Algebra 1/i);
+
+    await page.getByRole('button', { name: /^Submit$/i }).click();
+
+    const thankYouPath = localePath('/math-finals-practice-session/thank-you').replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&',
+    );
+    await expect(page).toHaveURL(new RegExp(`${thankYouPath}(\\?|$)`), { timeout: 20_000 });
+  });
+});

--- a/e2e/specs/self-check-detective.spec.ts
+++ b/e2e/specs/self-check-detective.spec.ts
@@ -169,7 +169,7 @@ test.describe('Self-Check funnel', { tag: '@nightly' }, () => {
   });
 
   // ── 6. Happy path — magic link card appears after submit ──────────────────
-  test('successful submission shows magic link card', async ({ page }) => {
+  test('successful submission shows magic link card', { tag: '@critical' }, async ({ page }) => {
     await mockSelfCheckSuccess(page);
     await goto(page, localePath('/self-check'));
     await fillAndSubmitForm(page, 'Grade 3');

--- a/e2e/specs/summer-camp-lottery.spec.ts
+++ b/e2e/specs/summer-camp-lottery.spec.ts
@@ -9,7 +9,7 @@ async function openSummerCampGuideModal(page: Page): Promise<void> {
 }
 
 test.describe('Summer camp lottery form (UI)', { tag: '@nightly' }, () => {
-  test('submits lottery form and navigates to thank-you page with mocked API', async ({ page }) => {
+  test('submits lottery form and navigates to thank-you page with mocked API', { tag: '@critical' }, async ({ page }) => {
     // The guide modal form posts to /api/summer-camp-summercamp (not /api/summer-camp-lottery).
     await page.route('**/api/summer-camp-summercamp', async (route) => {
       if (route.request().method() !== 'POST') {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ import { defineConfig, devices } from '@playwright/test';
  * - Otherwise defaults to http://localhost:3000
  *
  * Test tiers (see `.cursor/rules.md` §17):
- * - @critical — enrollment, checkout, ad landing routes; run on every PR (`npm run test:e2e:smoke`)
+ * - @critical — enrollment, checkout, all lead forms, ad landing routes; run on every PR (`npm run test:e2e:smoke`)
  * - @nightly — bulk SEO/camps/mobile audit; run on morning schedule only (`npm run test:e2e:full`)
  *
  * Stripe:


### PR DESCRIPTION
## Summary
- Promote lead-form E2E tests from `@nightly` to `@critical` so they run on every PR (`npm run test:e2e:smoke`): contact, book assessment, summer camp guide, and self-check happy-path submit.
- Add new `math-finals-practice.spec.ts` smoke test for the math finals lead form.
- Update Playwright config comments, CI runbook, and cursor rules to document that all lead-form submissions belong in smoke.

## Smoke coverage after merge (~14 @critical tests)
| Form | Spec |
|------|------|
| Enroll (general + academic) | `enrollment.spec.ts`, `enroll-academic.spec.ts` *(already smoke)* |
| Contact | `contact.spec.ts` |
| Book assessment | `book-assessment.spec.ts` |
| Summer camp guide | `summer-camp-lottery.spec.ts` (success path) |
| Self-check | `self-check-detective.spec.ts` (successful submit) |
| Math finals | `math-finals-practice.spec.ts` *(new)* |

All form tests mock API responses — no HubSpot/Brevo calls in CI.

## Test plan
- [ ] PR gate passes (Jest + Playwright smoke)
- [ ] Locally: `npm run build && E2E_USE_PROD=1 npm run test:e2e:smoke`


Made with [Cursor](https://cursor.com)