### PR TITLE
Add GCR opt-in on checkout success and Clarity dev diagnostics

### DIFF
--- a/src/app/[locale]/checkout/success/page.tsx
+++ b/src/app/[locale]/checkout/success/page.tsx
@@ -11,6 +11,11 @@ import { CheckCircle, Loader2, Home, FileText, AlertCircle } from 'lucide-react'
 import Link from 'next/link';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { publicPath } from '@/lib/publicPath';
+import { GoogleCustomerReviewsOptIn } from '@/components/analytics/GoogleCustomerReviewsOptIn';
+import {
+  getGcrFieldsFromCheckoutSession,
+  isGcrCheckoutReady,
+} from '@/lib/googleCustomerReviews';
 
 const CheckoutSuccessContent: React.FC = () => {
   const searchParams = useSearchParams();
@@ -130,9 +135,16 @@ const CheckoutSuccessContent: React.FC = () => {
 
   // If we have a session ID but no session data, assume payment was successful
   // (session fetch might have failed, but we're on the success page)
-  const isPaid = session?.payment_status === 'paid' || (sessionId && !error);
+  const isVerifiedPaid = session?.payment_status === 'paid';
+  // Legacy fallback UI when session fetch fails but Stripe redirected here
+  const isPaid = isVerifiedPaid || (sessionId && !error);
   const amountTotal = session?.amount_total ? (session.amount_total / 100).toFixed(2) : '0.00';
   const customerEmail = session?.customer_email || session?.customer_details?.email;
+  const gcrFields =
+    session && sessionId
+      ? getGcrFieldsFromCheckoutSession(session, sessionId)
+      : null;
+  const displayOrderId = gcrFields?.orderId || session?.id || sessionId;
 
   return (
     <div className="min-h-screen bg-[#ebebeb] py-12 px-4" style={{ fontFamily: '"Nunito", "Inter", system-ui, sans-serif' }}>
@@ -155,7 +167,7 @@ const CheckoutSuccessContent: React.FC = () => {
                     <div>
                       <div className="text-gray-600 mb-1">Order ID:</div>
                       <div className="font-medium text-gray-900 break-all">
-                        {session?.id || sessionId}
+                        {displayOrderId}
                       </div>
                     </div>
                     <div>
@@ -204,6 +216,13 @@ const CheckoutSuccessContent: React.FC = () => {
                     </Button>
                   </Link>
                 </div>
+                {gcrFields && isGcrCheckoutReady(gcrFields) ? (
+                  <GoogleCustomerReviewsOptIn
+                    orderId={gcrFields.orderId}
+                    email={gcrFields.email}
+                    estimatedDeliveryDate={gcrFields.estimatedDeliveryDate}
+                  />
+                ) : null}
               </>
             ) : (
               <>

--- a/src/components/analytics/AnalyticsAfterConsent.tsx
+++ b/src/components/analytics/AnalyticsAfterConsent.tsx
@@ -8,6 +8,7 @@ import MetaPixel from '@/components/analytics/MetaPixel';
 import HubSpotSpaTracker from '@/components/analytics/HubSpotSpaTracker';
 import { MicrosoftClarity } from '@/components/analytics/MicrosoftClarity';
 import { isClarityExcludedPath } from '@/lib/analytics/clarityPaths';
+import { getClaritySkipReasons, logClarityDebug } from '@/lib/analytics/clarityDebug';
 import {
   getStoredCookieConsent,
   isAutomatedAuditEnvironment,
@@ -50,6 +51,29 @@ export function AnalyticsAfterConsent() {
       clarityProjectId: process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID?.trim() || null,
     };
   }, []);
+
+  useEffect(() => {
+    if (!ready || isAutomatedAuditEnvironment()) return;
+
+    const clarityId = env.clarityProjectId ?? '';
+    const reasons = getClaritySkipReasons({
+      projectId: clarityId,
+      pathname: pathname ?? '/',
+      consentAccepted: consent === 'accepted',
+    }).filter(
+      (reason) =>
+        reason === 'no_cookie_consent' ||
+        reason === 'no_project_id' ||
+        reason === 'invalid_project_id',
+    );
+
+    if (reasons.length > 0) {
+      logClarityDebug('skipped', reasons, {
+        pathname: pathname ?? '/',
+        projectId: clarityId || undefined,
+      });
+    }
+  }, [ready, consent, env.clarityProjectId, pathname]);
 
   if (!ready) return null;
 

--- a/src/components/analytics/GoogleCustomerReviewsOptIn.tsx
+++ b/src/components/analytics/GoogleCustomerReviewsOptIn.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Script from 'next/script';
+import { GCR_MERCHANT_ID } from '@/lib/googleCustomerReviews';
+import {
+  getStoredCookieConsent,
+  isAutomatedAuditEnvironment,
+  type CookieConsentState,
+} from '@/lib/consent';
+
+const GCR_PLATFORM_SCRIPT = 'https://apis.google.com/js/platform.js';
+
+export interface GoogleCustomerReviewsOptInProps {
+  orderId: string;
+  email: string;
+  /** YYYY-MM-DD */
+  estimatedDeliveryDate: string;
+  deliveryCountry?: string;
+}
+
+type GcrRenderPayload = {
+  orderId: string;
+  email: string;
+  estimatedDeliveryDate: string;
+  deliveryCountry: string;
+};
+
+declare global {
+  interface Window {
+    gapi?: {
+      load: (module: string, callback: () => void) => void;
+      surveyoptin?: {
+        render: (options: Record<string, string | number>) => void;
+      };
+    };
+    renderOptIn?: () => void;
+  }
+}
+
+function gcrSessionKey(orderId: string): string {
+  return `gw_gcr_rendered_${orderId}`;
+}
+
+function hasAlreadyRendered(orderId: string): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return window.sessionStorage.getItem(gcrSessionKey(orderId)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function markRendered(orderId: string): void {
+  try {
+    window.sessionStorage.setItem(gcrSessionKey(orderId), '1');
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function renderSurveyOptIn(payload: GcrRenderPayload): void {
+  if (hasAlreadyRendered(payload.orderId)) return;
+  if (!window.gapi?.load) return;
+
+  window.gapi.load('surveyoptin', () => {
+    if (!window.gapi?.surveyoptin) return;
+    markRendered(payload.orderId);
+    window.gapi.surveyoptin.render({
+      merchant_id: GCR_MERCHANT_ID,
+      order_id: payload.orderId,
+      email: payload.email,
+      delivery_country: payload.deliveryCountry,
+      estimated_delivery_date: payload.estimatedDeliveryDate,
+    });
+  });
+}
+
+/**
+ * Google Customer Reviews post-purchase opt-in. Loads only after cookie consent
+ * and when order id, email, and estimated delivery date are provided.
+ */
+export function GoogleCustomerReviewsOptIn({
+  orderId,
+  email,
+  estimatedDeliveryDate,
+  deliveryCountry = 'US',
+}: GoogleCustomerReviewsOptInProps) {
+  const payloadRef = useRef<GcrRenderPayload>({
+    orderId,
+    email,
+    estimatedDeliveryDate,
+    deliveryCountry,
+  });
+
+  useEffect(() => {
+    payloadRef.current = { orderId, email, estimatedDeliveryDate, deliveryCountry };
+  }, [orderId, email, estimatedDeliveryDate, deliveryCountry]);
+
+  const [consent, setConsent] = useState<CookieConsentState | null>(null);
+  const [consentReady, setConsentReady] = useState(false);
+  const [loadScript, setLoadScript] = useState(false);
+
+  const tryRender = useCallback(() => {
+    const payload = payloadRef.current;
+    if (!payload.orderId || !payload.email || !payload.estimatedDeliveryDate) return;
+    renderSurveyOptIn(payload);
+  }, []);
+
+  useEffect(() => {
+    setConsent(getStoredCookieConsent());
+    setConsentReady(true);
+
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent).detail as unknown;
+      if (detail === 'accepted' || detail === 'rejected') setConsent(detail);
+    };
+    window.addEventListener('gw:cookie-consent', onChange);
+    return () => window.removeEventListener('gw:cookie-consent', onChange);
+  }, []);
+
+  useEffect(() => {
+    window.renderOptIn = () => tryRender();
+    return () => {
+      delete window.renderOptIn;
+    };
+  }, [tryRender]);
+
+  const hasRequiredFields =
+    orderId.trim().length > 0 &&
+    email.trim().length > 0 &&
+    estimatedDeliveryDate.trim().length > 0;
+
+  const shouldLoad =
+    consentReady &&
+    consent === 'accepted' &&
+    !isAutomatedAuditEnvironment() &&
+    hasRequiredFields;
+
+  useEffect(() => {
+    if (shouldLoad) setLoadScript(true);
+  }, [shouldLoad]);
+
+  if (!shouldLoad || !loadScript) return null;
+
+  return (
+    <Script
+      id="google-customer-reviews-platform"
+      src={`${GCR_PLATFORM_SCRIPT}?onload=renderOptIn`}
+      strategy="afterInteractive"
+      onLoad={() => {
+        tryRender();
+      }}
+    />
+  );
+}

--- a/src/components/analytics/MicrosoftClarity.tsx
+++ b/src/components/analytics/MicrosoftClarity.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import Clarity from '@microsoft/clarity';
 import { isAutomatedAuditEnvironment } from '@/lib/consent';
 import { isClarityExcludedPath } from '@/lib/analytics/clarityPaths';
+import { getClaritySkipReasons, logClarityDebug } from '@/lib/analytics/clarityDebug';
 
 interface MicrosoftClarityProps {
   projectId: string;
@@ -25,6 +26,7 @@ function stopClarityRecording() {
 export function MicrosoftClarity({ projectId, pathname }: MicrosoftClarityProps) {
   const id = projectId.trim();
   const initializedRef = useRef(false);
+  const lastLoggedSkipKeyRef = useRef<string | null>(null);
 
   const shouldSkip =
     !id ||
@@ -34,7 +36,18 @@ export function MicrosoftClarity({ projectId, pathname }: MicrosoftClarityProps)
 
   useEffect(() => {
     if (shouldSkip) {
+      const skipKey = `${pathname}:${getClaritySkipReasons({ projectId: id, pathname }).join(',')}`;
+      if (lastLoggedSkipKeyRef.current !== skipKey) {
+        lastLoggedSkipKeyRef.current = skipKey;
+        logClarityDebug(
+          'skipped',
+          getClaritySkipReasons({ projectId: id, pathname }),
+          { pathname, projectId: id || undefined },
+        );
+      }
+
       if (initializedRef.current) {
+        logClarityDebug('stopped', [], { pathname });
         stopClarityRecording();
         initializedRef.current = false;
       }
@@ -49,7 +62,9 @@ export function MicrosoftClarity({ projectId, pathname }: MicrosoftClarityProps)
       Clarity.consentV2({ ad_Storage: 'denied', analytics_Storage: 'granted' });
     }
     initializedRef.current = true;
-  }, [id, shouldSkip]);
+    lastLoggedSkipKeyRef.current = null;
+    logClarityDebug('initialized', [], { pathname, projectId: id });
+  }, [id, pathname, shouldSkip]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/__tests__/googleCustomerReviews.test.ts
+++ b/src/lib/__tests__/googleCustomerReviews.test.ts
@@ -1,0 +1,67 @@
+import {
+  formatGcrEstimatedDeliveryDate,
+  getGcrFieldsFromCheckoutSession,
+  isGcrCheckoutReady,
+} from '@/lib/googleCustomerReviews';
+
+describe('googleCustomerReviews', () => {
+  it('formatGcrEstimatedDeliveryDate returns YYYY-MM-DD UTC', () => {
+    expect(formatGcrEstimatedDeliveryDate(7, new Date('2026-05-26T12:00:00.000Z'))).toBe('2026-06-02');
+  });
+
+  it('getGcrFieldsFromCheckoutSession prefers metadata orderId', () => {
+    const fields = getGcrFieldsFromCheckoutSession(
+      {
+        id: 'cs_test_abc',
+        payment_status: 'paid',
+        customer_email: 'parent@example.com',
+        metadata: { orderId: 'ord_123' },
+      },
+      'cs_fallback',
+    );
+    expect(fields.orderId).toBe('ord_123');
+    expect(fields.email).toBe('parent@example.com');
+    expect(fields.estimatedDeliveryDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(fields.isVerifiedPaid).toBe(true);
+  });
+
+  it('getGcrFieldsFromCheckoutSession falls back to Stripe session id', () => {
+    const fields = getGcrFieldsFromCheckoutSession(
+      {
+        id: 'cs_test_abc',
+        payment_status: 'paid',
+        customer_details: { email: 'buyer@example.com' },
+      },
+      'cs_fallback',
+    );
+    expect(fields.orderId).toBe('cs_test_abc');
+    expect(fields.email).toBe('buyer@example.com');
+  });
+
+  it('isGcrCheckoutReady requires paid status, order id, and email', () => {
+    expect(
+      isGcrCheckoutReady({
+        orderId: 'ord_1',
+        email: 'a@b.com',
+        estimatedDeliveryDate: '2026-06-02',
+        isVerifiedPaid: true,
+      }),
+    ).toBe(true);
+    expect(
+      isGcrCheckoutReady({
+        orderId: 'ord_1',
+        email: '',
+        estimatedDeliveryDate: '2026-06-02',
+        isVerifiedPaid: true,
+      }),
+    ).toBe(false);
+    expect(
+      isGcrCheckoutReady({
+        orderId: 'ord_1',
+        email: 'a@b.com',
+        estimatedDeliveryDate: '2026-06-02',
+        isVerifiedPaid: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/analytics/__tests__/clarityDebug.test.ts
+++ b/src/lib/analytics/__tests__/clarityDebug.test.ts
@@ -1,0 +1,55 @@
+import { getClaritySkipReasons } from '@/lib/analytics/clarityDebug';
+
+jest.mock('@/lib/consent', () => ({
+  isAutomatedAuditEnvironment: jest.fn(() => false),
+}));
+
+const { isAutomatedAuditEnvironment } = require('@/lib/consent') as {
+  isAutomatedAuditEnvironment: jest.Mock;
+};
+
+describe('getClaritySkipReasons', () => {
+  beforeEach(() => {
+    isAutomatedAuditEnvironment.mockReturnValue(false);
+  });
+
+  it('returns no_cookie_consent when consent not accepted', () => {
+    expect(
+      getClaritySkipReasons({
+        projectId: 'abc123',
+        pathname: '/en/camps/summer',
+        consentAccepted: false,
+      }),
+    ).toContain('no_cookie_consent');
+  });
+
+  it('returns no_project_id when env id is empty', () => {
+    expect(
+      getClaritySkipReasons({
+        projectId: '',
+        pathname: '/en/camps/summer',
+        consentAccepted: true,
+      }),
+    ).toContain('no_project_id');
+  });
+
+  it('returns excluded_path on checkout routes', () => {
+    expect(
+      getClaritySkipReasons({
+        projectId: 'abc123',
+        pathname: '/en/checkout/success',
+        consentAccepted: true,
+      }),
+    ).toContain('excluded_path');
+  });
+
+  it('returns empty when all gates pass', () => {
+    expect(
+      getClaritySkipReasons({
+        projectId: 'abc123',
+        pathname: '/en/camps/summer',
+        consentAccepted: true,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/analytics/clarityDebug.ts
+++ b/src/lib/analytics/clarityDebug.ts
@@ -1,0 +1,86 @@
+import { isAutomatedAuditEnvironment } from '@/lib/consent';
+import { isClarityExcludedPath, stripLocalePrefix } from '@/lib/analytics/clarityPaths';
+
+const PROJECT_ID_PATTERN = /^[a-z0-9]+$/i;
+
+export type ClaritySkipReason =
+  | 'no_cookie_consent'
+  | 'no_project_id'
+  | 'invalid_project_id'
+  | 'automated_audit'
+  | 'excluded_path';
+
+const SKIP_MESSAGES: Record<ClaritySkipReason, string> = {
+  no_cookie_consent: 'Analytics cookies not accepted — Clarity will not load until the user clicks Accept.',
+  no_project_id:
+    'NEXT_PUBLIC_CLARITY_PROJECT_ID is empty — set it in .env.local or Vercel env vars.',
+  invalid_project_id:
+    'NEXT_PUBLIC_CLARITY_PROJECT_ID format is invalid — use the alphanumeric ID from Clarity Settings.',
+  automated_audit:
+    'Automated audit environment detected (Lighthouse/WebDriver) — Clarity is intentionally disabled.',
+  excluded_path:
+    'Current path is excluded from Clarity (login, checkout, dashboard) — no heatmaps on this page.',
+};
+
+export function getClaritySkipReasons(params: {
+  projectId: string;
+  pathname: string;
+  consentAccepted?: boolean;
+  isAudit?: boolean;
+}): ClaritySkipReason[] {
+  const reasons: ClaritySkipReason[] = [];
+  const id = params.projectId.trim();
+  const isAudit = params.isAudit ?? isAutomatedAuditEnvironment();
+
+  if (params.consentAccepted === false) {
+    reasons.push('no_cookie_consent');
+  }
+  if (!id) {
+    reasons.push('no_project_id');
+  } else if (!PROJECT_ID_PATTERN.test(id)) {
+    reasons.push('invalid_project_id');
+  }
+  if (isAudit) {
+    reasons.push('automated_audit');
+  }
+  if (isClarityExcludedPath(params.pathname)) {
+    reasons.push('excluded_path');
+  }
+
+  return reasons;
+}
+
+function formatSkipReasons(reasons: ClaritySkipReason[]): string {
+  return reasons.map((r) => SKIP_MESSAGES[r]).join(' ');
+}
+
+const LOG_PREFIX = '[GrowWise Clarity]';
+
+/** Dev-only diagnostics — silent in production. */
+export function logClarityDebug(
+  event: 'skipped' | 'initialized' | 'stopped',
+  reasons: ClaritySkipReason[],
+  meta?: { pathname?: string; projectId?: string },
+): void {
+  if (process.env.NODE_ENV !== 'development') return;
+
+  const path = meta?.pathname ? stripLocalePrefix(meta.pathname) : undefined;
+
+  if (event === 'initialized') {
+    console.info(
+      `${LOG_PREFIX} Recording started.`,
+      path ? `path=${path}` : '',
+      meta?.projectId ? `project=${meta.projectId}` : '',
+    );
+    return;
+  }
+
+  if (event === 'stopped') {
+    console.info(`${LOG_PREFIX} Recording stopped.`, path ? `path=${path}` : '');
+    return;
+  }
+
+  if (reasons.length === 0) return;
+
+  console.info(`${LOG_PREFIX} Not recording:`, formatSkipReasons(reasons), path ? `(path=${path})` : '');
+}

--- a/src/lib/googleCustomerReviews.ts
+++ b/src/lib/googleCustomerReviews.ts
@@ -1,0 +1,47 @@
+/** Google Merchant Center ID for Customer Reviews opt-in. */
+export const GCR_MERCHANT_ID = 5572733436;
+
+export interface StripeCheckoutSessionForGcr {
+  id?: string;
+  payment_status?: string;
+  customer_email?: string | null;
+  customer_details?: { email?: string | null } | null;
+  metadata?: { orderId?: string | null } | null;
+}
+
+export interface GcrCheckoutFields {
+  orderId: string;
+  email: string;
+  estimatedDeliveryDate: string;
+  isVerifiedPaid: boolean;
+}
+
+/** Returns YYYY-MM-DD for Google Customer Reviews (UTC). */
+export function formatGcrEstimatedDeliveryDate(daysFromNow = 7, fromDate = new Date()): string {
+  const d = new Date(fromDate);
+  d.setUTCDate(d.getUTCDate() + daysFromNow);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Maps a paid Stripe Checkout session to GCR opt-in fields.
+ * Prefers internal order id from metadata; falls back to Stripe session id.
+ */
+export function getGcrFieldsFromCheckoutSession(
+  session: StripeCheckoutSessionForGcr,
+  sessionIdFallback: string,
+): GcrCheckoutFields {
+  const metadataOrderId = session.metadata?.orderId?.trim();
+  const orderId = metadataOrderId || session.id?.trim() || sessionIdFallback.trim();
+  const email = (session.customer_email ?? session.customer_details?.email ?? '').trim();
+  return {
+    orderId,
+    email,
+    estimatedDeliveryDate: formatGcrEstimatedDeliveryDate(7),
+    isVerifiedPaid: session.payment_status === 'paid',
+  };
+}
+
+export function isGcrCheckoutReady(fields: GcrCheckoutFields): boolean {
+  return fields.isVerifiedPaid && fields.orderId.length > 0 && fields.email.length > 0;
+}


### PR DESCRIPTION
## Summary
- Add Google Customer Reviews (GCR) post-purchase opt-in on `/checkout/success` after verified paid Stripe sessions and cookie consent
- Introduce `GoogleCustomerReviewsOptIn` component with correct `gapi.load('surveyoptin')` flow, session dedupe, and merchant id `5572733436`
- Map GCR fields from Stripe session (`metadata.orderId`, customer email, estimated delivery +7 days)
- Add dev-only Clarity diagnostics (`[GrowWise Clarity]` console logs) explaining skip reasons: missing project id, no consent, excluded paths, audit mode
- Fix `AnalyticsAfterConsent` hook order so Clarity debug effect runs after `env` is defined

## Test plan
- [x] `npm test -- --testPathPatterns=googleCustomerReviews`
- [x] `npm test -- --testPathPatterns=clarityDebug|MicrosoftClarity`
- [x] `npm run build`
- [x] `npm run test:e2e:smoke -- e2e/specs/checkout-success.spec.ts`
- [ ] Manual: Stripe test checkout on staging/prod → accept cookies → confirm GCR opt-in on success page
- [ ] Manual: `npm run dev` → open marketing page → check console for `[GrowWise Clarity]` messages after Accept


Made with [Cursor](https://cursor.com)