### PR TITLE
fix(seo): remove www redirect to stop production redirect loop

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -215,12 +215,6 @@ const nextConfig: NextConfig = {
     ]);
 
     return [
-      {
-        source: '/:path*',
-        destination: 'https://growwiseschool.org/:path*',
-        permanent: true,
-        has: [{ type: 'host', value: 'www.growwiseschool.org' }],
-      },
       ...legacyMarketingRedirects,
       { source: '/camp', destination: '/camps/summer', permanent: true },
       { source: '/camp/:slug', destination: '/camps/:slug', permanent: true },


### PR DESCRIPTION
## Summary
- Removes the app-level `www.growwiseschool.org` → `growwiseschool.org` redirect from `next.config.ts` that caused `ERR_TOO_MANY_REDIRECTS` when combined with Vercel's apex → www domain redirect.
- Host canonicalization should be handled in Vercel Domains: apex connected to Production, www 308 → apex.

## Test plan
- [x] Jest suite passes on `dev`
- [ ] After merge + Vercel domain flip: `curl -I https://growwiseschool.org/` returns 200
- [ ] `curl -I https://www.growwiseschool.org/` returns 308 → `https://growwiseschool.org/`
- [ ] Confirm `NEXT_PUBLIC_SITE_URL=https://growwiseschool.org` in Vercel production


Made with [Cursor](https://cursor.com)