### PR TITLE
fix(seo): standardize canonical URLs on non-www growwiseschool.org

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -45,7 +45,7 @@ NEXT_PUBLIC_CLARITY_PROJECT_ID=
 # 3) Trigger: Custom Event -> Event name equals "virtual_page_view".
 # Alternatively: disable automatic page_view in the GA4 Configuration tag and listen for these events instead.
 # Public / canonical site URL (no trailing slash): SEO, sitemap, JSON-LD, Stripe success URLs. Use NEXT_PUBLIC_SITE_URL only — NEXT_PUBLIC_BASE_URL is not read by the app.
-NEXT_PUBLIC_SITE_URL=https://www.growwiseschool.org
+NEXT_PUBLIC_SITE_URL=https://growwiseschool.org
 
 # Backend URL (Express API). Required on Vercel Preview + Production so /api/* proxy routes reach the API.
 # Do not set this to the Next dev URL (:3000) or the proxy will call itself.

--- a/next.config.ts
+++ b/next.config.ts
@@ -215,6 +215,12 @@ const nextConfig: NextConfig = {
     ]);
 
     return [
+      {
+        source: '/:path*',
+        destination: 'https://growwiseschool.org/:path*',
+        permanent: true,
+        has: [{ type: 'host', value: 'www.growwiseschool.org' }],
+      },
       ...legacyMarketingRedirects,
       { source: '/camp', destination: '/camps/summer', permanent: true },
       { source: '/camp/:slug', destination: '/camps/:slug', permanent: true },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,4 +8,4 @@ Disallow: /favicon.ico
 Disallow: /cart
 Disallow: /student-login
 
-Sitemap: https://www.growwiseschool.org/sitemap.xml
+Sitemap: https://growwiseschool.org/sitemap.xml

--- a/src/app/[locale]/self-check/layout.tsx
+++ b/src/app/[locale]/self-check/layout.tsx
@@ -12,6 +12,8 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const meta = generateMetadataFromPath('/self-check', locale);
+  const baseUrl = getCanonicalSiteUrl();
+  const selfCheckUrl = absoluteSiteUrl('/self-check', locale, baseUrl);
   return (
     meta ?? {
       title: 'Academic Self-Check for Students | GrowWise Dublin CA',
@@ -30,13 +32,13 @@ export async function generateMetadata({
         title: 'Free Math Self-Check — Find Your Child\'s Mistake Pattern',
         description:
           '8 questions. Personalized report emailed in minutes. Free for Grades 3–8.',
-        url: 'https://www.growwiseschool.org/self-check',
+        url: selfCheckUrl,
         siteName: 'GrowWise School',
         locale: 'en_US',
         type: 'website',
       },
       alternates: {
-        canonical: 'https://www.growwiseschool.org/self-check',
+        canonical: selfCheckUrl,
       },
     }
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://growwiseschool.org'),
   title: "K-12 Online Tutoring & Coding Classes | GrowWise",
   description:
     "GrowWise helps Grades 1-12 students become confident, independent learners. Academic tutoring, Python & AI coding, and STEAM programs. Live online nationwide + in-person in Dublin, CA. Book a free assessment today.",

--- a/src/components/schema/EventSchema.tsx
+++ b/src/components/schema/EventSchema.tsx
@@ -66,7 +66,7 @@ export default function EventSchema({
     performer: {
       '@type': 'Organization',
       name: 'GrowWise School',
-      url: 'https://www.growwiseschool.org',
+      url: site,
     },
     offers: {
       '@type': 'Offer',

--- a/src/lib/seo/homeGraphJsonLd.ts
+++ b/src/lib/seo/homeGraphJsonLd.ts
@@ -1,5 +1,8 @@
 import { HOME_VISIBLE_FAQS } from '@/lib/home/homeFaqCopy'
 import { generateFAQPageSchema } from '@/lib/seo/structuredData'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+
+const CANONICAL_BASE = getCanonicalSiteUrl()
 
 const { ['@context']: _faqContext, ...faqPageNode } = generateFAQPageSchema(HOME_VISIBLE_FAQS)
 
@@ -9,8 +12,8 @@ export const HOME_GRAPH_JSON_LD = {
     {
       '@type': 'EducationalOrganization',
       name: 'GrowWise School',
-      url: 'https://www.growwiseschool.org',
-      logo: 'https://www.growwiseschool.org/logo.png',
+      url: CANONICAL_BASE,
+      logo: `${CANONICAL_BASE}/logo.png`,
       description:
         'GrowWise helps Grades 1-12 students become confident, independent learners through academic tutoring and STEAM programs. Available online nationwide and in-person in Dublin, CA.',
       address: {

--- a/src/lib/seo/siteUrl.ts
+++ b/src/lib/seo/siteUrl.ts
@@ -3,6 +3,6 @@
  * No trailing slash. Set NEXT_PUBLIC_SITE_URL in each environment; falls back to production host.
  */
 export function getCanonicalSiteUrl(): string {
-  const raw = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.growwiseschool.org'
+  const raw = process.env.NEXT_PUBLIC_SITE_URL || 'https://growwiseschool.org'
   return raw.replace(/\/$/, '')
 }


### PR DESCRIPTION
## Summary
- Add a 301 redirect from `www.growwiseschool.org` to `growwiseschool.org` for all paths via `next.config.ts` host matching.
- Point canonical URL defaults (`getCanonicalSiteUrl`, `metadataBase`, `robots.txt`, env example) at the non-www apex domain.
- Replace hardcoded `www` URLs in self-check fallback metadata, homepage JSON-LD, and Event schema with `getCanonicalSiteUrl()`.

## Test plan
- [x] Local: `curl -I -H "Host: www.growwiseschool.org" http://localhost:3000/` returns `308` → `https://growwiseschool.org`
- [x] Production build with `NEXT_PUBLIC_SITE_URL=https://growwiseschool.org`: sitemap and robots.txt use non-www URLs
- [x] Unit tests: `homeGraphJsonLd`, `sitemapData`, `robots.seo` pass
- [ ] After deploy: set `NEXT_PUBLIC_SITE_URL=https://growwiseschool.org` in Vercel production and preview
- [ ] After deploy: verify Google Search Console preferred domain / URL Inspection shows non-www canonicals


Made with [Cursor](https://cursor.com)