### PR TITLE
feat: /courses/math/elementary — full page (Grades 1–5)

### DIFF
--- a/src/app/[locale]/courses/math/elementary/layout.tsx
+++ b/src/app/[locale]/courses/math/elementary/layout.tsx
@@ -1,0 +1,77 @@
+import { Metadata } from 'next'
+import FAQSchema from '@/components/schema/FAQSchema'
+import { ELEMENTARY_MATH_VISIBLE_FAQS } from '@/lib/schema/elementary-math-faqs'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+import { generateCourseSchema, generateBreadcrumbSchema } from '@/lib/seo/structuredData'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params
+  return (
+    generateMetadataFromPath('/courses/math/elementary', locale) ?? {
+      title: 'Elementary Math Tutoring Grades 1–5 | GrowWise',
+      description: 'Structured math programs for Grades 1–5. Diagnostic-first. Live online small groups.',
+    }
+  )
+}
+
+export default async function ElementaryMathLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+
+  const courseSchema = generateCourseSchema({
+    name: 'Elementary Math Foundation — Grades 1–5',
+    description:
+      'Structured 3-month math programs for Grades 1–5. Covers number sense, place value, fractions, decimal operations, and multi-step word problem reasoning. Live online small groups of 6–10 students. Diagnostic-first.',
+    provider: 'GrowWise',
+    educationalLevel: 'Grades 1–5',
+    teaches: [
+      'Number sense and place value',
+      'Addition and subtraction with understanding',
+      'Multiplication and division fluency',
+      'Fractions as numbers on a number line',
+      'Equivalent fractions',
+      'Multi-step word problems',
+      'Decimal operations',
+      'Order of operations',
+    ],
+    coursePrerequisites: 'Grades 1–5 elementary school level',
+    url: absoluteSiteUrl('/courses/math/elementary', locale, baseUrl),
+    image: `${baseUrl}/assets/growwise-logo.png`,
+    offers: {
+      price: '349',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+      url: absoluteSiteUrl('/book-assessment', locale, baseUrl),
+    },
+  })
+
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: 'Academic', url: absoluteSiteUrl('/academic', locale, baseUrl) },
+    { name: 'Math Programs', url: absoluteSiteUrl('/courses/math', locale, baseUrl) },
+    { name: 'Elementary Math', url: absoluteSiteUrl('/courses/math/elementary', locale, baseUrl) },
+  ])
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(courseSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <FAQSchema faqs={ELEMENTARY_MATH_VISIBLE_FAQS} />
+      {children}
+    </>
+  )
+}

--- a/src/app/[locale]/courses/math/elementary/page.tsx
+++ b/src/app/[locale]/courses/math/elementary/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import ElementaryMathPage from '@/components/ElementaryMathPage'
+
+export default function ElementaryMathPageRoute() {
+  return <ElementaryMathPage />
+}

--- a/src/components/ElementaryMathPage.tsx
+++ b/src/components/ElementaryMathPage.tsx
@@ -84,43 +84,55 @@ interface JTBDSituation {
   body: string
   cta: 'assessment' | 'selfcheck' | 'summer' | 'advisor'
   ctaLabel: string
+  levelTag: string
+  levelColor: string // Tailwind bg + text classes
 }
 
 const JTBD_SITUATIONS: JTBDSituation[] = [
   {
-    label: 'Fractions',
-    heading: "\"My child has been struggling with fractions for months and I can't figure out why\"",
-    body: 'This is the most common elementary math presentation. Fractions are where conceptual gaps in multiplication and number sense compound all at once. The fix is almost always a few weeks back — not in the fractions unit itself.',
+    label: 'Falling behind',
+    heading: '"My child has been struggling and falling behind"',
+    body: 'This is the most common presentation. The gap usually started 6–18 months ago and has been compounding ever since. The diagnostic finds the root concept; the Beginner track closes it systematically.',
     cta: 'assessment',
     ctaLabel: 'Book free assessment',
+    levelTag: 'Beginner level',
+    levelColor: 'bg-green-100 text-green-700',
   },
   {
-    label: 'Word problems',
-    heading: "\"They're fine at computation but fall apart on word problems\"",
-    body: 'Word problems require reading the mathematical structure of a situation — not just calculating. This is a reasoning gap, not a computation gap. Different fix.',
-    cta: 'selfcheck',
-    ctaLabel: 'Try the Self-Check',
-  },
-  {
-    label: 'Practice gaps',
-    heading: "\"Teacher says they need more practice, but I don't know practice of what\"",
-    body: '"More practice" applied to the wrong concept produces frustration, not progress. The first step is identifying exactly which concept needs work.',
+    label: 'Needs consistency',
+    heading: '"They\'re doing okay but I want them more consistent"',
+    body: "Your child is at grade level but performance is uneven — good days and bad days, strong on some topics and shaky on others. The Champ track builds the consistency that makes math reliable.",
     cta: 'assessment',
     ctaLabel: 'Book free assessment',
+    levelTag: 'Champ level',
+    levelColor: 'bg-blue-100 text-blue-700',
+  },
+  {
+    label: 'Already strong',
+    heading: '"They\'re already strong — I want them further ahead"',
+    body: 'Your child has mastered grade-level material and is ready to work above it. The Pro track moves them into accelerated content with the same structured, gap-aware approach.',
+    cta: 'advisor',
+    ctaLabel: 'Talk to an advisor',
+    levelTag: 'Pro level',
+    levelColor: 'bg-purple-100 text-purple-700',
+  },
+  {
+    label: 'Practice of what?',
+    heading: '"Teacher says they need more practice but I don\'t know of what"',
+    body: '"More practice" applied to the wrong concept produces frustration, not progress. The 45-minute assessment identifies exactly which concept needs work and whether Beginner or Champ is the right starting point.',
+    cta: 'assessment',
+    ctaLabel: 'Book free assessment',
+    levelTag: 'Beginner or Champ · assessment decides',
+    levelColor: 'bg-gray-100 text-gray-600',
   },
   {
     label: 'New grade prep',
-    heading: "\"Going into a new grade and I want to make sure the foundation is solid\"",
-    body: 'Summer and transition prep for rising Grade 2–5 students. We assess where they are and build forward.',
+    heading: '"Going into a new grade, want the foundation solid"',
+    body: 'Transition prep for rising Grade 2–5 students. We assess where they are and build forward so they start the new year from a position of strength, not catch-up.',
     cta: 'summer',
     ctaLabel: 'See summer programs',
-  },
-  {
-    label: 'Enrichment',
-    heading: "\"They're doing fine — I want them ahead\"",
-    body: 'Enrichment track for students who have mastered grade-level material and are ready to work above it.',
-    cta: 'advisor',
-    ctaLabel: 'Talk to an advisor',
+    levelTag: 'Champ level',
+    levelColor: 'bg-blue-100 text-blue-700',
   },
 ]
 
@@ -278,8 +290,12 @@ const ElementaryMathPage: React.FC = () => {
               We find it before it spreads.
             </span>
           </h1>
-          <p className="max-w-2xl mx-auto text-lg text-gray-600 mb-8 leading-relaxed">
+          <p className="max-w-2xl mx-auto text-lg text-gray-600 mb-4 leading-relaxed">
             By the time a parent notices the problem — grades slipping, homework battles, "I hate math" — the real blocker is usually something from 6 to 18 months ago that never fully landed. Our programs start with a free 45-minute diagnostic session that identifies where reasoning breaks down, not where the current worksheet is hard.
+          </p>
+          {/* Change 1 — level line */}
+          <p className="max-w-xl mx-auto text-sm text-gray-500 mb-8">
+            3 levels: <span className="font-medium text-green-700">Beginner</span> · <span className="font-medium text-blue-700">Champ</span> · <span className="font-medium text-purple-700">Pro</span> — assessment places your child in the right one.
           </p>
 
           {/* Trust chips */}
@@ -307,6 +323,75 @@ const ElementaryMathPage: React.FC = () => {
               Try the free Self-Check
             </Link>
           </div>
+        </div>
+      </section>
+
+      {/* ── MASTERY TRACK SECTION ────────────────────── */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">GrowWise Mastery Track</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-5">
+            A structured progression — not open-ended tutoring.
+          </h2>
+          <p className="text-gray-600 leading-relaxed mb-10 max-w-2xl">
+            Most tutoring programs run indefinitely with no defined milestones. GrowWise Elementary works differently. Every student is placed in one of three levels based on their assessment. Every 3 months, they are re-assessed. Advance to the next level only happens at 90% or above — not before.
+          </p>
+
+          {/* Stepper — 3 level boxes + assessment checkpoints */}
+          <div className="flex flex-col md:flex-row items-stretch gap-0 mb-8">
+            {/* Box 1 — Beginner */}
+            <div className="flex-1 rounded-xl border-2 border-green-200 bg-green-50 p-5">
+              <p className="text-xs font-semibold uppercase tracking-widest text-green-600 mb-1">Level 1</p>
+              <p className="text-lg font-bold text-green-800 mb-1">Beginner</p>
+              <p className="text-sm text-green-700">Below grade level · Closing the gap</p>
+            </div>
+
+            {/* Checkpoint 1 */}
+            <div className="flex flex-col md:flex-row items-center justify-center gap-1 px-2 py-3 md:py-0 shrink-0">
+              <div className="flex flex-col items-center gap-1">
+                <ArrowRight className="h-5 w-5 text-gray-400 hidden md:block" aria-hidden />
+                <span className="text-[10px] font-semibold text-gray-500 text-center bg-gray-100 rounded-full px-2 py-0.5 whitespace-nowrap">3-month assessment · 90% to advance</span>
+                <ArrowRight className="h-5 w-5 text-gray-400 hidden md:block" aria-hidden />
+              </div>
+            </div>
+
+            {/* Box 2 — Champ */}
+            <div className="flex-1 rounded-xl border-2 border-blue-200 bg-blue-50 p-5">
+              <p className="text-xs font-semibold uppercase tracking-widest text-blue-600 mb-1">Level 2</p>
+              <p className="text-lg font-bold text-blue-800 mb-1">Champ</p>
+              <p className="text-sm text-blue-700">At grade level · Building consistency</p>
+            </div>
+
+            {/* Checkpoint 2 */}
+            <div className="flex flex-col md:flex-row items-center justify-center gap-1 px-2 py-3 md:py-0 shrink-0">
+              <div className="flex flex-col items-center gap-1">
+                <ArrowRight className="h-5 w-5 text-gray-400 hidden md:block" aria-hidden />
+                <span className="text-[10px] font-semibold text-gray-500 text-center bg-gray-100 rounded-full px-2 py-0.5 whitespace-nowrap">3-month assessment · 90% to advance</span>
+                <ArrowRight className="h-5 w-5 text-gray-400 hidden md:block" aria-hidden />
+              </div>
+            </div>
+
+            {/* Box 3 — Pro */}
+            <div className="flex-1 rounded-xl border-2 border-purple-200 bg-purple-50 p-5">
+              <p className="text-xs font-semibold uppercase tracking-widest text-purple-600 mb-1">Level 3</p>
+              <p className="text-lg font-bold text-purple-800 mb-1">Pro</p>
+              <p className="text-sm text-purple-700">Above grade level · Accelerating ahead</p>
+            </div>
+          </div>
+
+          <p className="text-gray-600 mb-3 leading-relaxed">
+            Students who score below 90% stay at their current level and continue building — no rushing, no skipping steps.
+          </p>
+          <p className="font-semibold text-gray-800 mb-6">
+            The assessment is free, takes 45 minutes, and places your child in the right level before the first paid session.
+          </p>
+          <Link
+            href={publicPath('/book-assessment', locale)}
+            className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#F16112] to-[#F1894F] px-7 py-3 text-sm font-semibold text-white shadow hover:shadow-md transition-shadow"
+          >
+            Book free 45-minute assessment
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Link>
         </div>
       </section>
 
@@ -374,7 +459,12 @@ const ElementaryMathPage: React.FC = () => {
               <div key={i} className="rounded-xl border border-gray-200 bg-gray-50 p-5 lg:p-6">
                 <div className="flex flex-wrap items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <p className="font-semibold text-gray-800 mb-2">{situation.heading}</p>
+                    <div className="flex flex-wrap items-center gap-2 mb-2">
+                      <p className="font-semibold text-gray-800">{situation.heading}</p>
+                      <span className={`inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full ${situation.levelColor}`}>
+                        → {situation.levelTag}
+                      </span>
+                    </div>
                     <p className="text-gray-600 text-sm leading-relaxed">{situation.body}</p>
                   </div>
                   <div className="shrink-0 mt-1">
@@ -656,7 +746,7 @@ const ElementaryMathPage: React.FC = () => {
           <Brain className="h-10 w-10 text-[#F1894F] mx-auto mb-5" aria-hidden />
           <h2 className="text-2xl lg:text-3xl font-bold mb-4">Start with a free 45-minute assessment.</h2>
           <p className="text-white/80 mb-8 leading-relaxed">
-            The free 45-minute assessment tells you exactly which gap to close — before you commit to anything. Most parents leave knowing more about their child's math than they did after months of homework help.
+            The free 45-minute assessment does three things: identifies your child's specific gap, places them in the right level (Beginner, Champ, or Pro), and maps out what month one of their program will focus on. No charge. No commitment. Results you can act on immediately.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Button

--- a/src/components/ElementaryMathPage.tsx
+++ b/src/components/ElementaryMathPage.tsx
@@ -16,6 +16,7 @@ import {
   Clock,
   Star,
   Phone,
+  Sparkles,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -278,7 +279,7 @@ const ElementaryMathPage: React.FC = () => {
             </span>
           </h1>
           <p className="max-w-2xl mx-auto text-lg text-gray-600 mb-8 leading-relaxed">
-            By the time a parent notices the problem — grades slipping, homework battles, "I hate math" — the real blocker is usually something from 6 to 18 months ago that never fully landed. Our programs start with a diagnostic session that identifies where reasoning breaks down, not where the current worksheet is hard.
+            By the time a parent notices the problem — grades slipping, homework battles, "I hate math" — the real blocker is usually something from 6 to 18 months ago that never fully landed. Our programs start with a free 45-minute diagnostic session that identifies where reasoning breaks down, not where the current worksheet is hard.
           </p>
 
           {/* Trust chips */}
@@ -445,15 +446,52 @@ const ElementaryMathPage: React.FC = () => {
                   </li>
                 ))}
               </ul>
+
+              {/* Pricing table */}
               <div className="rounded-xl border border-[#F16112]/20 bg-orange-50 p-5">
-                <p className="text-2xl font-bold text-[#F16112] mb-1">From $349/month</p>
-                <p className="text-sm text-gray-600 mb-1">Billed monthly · 3-month minimum</p>
-                <p className="text-xs text-gray-500 mb-4">Contact us for exact pricing by schedule and session type.</p>
+                <p className="text-2xl font-bold text-[#F16112] mb-1">From $169/month</p>
+                <p className="text-sm text-gray-600 mb-4">Billed monthly · 3-month minimum</p>
+
+                <div className="space-y-2 mb-4">
+                  {/* 1 Subject */}
+                  <div className="flex items-center justify-between bg-white rounded-lg px-4 py-3 border border-gray-100">
+                    <div>
+                      <p className="font-semibold text-gray-800 text-sm">1 Subject</p>
+                      <p className="text-xs text-gray-500">75 min/week</p>
+                    </div>
+                    <p className="font-bold text-[#F16112]">$169/mo</p>
+                  </div>
+                  {/* 2 Subject */}
+                  <div className="flex items-center justify-between bg-white rounded-lg px-4 py-3 border border-gray-100 relative">
+                    <div>
+                      <p className="font-semibold text-gray-800 text-sm">2 Subject</p>
+                      <p className="text-xs text-gray-500">2 × 60 min/week</p>
+                    </div>
+                    <p className="font-bold text-[#F16112]">$279/mo</p>
+                  </div>
+                  {/* Academic + Coding */}
+                  <div className="flex items-center justify-between bg-white rounded-lg px-4 py-3 border border-gray-100">
+                    <div>
+                      <p className="font-semibold text-gray-800 text-sm">Academic + Coding</p>
+                      <p className="text-xs text-gray-500">2 × 60 min/week</p>
+                    </div>
+                    <p className="font-bold text-[#F16112]">$279/mo</p>
+                  </div>
+                </div>
+
+                {/* FIX 3 — Urgency badge */}
+                <div className="flex items-center gap-1.5 mb-4">
+                  <span className="inline-flex items-center gap-1 bg-green-100 text-green-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-green-200">
+                    <Sparkles className="h-3 w-3" aria-hidden />
+                    No registration fee through July 2026
+                  </span>
+                </div>
+
                 <Button
                   onClick={openAssessment}
                   className="bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white rounded-full w-full font-semibold"
                 >
-                  Book free assessment
+                  Book free 45-min assessment
                 </Button>
               </div>
             </div>
@@ -546,13 +584,79 @@ const ElementaryMathPage: React.FC = () => {
         </div>
       </section>
 
-      {/* ── SECTION 10: CTA block ────────────────────── */}
+      {/* ── SECTION 10: Paid trial ───────────────────── */}
+      <section className="bg-[#ebebeb] py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">Try before you commit</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-5">
+            Not sure yet? Start with a single session.
+          </h2>
+          <p className="text-gray-600 leading-relaxed mb-8 max-w-2xl">
+            A lot can show up in one well-structured session. Your child works through problems with the instructor. We identify where reasoning breaks down and where it is solid. You leave with a clear picture of what needs work — and whether GrowWise is the right fit.
+          </p>
+
+          {/* Trial card */}
+          <div className="rounded-xl border-2 border-[#1F396D]/20 bg-white p-6 lg:p-8 mb-6 shadow-sm">
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
+              <div>
+                <p className="font-bold text-gray-800 text-lg mb-1">Trial session — Grades 1–5</p>
+                <p className="text-gray-500 text-sm">One session · 60 minutes</p>
+              </div>
+              <div className="text-right shrink-0">
+                <p className="text-3xl font-bold text-[#1F396D]">$45</p>
+                <p className="text-xs text-green-600 font-semibold mt-0.5">Fee fully waived when you enroll within 7 days.</p>
+              </div>
+            </div>
+
+            <p className="text-sm font-semibold text-gray-700 mb-3">What happens in the trial:</p>
+            <ul className="space-y-2 mb-6">
+              {[
+                'Instructor works through grade-level problems with your child',
+                'Identifies the primary gap and specific mistake patterns',
+                'Parent debrief at the end — what we found, what we would focus on, which program fits',
+                'No pressure, no obligation',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-2.5 text-sm text-gray-700">
+                  <CheckCircle className="h-4 w-4 mt-0.5 text-[#1F396D] shrink-0" aria-hidden />
+                  {item}
+                </li>
+              ))}
+            </ul>
+
+            <p className="text-sm text-gray-700 font-semibold mb-6 border-l-4 border-[#F16112] pl-4">
+              The $45 is not a deposit. It is a session fee — for a real session, with a real instructor, producing a real result. If you enroll within 7 days, it is credited in full toward your first month.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Link
+                href={publicPath('/enroll-academic', locale)}
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#F16112] to-[#F1894F] px-6 py-3 text-sm font-semibold text-white shadow hover:shadow-md transition-shadow"
+              >
+                Book a trial session — $45
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+              <Link
+                href={publicPath('/book-assessment', locale)}
+                className="inline-flex items-center justify-center text-sm font-medium text-[#1F396D] hover:text-[#F16112] underline underline-offset-4 px-4 py-3 transition-colors"
+              >
+                Or start with the free 45-min assessment first
+              </Link>
+            </div>
+
+            <p className="text-xs text-gray-400 mt-4">
+              Trial fee applies to Grades 1–8. Fee waived upon enrollment within 7 days of trial session.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 11: CTA block ────────────────────── */}
       <section className="bg-gradient-to-br from-[#1F396D] to-[#29335C] py-16 lg:py-24 text-white text-center">
         <div className="max-w-2xl mx-auto px-4 lg:px-8">
           <Brain className="h-10 w-10 text-[#F1894F] mx-auto mb-5" aria-hidden />
-          <h2 className="text-2xl lg:text-3xl font-bold mb-4">Start with a free assessment.</h2>
+          <h2 className="text-2xl lg:text-3xl font-bold mb-4">Start with a free 45-minute assessment.</h2>
           <p className="text-white/80 mb-8 leading-relaxed">
-            The diagnostic session is free, takes 20 minutes, and tells you exactly which gap to close — before you commit to anything. Most parents leave knowing more about their child's math than they did after months of homework help.
+            The free 45-minute assessment tells you exactly which gap to close — before you commit to anything. Most parents leave knowing more about their child's math than they did after months of homework help.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Button
@@ -573,6 +677,10 @@ const ElementaryMathPage: React.FC = () => {
             <Phone className="h-4 w-4" aria-hidden />
             <span>Or call <a href="tel:+19254564606" className="underline underline-offset-2 hover:text-white">(925) 456-4606</a></span>
           </div>
+          {/* FIX 5 — trust line */}
+          <p className="mt-6 text-white/50 text-xs">
+            No registration fee through July 2026. No long-term contract. Monthly enrollment — cancel anytime.
+          </p>
         </div>
       </section>
 

--- a/src/components/ElementaryMathPage.tsx
+++ b/src/components/ElementaryMathPage.tsx
@@ -1,0 +1,587 @@
+'use client'
+
+import React, { useState } from 'react'
+import Link from 'next/link'
+import {
+  Calculator,
+  BookOpen,
+  Users,
+  CheckCircle,
+  ChevronRight,
+  MapPin,
+  ArrowRight,
+  Target,
+  Brain,
+  TrendingUp,
+  Clock,
+  Star,
+  Phone,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Breadcrumbs } from '@/components/seo/Breadcrumbs'
+import { CourseFAQ } from '@/components/seo/CourseFAQ'
+import FreeAssessmentModal from '@/components/FreeAssessmentModal'
+import { ELEMENTARY_MATH_VISIBLE_FAQS } from '@/lib/schema/elementary-math-faqs'
+import { absoluteSiteUrl, publicPath } from '@/lib/publicPath'
+import { useLocale } from 'next-intl'
+
+// ─────────────────────────────────────────────
+// Static data
+// ─────────────────────────────────────────────
+
+const TRUST_CHIPS = [
+  { icon: BookOpen, label: 'Grades 1–5' },
+  { icon: Users, label: 'Live online nationwide + in-person Dublin CA' },
+  { icon: Target, label: '6–10 students per group' },
+  { icon: Clock, label: 'Starts monthly' },
+]
+
+const GRADE_SIGNS = [
+  {
+    grades: 'Grade 1–2',
+    color: 'border-[#1F396D]',
+    badgeColor: 'bg-[#1F396D]',
+    signs: [
+      'Can count but struggles to compose and decompose numbers',
+      "Knows addition facts but can't explain what addition means",
+      'Confuses tens and ones place value under pressure',
+    ],
+    meaning:
+      "Number sense isn't concrete yet. The student is relying on memorization, not understanding.",
+  },
+  {
+    grades: 'Grade 3–4',
+    color: 'border-[#F16112]',
+    badgeColor: 'bg-[#F16112]',
+    signs: [
+      'Multiplication facts are shaky or slow',
+      'Word problems work in one step but fall apart in two steps',
+      'Fractions feel arbitrary — no intuition for what a fraction represents',
+    ],
+    meaning:
+      'Conceptual gaps in multiplication and early fractions. Procedural drill without meaning.',
+  },
+  {
+    grades: 'Grade 5',
+    color: 'border-[#F1894F]',
+    badgeColor: 'bg-[#F1894F]',
+    signs: [
+      'Fractions with unlike denominators are inconsistent',
+      "Decimal operations produce errors that don't feel \"wrong\" to the student",
+      'Order of operations is memorized but not understood',
+    ],
+    meaning:
+      "One or two fraction concepts that never fully landed are now showing up in everything. Usually fixable in 4–6 weeks of targeted work.",
+  },
+]
+
+interface JTBDSituation {
+  label: string
+  heading: string
+  body: string
+  cta: 'assessment' | 'selfcheck' | 'summer' | 'advisor'
+  ctaLabel: string
+}
+
+const JTBD_SITUATIONS: JTBDSituation[] = [
+  {
+    label: 'Fractions',
+    heading: "\"My child has been struggling with fractions for months and I can't figure out why\"",
+    body: 'This is the most common elementary math presentation. Fractions are where conceptual gaps in multiplication and number sense compound all at once. The fix is almost always a few weeks back — not in the fractions unit itself.',
+    cta: 'assessment',
+    ctaLabel: 'Book free assessment',
+  },
+  {
+    label: 'Word problems',
+    heading: "\"They're fine at computation but fall apart on word problems\"",
+    body: 'Word problems require reading the mathematical structure of a situation — not just calculating. This is a reasoning gap, not a computation gap. Different fix.',
+    cta: 'selfcheck',
+    ctaLabel: 'Try the Self-Check',
+  },
+  {
+    label: 'Practice gaps',
+    heading: "\"Teacher says they need more practice, but I don't know practice of what\"",
+    body: '"More practice" applied to the wrong concept produces frustration, not progress. The first step is identifying exactly which concept needs work.',
+    cta: 'assessment',
+    ctaLabel: 'Book free assessment',
+  },
+  {
+    label: 'New grade prep',
+    heading: "\"Going into a new grade and I want to make sure the foundation is solid\"",
+    body: 'Summer and transition prep for rising Grade 2–5 students. We assess where they are and build forward.',
+    cta: 'summer',
+    ctaLabel: 'See summer programs',
+  },
+  {
+    label: 'Enrichment',
+    heading: "\"They're doing fine — I want them ahead\"",
+    body: 'Enrichment track for students who have mastered grade-level material and are ready to work above it.',
+    cta: 'advisor',
+    ctaLabel: 'Talk to an advisor',
+  },
+]
+
+const CURRICULUM_BANDS = [
+  {
+    label: 'Grade 1–2 focus',
+    color: 'bg-[#1F396D]',
+    topics: [
+      'Number sense and place value — tens, ones, composing and decomposing numbers',
+      'Addition and subtraction with understanding — not just fact memorization',
+      'Measuring and comparing — early geometric thinking',
+      'Introduction to repeated addition as multiplication foundation',
+    ],
+  },
+  {
+    label: 'Grade 3–4 focus',
+    color: 'bg-[#F16112]',
+    topics: [
+      'Multiplication and division fluency — with conceptual backing, not just times tables',
+      'Fractions as numbers on a number line — not just parts of a shape',
+      'Equivalent fractions — the most commonly skipped and most consequential concept',
+      'Multi-step word problems — identifying the mathematical structure before calculating',
+    ],
+  },
+  {
+    label: 'Grade 5 focus',
+    color: 'bg-[#F1894F]',
+    topics: [
+      'Fractions: addition, subtraction, multiplication, division — all operations with conceptual grounding',
+      'Decimal operations connected to fraction understanding',
+      'Order of operations — with meaning, not just PEMDAS memorization',
+      'Intro to coordinate planes and basic data interpretation',
+    ],
+  },
+]
+
+const PROGRAM_INCLUDES = [
+  'Diagnostic assessment before session 1 (identifies the primary gap and sets the curriculum entry point)',
+  '2 sessions per week · 60 minutes each · 24 sessions total',
+  'Small group of 6–10 students at the same skill level',
+  "Defined curriculum scope — you know what's covered before you start",
+  'Monthly parent progress report (skills covered, mistake patterns corrected, next steps)',
+  "Common Core aligned — tracks the concepts your child's school teaches",
+  'Live online or in-person at Dublin Blvd, Dublin CA',
+]
+
+const PROGRAM_OUTCOMES = [
+  'Have the primary identified gap closed',
+  'Be able to approach multi-step problems with a system, not guesswork',
+  'Have measurable improvement in the specific skills identified at diagnostic',
+]
+
+const NOT_ITEMS = [
+  'Assign worksheets without instructor-led explanation',
+  "Reteach the current school unit without diagnosing what's blocking it",
+  'Operate as homework completion supervision',
+]
+
+// ─────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────
+
+const ElementaryMathPage: React.FC = () => {
+  const locale = useLocale()
+  const [isAssessmentModalOpen, setIsAssessmentModalOpen] = useState(false)
+
+  const openAssessment = () => setIsAssessmentModalOpen(true)
+
+  const ctaForSituation = (situation: JTBDSituation) => {
+    if (situation.cta === 'assessment') {
+      return (
+        <button
+          onClick={openAssessment}
+          className="inline-flex items-center gap-1.5 rounded-full bg-[#F16112] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#d54f0a] transition-colors"
+        >
+          {situation.ctaLabel}
+          <ArrowRight className="h-4 w-4" aria-hidden />
+        </button>
+      )
+    }
+    if (situation.cta === 'selfcheck') {
+      return (
+        <Link
+          href={publicPath('/self-check', locale)}
+          className="inline-flex items-center gap-1.5 rounded-full bg-[#1F396D] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#162850] transition-colors"
+        >
+          {situation.ctaLabel}
+          <ArrowRight className="h-4 w-4" aria-hidden />
+        </Link>
+      )
+    }
+    if (situation.cta === 'summer') {
+      return (
+        <Link
+          href={publicPath('/camps/academic-summer-programs-dublin-ca', locale)}
+          className="inline-flex items-center gap-1.5 rounded-full bg-[#1F396D] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#162850] transition-colors"
+        >
+          {situation.ctaLabel}
+          <ArrowRight className="h-4 w-4" aria-hidden />
+        </Link>
+      )
+    }
+    // advisor
+    return (
+      <button
+        onClick={openAssessment}
+        className="inline-flex items-center gap-1.5 rounded-full border-2 border-[#1F396D] px-5 py-2.5 text-sm font-semibold text-[#1F396D] hover:bg-[#1F396D]/5 transition-colors"
+      >
+        {situation.ctaLabel}
+        <ArrowRight className="h-4 w-4" aria-hidden />
+      </button>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-[#ebebeb]" style={{ fontFamily: '"Nunito", "Inter", system-ui, sans-serif' }}>
+      {/* Breadcrumb */}
+      <Breadcrumbs
+        noSchema
+        items={[
+          { name: 'Academic', url: absoluteSiteUrl('/academic', locale) },
+          { name: 'Math Programs', url: absoluteSiteUrl('/courses/math', locale) },
+          { name: 'Elementary Math', url: absoluteSiteUrl('/courses/math/elementary', locale) },
+        ]}
+      />
+
+      {/* ── HERO ─────────────────────────────────────── */}
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50">
+          <div className="absolute top-20 left-10 w-64 h-64 bg-[#F16112]/10 rounded-full blur-3xl animate-pulse" />
+          <div className="absolute bottom-20 right-10 w-80 h-80 bg-[#1F396D]/10 rounded-full blur-3xl animate-pulse" style={{ animationDelay: '1s' }} />
+          {/* Floating number symbols */}
+          {['1', '2', '+', '½', '×', '÷', '=', '3', '5', '¼'].map((sym, i) => (
+            <div
+              key={i}
+              className="absolute text-gray-400/40 font-bold select-none"
+              style={{
+                left: `${10 + i * 9}%`,
+                top: `${15 + (i % 3) * 25}%`,
+                fontSize: `${18 + (i % 3) * 8}px`,
+              }}
+            >
+              {sym}
+            </div>
+          ))}
+        </div>
+
+        <div className="relative z-10 max-w-5xl mx-auto px-4 lg:px-8 py-16 lg:py-24 text-center">
+          <Badge className="mb-4 bg-[#F16112]/10 text-[#F16112] border-[#F16112]/20 hover:bg-[#F16112]/20">
+            Elementary Math · Grades 1–5
+          </Badge>
+          <h1 className="text-3xl lg:text-5xl font-bold text-gray-800 mb-5 leading-tight">
+            Most elementary math struggles trace back to one gap.
+            <span className="block bg-gradient-to-r from-[#1F396D] to-[#F16112] bg-clip-text text-transparent mt-1">
+              We find it before it spreads.
+            </span>
+          </h1>
+          <p className="max-w-2xl mx-auto text-lg text-gray-600 mb-8 leading-relaxed">
+            By the time a parent notices the problem — grades slipping, homework battles, "I hate math" — the real blocker is usually something from 6 to 18 months ago that never fully landed. Our programs start with a diagnostic session that identifies where reasoning breaks down, not where the current worksheet is hard.
+          </p>
+
+          {/* Trust chips */}
+          <div className="flex flex-wrap justify-center gap-3 mb-10">
+            {TRUST_CHIPS.map(({ icon: Icon, label }) => (
+              <div key={label} className="inline-flex items-center gap-2 bg-white/80 backdrop-blur-sm rounded-full px-4 py-2 border border-gray-200/60 text-sm text-gray-700 font-medium shadow-sm">
+                <Icon className="h-4 w-4 text-[#F16112]" aria-hidden />
+                {label}
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-3">
+            <Button
+              onClick={openAssessment}
+              className="bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white rounded-full px-8 py-4 text-base font-semibold shadow-lg hover:shadow-xl transition-shadow"
+            >
+              <Calculator className="mr-2 h-5 w-5" aria-hidden />
+              Book free assessment
+            </Button>
+            <Link
+              href={publicPath('/self-check', locale)}
+              className="inline-flex items-center gap-2 rounded-full border-2 border-[#1F396D] px-8 py-4 text-base font-semibold text-[#1F396D] hover:bg-[#1F396D]/5 transition-colors"
+            >
+              Try the free Self-Check
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 1: The real problem ─────────────── */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">What's actually happening</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-6">
+            Elementary math has a compounding problem most parents don't see.
+          </h2>
+          <div className="space-y-4 text-gray-600 leading-relaxed text-base lg:text-lg">
+            <p>
+              Each new math concept in Grades 1–5 builds on what came before. Fractions assume multiplication fluency. Multi-step word problems assume solid operations. Decimals assume fraction understanding.
+            </p>
+            <p>
+              When one concept doesn't land fully — and the class moves on — the gap doesn't disappear. It compounds. The student arrives at the next unit slightly behind, the unit after that a little more behind, and by Grade 4 or 5 the problem is visible everywhere even though it started in one narrow place.
+            </p>
+            <p className="font-medium text-gray-700">
+              The most common parent experience: "They were fine until this year." They weren't behind in previous years — the gap was just smaller than the work required to expose it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 2: Signs by grade ────────────────── */}
+      <section className="bg-[#ebebeb] py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">What to look for</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-10">
+            Common signs at each stage — and what they usually mean.
+          </h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            {GRADE_SIGNS.map((band) => (
+              <Card key={band.grades} className={`border-t-4 ${band.color} bg-white shadow-sm`}>
+                <CardContent className="pt-5 pb-6 px-5">
+                  <Badge className={`${band.badgeColor} text-white mb-4`}>{band.grades}</Badge>
+                  <ul className="space-y-2 mb-4">
+                    {band.signs.map((sign) => (
+                      <li key={sign} className="flex items-start gap-2 text-sm text-gray-700">
+                        <ChevronRight className="h-4 w-4 mt-0.5 text-[#F16112] shrink-0" aria-hidden />
+                        {sign}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="text-sm italic text-gray-500 border-t border-gray-100 pt-3">
+                    <span className="font-semibold not-italic text-gray-600">What it usually means: </span>
+                    {band.meaning}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 3: JTBD ──────────────────────────── */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">Which situation fits your child?</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-10">
+            We've seen every version of this.
+          </h2>
+          <div className="space-y-5">
+            {JTBD_SITUATIONS.map((situation, i) => (
+              <div key={i} className="rounded-xl border border-gray-200 bg-gray-50 p-5 lg:p-6">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-gray-800 mb-2">{situation.heading}</p>
+                    <p className="text-gray-600 text-sm leading-relaxed">{situation.body}</p>
+                  </div>
+                  <div className="shrink-0 mt-1">
+                    {ctaForSituation(situation)}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 4: Curriculum ────────────────────── */}
+      <section className="bg-[#ebebeb] py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">Curriculum scope — Grades 1–5</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-3">
+            What we cover and why the order matters.
+          </h2>
+          <p className="text-gray-600 mb-10 max-w-2xl">
+            Every session sequence is built backward from where the gaps most commonly appear — not forward from a textbook chapter order.
+          </p>
+          <div className="grid md:grid-cols-3 gap-6">
+            {CURRICULUM_BANDS.map((band) => (
+              <div key={band.label} className="bg-white rounded-xl shadow-sm overflow-hidden">
+                <div className={`${band.color} px-5 py-3`}>
+                  <span className="text-white font-semibold text-sm">{band.label}</span>
+                </div>
+                <ul className="px-5 py-4 space-y-3">
+                  {band.topics.map((topic) => (
+                    <li key={topic} className="flex items-start gap-2 text-sm text-gray-700">
+                      <CheckCircle className="h-4 w-4 mt-0.5 text-[#F16112] shrink-0" aria-hidden />
+                      {topic}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 5: Program details ───────────────── */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F16112] mb-3">Program details</p>
+          <h2 className="text-2xl lg:text-3xl font-bold text-gray-800 mb-8">
+            Elementary Math Foundation — 3-Month Program
+          </h2>
+          <div className="grid md:grid-cols-2 gap-8">
+            <div>
+              <p className="font-semibold text-gray-800 mb-4">What's included:</p>
+              <ul className="space-y-3">
+                {PROGRAM_INCLUDES.map((item) => (
+                  <li key={item} className="flex items-start gap-2.5 text-gray-700 text-sm">
+                    <CheckCircle className="h-4 w-4 mt-0.5 text-[#F16112] shrink-0" aria-hidden />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="font-semibold text-gray-800 mb-4">At the end of 3 months, your child should:</p>
+              <ul className="space-y-3 mb-8">
+                {PROGRAM_OUTCOMES.map((item) => (
+                  <li key={item} className="flex items-start gap-2.5 text-gray-700 text-sm">
+                    <Star className="h-4 w-4 mt-0.5 text-[#F16112] shrink-0" aria-hidden />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <div className="rounded-xl border border-[#F16112]/20 bg-orange-50 p-5">
+                <p className="text-2xl font-bold text-[#F16112] mb-1">From $349/month</p>
+                <p className="text-sm text-gray-600 mb-1">Billed monthly · 3-month minimum</p>
+                <p className="text-xs text-gray-500 mb-4">Contact us for exact pricing by schedule and session type.</p>
+                <Button
+                  onClick={openAssessment}
+                  className="bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white rounded-full w-full font-semibold"
+                >
+                  Book free assessment
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 6: Not homework help ─────────────── */}
+      <section className="bg-[#1F396D] py-16 lg:py-20 text-white">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <p className="text-sm font-semibold uppercase tracking-widest text-[#F1894F] mb-3">What this is not</p>
+          <h2 className="text-2xl lg:text-3xl font-bold mb-4">
+            Not more of what isn't working.
+          </h2>
+          <p className="text-white/80 mb-8 max-w-2xl leading-relaxed">
+            Most children with elementary math gaps have already done more worksheets. The problem is rarely practice volume — it's practice of the wrong concept, or practice of the right concept without understanding.
+          </p>
+          <p className="font-semibold text-white/90 mb-4">GrowWise elementary sessions do not:</p>
+          <ul className="space-y-3 mb-8">
+            {NOT_ITEMS.map((item) => (
+              <li key={item} className="flex items-start gap-2.5 text-white/80 text-sm">
+                <div className="h-1.5 w-1.5 rounded-full bg-[#F1894F] mt-2 shrink-0" />
+                {item}
+              </li>
+            ))}
+          </ul>
+          <p className="text-white/80 leading-relaxed">
+            Every session is instructed. The diagnostic determines the starting concept. The instructor corrects specific mistake patterns — not just wrong answers. Students leave each session with something they can do that they couldn't do before.
+          </p>
+        </div>
+      </section>
+
+      {/* ── SECTION 7: Geo callout ───────────────────── */}
+      <section className="bg-white py-12 lg:py-16">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <div className="rounded-xl border border-[#1F396D]/20 bg-blue-50 p-6 lg:p-8 flex flex-col md:flex-row items-start md:items-center gap-5">
+            <div className="shrink-0 h-12 w-12 rounded-full bg-[#1F396D] flex items-center justify-center">
+              <MapPin className="h-6 w-6 text-white" aria-hidden />
+            </div>
+            <div className="flex-1">
+              <p className="font-bold text-gray-800 text-lg mb-1">In Dublin, Pleasanton, or the Tri-Valley?</p>
+              <p className="text-gray-600 text-sm">
+                Our Dublin, CA center offers in-person elementary math sessions — same curriculum, same small groups, same diagnostic approach.
+              </p>
+            </div>
+            <Link
+              href={publicPath('/math-tutoring-dublin-ca/elementary', locale)}
+              className="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-[#1F396D] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#162850] transition-colors whitespace-nowrap"
+            >
+              See local programs
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 8: Middle school transition ─────── */}
+      <section className="bg-[#ebebeb] py-12 lg:py-16">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 lg:p-8 flex flex-col md:flex-row items-start md:items-center gap-5">
+            <div className="shrink-0 h-12 w-12 rounded-full bg-[#F16112] flex items-center justify-center">
+              <TrendingUp className="h-6 w-6 text-white" aria-hidden />
+            </div>
+            <div className="flex-1">
+              <p className="font-bold text-gray-800 text-lg mb-1">Heading into middle school?</p>
+              <p className="text-gray-600 text-sm">
+                If your child is finishing Grade 5 and moving into 6th grade math or a Pre-Algebra track, the middle school program is the right next step.
+              </p>
+            </div>
+            <Link
+              href={publicPath('/courses/math/middle-school', locale)}
+              className="shrink-0 inline-flex items-center gap-1.5 rounded-full border-2 border-[#F16112] px-5 py-2.5 text-sm font-semibold text-[#F16112] hover:bg-[#F16112]/5 transition-colors whitespace-nowrap"
+            >
+              See middle school math
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SECTION 9: FAQ ───────────────────────────── */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 lg:px-8">
+          <CourseFAQ
+            faqs={ELEMENTARY_MATH_VISIBLE_FAQS}
+            title="Elementary Math FAQs"
+            subtitle="Common questions about the Grades 1–5 program."
+            includeStructuredData={false}
+          />
+        </div>
+      </section>
+
+      {/* ── SECTION 10: CTA block ────────────────────── */}
+      <section className="bg-gradient-to-br from-[#1F396D] to-[#29335C] py-16 lg:py-24 text-white text-center">
+        <div className="max-w-2xl mx-auto px-4 lg:px-8">
+          <Brain className="h-10 w-10 text-[#F1894F] mx-auto mb-5" aria-hidden />
+          <h2 className="text-2xl lg:text-3xl font-bold mb-4">Start with a free assessment.</h2>
+          <p className="text-white/80 mb-8 leading-relaxed">
+            The diagnostic session is free, takes 20 minutes, and tells you exactly which gap to close — before you commit to anything. Most parents leave knowing more about their child's math than they did after months of homework help.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Button
+              onClick={openAssessment}
+              className="bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white rounded-full px-8 py-4 text-base font-semibold shadow-lg hover:shadow-xl transition-shadow"
+            >
+              <Calculator className="mr-2 h-5 w-5" aria-hidden />
+              Book free assessment
+            </Button>
+            <Link
+              href={publicPath('/self-check', locale)}
+              className="inline-flex items-center gap-2 rounded-full border-2 border-white/60 px-8 py-4 text-base font-semibold text-white hover:bg-white/10 transition-colors"
+            >
+              Try the free Self-Check
+            </Link>
+          </div>
+          <div className="mt-8 flex items-center justify-center gap-2 text-white/70 text-sm">
+            <Phone className="h-4 w-4" aria-hidden />
+            <span>Or call <a href="tel:+19254564606" className="underline underline-offset-2 hover:text-white">(925) 456-4606</a></span>
+          </div>
+        </div>
+      </section>
+
+      <FreeAssessmentModal
+        isOpen={isAssessmentModalOpen}
+        onClose={() => setIsAssessmentModalOpen(false)}
+      />
+    </div>
+  )
+}
+
+export default ElementaryMathPage

--- a/src/components/courses/math-hub/GradeBandCards.tsx
+++ b/src/components/courses/math-hub/GradeBandCards.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { MATH_HUB_COPY } from '@/lib/math-hub-copy';
+import { publicPath } from '@/lib/publicPath';
+import { MathHubSection } from './MathHubSection';
+
+type GradeBandCardsProps = {
+  locale: string;
+};
+
+export function GradeBandCards({ locale }: GradeBandCardsProps) {
+  const { gradeBands } = MATH_HUB_COPY;
+
+  return (
+    <MathHubSection
+      label={gradeBands.sectionLabel}
+      heading={gradeBands.subheading}
+      className="bg-white"
+    >
+      <div className="grid gap-6 md:grid-cols-3">
+        {gradeBands.cards.map((card) => (
+          <Link
+            key={card.id}
+            href={publicPath(card.path, locale)}
+            className={`group flex cursor-pointer flex-col overflow-hidden rounded-2xl border bg-white shadow-sm transition-shadow hover:shadow-md ${
+              card.featured
+                ? 'border-[#F16112] ring-2 ring-[#F16112]/30'
+                : 'border-slate-200'
+            }`}
+          >
+            <div className="relative aspect-[16/10] w-full shrink-0 overflow-hidden bg-slate-100">
+              <img
+                src={card.imageSrc}
+                alt={card.imageAlt}
+                width={640}
+                height={400}
+                loading="lazy"
+                decoding="async"
+                className="h-full w-full object-cover object-center select-none"
+                draggable={false}
+              />
+              {card.featured ? (
+                <span className="absolute left-4 top-4 inline-flex w-fit rounded-full bg-[#F16112] px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white shadow-sm">
+                  Most enrolled
+                </span>
+              ) : null}
+            </div>
+
+            <div className="flex flex-1 flex-col p-6">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[#1F396D]">
+                {card.gradeTag}
+              </span>
+              <h3 className="font-heading mt-1 text-xl font-bold text-slate-900">{card.heading}</h3>
+              <p className="mt-1 text-sm font-medium text-slate-700">{card.tagline}</p>
+              <p className="mt-3 text-sm leading-relaxed text-slate-600">{card.description}</p>
+              {card.masteryLine ? (
+                <p className="mt-1.5 flex-1 text-[11px] text-slate-400">{card.masteryLine}</p>
+              ) : (
+                <div className="flex-1" />
+              )}
+              <p className="mt-4 text-xs font-medium text-slate-500">Courses included</p>
+              <ul className="mt-1 flex flex-wrap gap-1.5">
+                {card.coursesIncluded.map((topic) => (
+                  <li
+                    key={topic}
+                    className="rounded-md bg-slate-100 px-2 py-0.5 text-[11px] text-slate-700"
+                  >
+                    {topic}
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4 text-sm font-semibold text-[#1F396D]">{card.packageLine}</p>
+              <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-[#F16112] group-hover:text-[#d54f0a]">
+                {card.ctaLabel}
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </MathHubSection>
+  );
+}

--- a/src/lib/math-hub-copy.ts
+++ b/src/lib/math-hub-copy.ts
@@ -1,0 +1,419 @@
+/**
+ * English copy for /courses/math hub and grade-band stub pages.
+ * Single source for UI + JSON-LD FAQ text.
+ */
+
+export const MATH_HUB_PATH = '/courses/math' as const;
+
+/** Pre-compressed WebP hero (~23KB @ 1024w). Served from /public/assets/courses/. */
+export const MATH_HUB_BANNER_SRC = '/assets/courses/math-hub-banner.webp' as const;
+
+/** Smaller variant for viewports ≤768px (~13KB @ 640w). */
+export const MATH_HUB_BANNER_SM_SRC = '/assets/courses/math-hub-banner-sm.webp' as const;
+
+export type MathGradeBandId = 'elementary' | 'middle-school' | 'high-school';
+
+export type MathHubJtbdSituation = {
+  readonly id: string;
+  readonly label: string;
+  readonly symptoms: string;
+  readonly resolution: string;
+  readonly primaryCta: { readonly label: string; readonly href: string };
+  readonly secondaryCta: { readonly label: string; readonly href: string };
+};
+
+export type MathHubGradeBandCard = {
+  readonly id: MathGradeBandId;
+  readonly path: string;
+  readonly gradeTag: string;
+  readonly heading: string;
+  readonly tagline: string;
+  readonly description: string;
+  readonly masteryLine?: string;
+  readonly coursesIncluded: readonly string[];
+  readonly packageLine: string;
+  readonly ctaLabel: string;
+  readonly imageSrc: string;
+  readonly imageAlt: string;
+  readonly featured?: boolean;
+};
+
+export type MathHubProgramOption = {
+  readonly name: string;
+  readonly schedule: string;
+  readonly price: string;
+};
+
+export type MathHubProgramBandCard = {
+  readonly id: MathGradeBandId;
+  readonly path: string;
+  readonly heading: string;
+  readonly gradeRange: string;
+  readonly tracks: string;
+  readonly options: readonly MathHubProgramOption[];
+  readonly ctaLabel: string;
+  readonly includedBenefit?: string;
+};
+
+export const MATH_HUB_COPY = {
+  breadcrumb: {
+    academic: 'Academic',
+    mathPrograms: 'Math Programs',
+  },
+  hero: {
+    bannerAlt:
+      'A math teacher leading a small-group tutoring session with students around a table in a bright classroom.',
+    h1: "Find the right math program for your child's grade and goal.",
+    subheading:
+      "Not all math problems are the same — and neither are the programs. Every grade band has different gaps, different curriculum demands, and different parent concerns. Start by selecting where your child is right now.",
+    trustBar: [
+      'Live online · nationwide',
+      '6–10 students per group',
+      'Starts monthly — no waiting for September',
+      'Diagnostic-first',
+    ] as const,
+  },
+  gradeBands: {
+    sectionLabel: "Choose your child's grade level",
+    subheading: 'Three programs. Each built for a different stage of math learning.',
+    cards: [
+      {
+        id: 'elementary',
+        path: '/courses/math/elementary',
+        gradeTag: 'Grades 1–5',
+        heading: 'Elementary math',
+        tagline: 'Number sense, fractions, and reasoning — before the gaps compound.',
+        description:
+          'Most elementary math struggles trace back to one unaddressed concept from 6–12 months ago. We find it before it becomes a pattern.',
+        masteryLine: '3 levels: Beginner · Champ · Pro · 90% mastery to advance',
+        coursesIncluded: [
+          'Place value',
+          'Operations fluency',
+          'Fractions & decimals',
+          'Word problem structure',
+          'Intro geometry',
+        ],
+        packageLine: 'From $169/month · 75 min, once a week · 3-month program',
+        ctaLabel: 'See elementary programs',
+        imageSrc: '/assets/courses/math-band-elementary.webp',
+        imageAlt:
+          'Elementary students learning number sense and fractions in a small-group online math class.',
+      },
+      {
+        id: 'middle-school',
+        path: '/courses/math/middle-school',
+        gradeTag: 'Grades 6–8',
+        heading: 'Middle school math',
+        tagline: 'Pre-Algebra, IM1, IM2 — including accelerated curriculum tracks.',
+        description:
+          'The jump into Integrated Math catches many students off guard. We close the gaps before they compound across the year.',
+        coursesIncluded: [
+          'Pre-Algebra',
+          'Integrated Math 1',
+          'Integrated Math 2',
+          'Proportional reasoning',
+          'Linear functions',
+        ],
+        packageLine: 'From $179/month · 75 min, once a week · 3-month program',
+        ctaLabel: 'See middle school programs',
+        imageSrc: '/assets/courses/math-band-middle-school.webp',
+        imageAlt:
+          'Middle school students working through pre-algebra and integrated math in a live tutoring session.',
+        featured: true,
+      },
+      {
+        id: 'high-school',
+        path: '/courses/math/high-school',
+        gradeTag: 'Grades 9–12',
+        heading: 'High school math',
+        tagline: 'Algebra 2 through AP Calculus — course-specific, not general review.',
+        description:
+          'High school math moves at pace. Our programs are built around the course your child is actually in — not a broad review of everything.',
+        coursesIncluded: [
+          'Algebra 2',
+          'Geometry',
+          'Pre-Calculus',
+          'AP Calculus AB/BC',
+          'AP Statistics',
+          'SAT Math',
+        ],
+        packageLine: 'From $189/month · 75 min, once a week · 3-month program',
+        ctaLabel: 'See high school programs',
+        imageSrc: '/assets/courses/math-band-high-school.webp',
+        imageAlt:
+          'High school student writing math notes in a notebook at a desk with a laptop.',
+      },
+    ] satisfies readonly MathHubGradeBandCard[],
+  },
+  jtbd: {
+    sectionLabel: 'Step 2 — Find your situation',
+    heading: 'What problem are we solving?',
+    body: "Most parents arrive with a symptom — grades dropped, homework is a battle, a harder course is coming. Select the situation that fits. We'll show you what's usually behind it and which program closes it.",
+    situations: [
+      {
+        id: 'falling-behind',
+        label: 'My child is falling behind and struggling to keep up',
+        symptoms: 'Grades dropping, homework avoidance, inconsistent test scores',
+        resolution:
+          "A gap from 12–18 months back that hasn't been named. We run a diagnostic before the first session to find it.",
+        primaryCta: { label: 'Book free assessment', href: '/book-assessment' },
+        secondaryCta: { label: 'See rescue programs', href: '/courses/math' },
+      },
+      {
+        id: 'harder-course-coming',
+        label: 'A harder course is coming — I want them ready before day one',
+        symptoms: 'IM1, IM2, Algebra 2, Pre-Calc transition',
+        resolution:
+          "Placement doesn't guarantee readiness. We prep for the specific concepts the course assumes on week one.",
+        primaryCta: { label: 'See Math Get Ready programs', href: '/camps/academic-summer-programs-dublin-ca' },
+        secondaryCta: { label: 'View 3-month packages', href: '/courses/math#packages' },
+      },
+      {
+        id: 'gaps-unclear',
+        label: "I can see gaps but can't pinpoint exactly what",
+        symptoms:
+          'Inconsistent performance, careless errors that never go away, strong on some topics and weak on others',
+        resolution:
+          'The GrowWise pattern finder runs before instruction begins. We identify the real gap — not just the symptom.',
+        primaryCta: { label: 'Try the free Self-Check', href: '/self-check' },
+        secondaryCta: { label: 'Book assessment', href: '/book-assessment' },
+      },
+      {
+        id: 'ahead',
+        label: 'My child is doing fine — I want them ahead',
+        symptoms: 'Accelerated track, staying competitive, Math Olympiad interest',
+        resolution:
+          'We work above grade level in a small group with peers at the same pace. No ceiling.',
+        primaryCta: { label: 'Talk to an advisor', href: '/contact' },
+        secondaryCta: { label: 'View advanced programs', href: '/courses/math/high-school' },
+      },
+      {
+        id: 'year-round',
+        label: 'They need consistent support through the school year',
+        symptoms: 'Weekly instruction that tracks school, progress updates, continuity',
+        resolution:
+          '3-month rolling programs with monthly parent reports. Renew by quarter.',
+        primaryCta: { label: 'Book free assessment', href: '/book-assessment' },
+        secondaryCta: { label: 'See year-round packages', href: '/courses/math#packages' },
+      },
+    ] satisfies readonly MathHubJtbdSituation[],
+  },
+  howItWorks: {
+    sectionLabel: 'How it works',
+    heading: 'Every program starts with a diagnostic. Not a placement test — a pattern finder.',
+    steps: [
+      {
+        title: 'Assessment (free)',
+        description:
+          'A 45-minute session that maps what your child knows, where reasoning breaks down, and what the first month of instruction should focus on. No charge. No commitment.',
+      },
+      {
+        title: 'Program placement',
+        description:
+          'Based on assessment results, we place your child in the right grade band and curriculum track — standard or accelerated. Group size: 6–10 students.',
+      },
+      {
+        title: '3-month program',
+        description:
+          'Defined curriculum scope. Sessions twice per week. Monthly parent progress report showing skills covered, patterns corrected, and next steps. Renew by quarter.',
+      },
+    ] as const,
+  },
+  programOptions: {
+    sectionLabel: 'Programs · 3-month commitment',
+    heading: 'Defined programs. Not open-ended tutoring.',
+    body: "Each package has a fixed curriculum scope, a start-point diagnostic, and a clear outcome by the end of three months. You know what's covered before you enroll.",
+    footnote: 'Prices shown are monthly rates. Contact us for exact pricing by program and schedule.',
+    cards: [
+      {
+        id: 'elementary',
+        path: '/courses/math/elementary',
+        heading: 'Elementary math',
+        gradeRange: 'Grades 1–5',
+        tracks: 'Beginner · Champ · Pro',
+        ctaLabel: 'See full program',
+        options: [
+          { name: '1 Subject', schedule: '75 min, once a week', price: '$169/mo' },
+          { name: '2 Subject', schedule: '2×60 min/week', price: '$279/mo' },
+        ],
+      },
+      {
+        id: 'middle-school',
+        path: '/courses/math/middle-school',
+        heading: 'Middle school math',
+        gradeRange: 'Grades 6–8',
+        tracks: 'IM1 · IM2 · Accelerated',
+        ctaLabel: 'See full program',
+        options: [
+          { name: '1 Subject', schedule: '75 min, once a week', price: '$179/mo' },
+          { name: '2 Subject', schedule: '2×60 min/week', price: '$289/mo' },
+          { name: 'Accelerated Math', schedule: '120 min/week', price: '$289/mo' },
+        ],
+        includedBenefit:
+          'Complimentary 60-minute weekly practice session included with every program',
+      },
+      {
+        id: 'high-school',
+        path: '/courses/math/high-school',
+        heading: 'High school math',
+        gradeRange: 'Grades 9–12',
+        tracks: 'Algebra 2 · AP Calc · SAT',
+        ctaLabel: 'See full program',
+        options: [
+          { name: '1 Subject', schedule: '75 min, once a week', price: '$189/mo' },
+          { name: '2 Subject', schedule: '2×60 min/week', price: '$369/mo' },
+          { name: 'AP Math', schedule: '120 min/week', price: '$376/mo' },
+        ],
+        includedBenefit:
+          'Complimentary 60-minute weekly practice session included with every program',
+      },
+    ] satisfies readonly MathHubProgramBandCard[],
+  },
+  geo: {
+    heading: 'In the Tri-Valley?',
+    body: "We also offer in-person sessions at our Dublin, CA center — aligned to the DUSD and PUSD curriculum sequences your child's school uses.",
+    ctaLabel: 'See Dublin, CA programs',
+    href: '/dublin-ca',
+  },
+  trust: {
+    metrics: [
+      { value: '6–10', label: 'students per group' },
+      { value: 'Gr 1–12', label: 'full range covered' },
+      { value: 'Free', label: 'first assessment' },
+      { value: 'Monthly', label: 'Cohorts start monthly' },
+    ] as const,
+    paragraph:
+      'GrowWise is not a tutoring marketplace. Every instructor is subject-trained. Every program has a defined curriculum and a measurable outcome. Sessions run live — not recorded, not self-paced.',
+  },
+  faq: {
+    title: 'Math program FAQs',
+    subtitle: 'Common questions about our 3-month math programs',
+    items: [
+      {
+        question: 'Do I have to commit to 3 months upfront?',
+        answer:
+          "Yes. The 3-month minimum is what makes these programs work — it's enough time to run a diagnostic, close the primary gap, and verify the fix held. One-off sessions don't produce the same outcome.",
+      },
+      {
+        question: 'Can my child join mid-year?',
+        answer:
+          'Yes. Programs start monthly. The diagnostic at program start sets the right entry point regardless of where the school year is.',
+      },
+      {
+        question:
+          'What if my child is between grade levels — for example, doing 7th grade math in 6th grade?',
+        answer:
+          'Placement is based on the diagnostic, not grade level. A 6th grader doing accelerated 7th grade math would be placed in the middle school accelerated track at the correct entry point.',
+      },
+      {
+        question: "What's the difference between a 3-month program and regular tutoring?",
+        answer:
+          "Regular tutoring is reactive — homework help, test prep session by session. A 3-month program has a defined curriculum scope, a diagnostic at the start, and a clear outcome by the end. You know what's covered before you pay.",
+      },
+      {
+        question: 'Is this in-person or online?',
+        answer:
+          'Both. Live online sessions are available nationwide. In-person sessions run at 4564 Dublin Blvd, Dublin, CA. Same curriculum, same group size, same instruction quality.',
+      },
+      {
+        question: 'How do I know which grade band is right?',
+        answer:
+          'Use the free Self-Check or book a free 45-minute assessment. The assessment takes about 45 minutes and gives you a clear answer before you commit to anything.',
+      },
+    ] as const,
+  },
+  cta: {
+    heading: 'Not sure where to start?',
+    body: 'A free 45-minute assessment identifies the real gap, places your child in the right program, and gives you a concrete plan — before you pay anything.',
+    primary: { label: 'Book free assessment', href: '/book-assessment' },
+    secondary: { label: 'Try the free Self-Check', href: '/self-check' },
+    phoneLabel: 'Call (925) 456-4606',
+  },
+} as const;
+
+export type MathGradeBandStubCopy = {
+  readonly id: MathGradeBandId;
+  readonly path: string;
+  readonly breadcrumbLabel: string;
+  readonly h1: string;
+  readonly intro: string;
+  readonly body: string;
+  readonly coursesIncluded: readonly string[];
+  readonly packageLine: string;
+  readonly schemaCourseName: string;
+  readonly schemaDescription: string;
+};
+
+export const MATH_GRADE_BAND_STUBS: Record<MathGradeBandId, MathGradeBandStubCopy> = {
+  elementary: {
+    id: 'elementary',
+    path: '/courses/math/elementary',
+    breadcrumbLabel: 'Elementary Math',
+    h1: 'Elementary math programs — Grades 1–5',
+    intro:
+      'Number sense, fractions, and reasoning — before the gaps compound.',
+    body: 'Most elementary math struggles trace back to one unaddressed concept from 6–12 months ago. We find it before it becomes a pattern. Live online small groups with a defined 3-month curriculum.',
+    coursesIncluded: MATH_HUB_COPY.gradeBands.cards[0].coursesIncluded,
+    packageLine: 'From $169/month · 75 min, once a week · 3-month program',
+    schemaCourseName: 'Elementary Math Program — Grades 1–5',
+    schemaDescription:
+      '3-month structured math program for Grades 1–5. Covers number sense, fractions, operations, and word problem reasoning. Live online small groups.',
+  },
+  'middle-school': {
+    id: 'middle-school',
+    path: '/courses/math/middle-school',
+    breadcrumbLabel: 'Middle School Math',
+    h1: 'Middle school math programs — Grades 6–8',
+    intro: 'Pre-Algebra, IM1, IM2 — including accelerated curriculum tracks.',
+    body: 'The jump into Integrated Math catches many students off guard. We close the gaps before they compound across the year. Programs align with Common Core and local IM sequences.',
+    coursesIncluded: MATH_HUB_COPY.gradeBands.cards[1].coursesIncluded,
+    packageLine: 'From $179/month · 75 min, once a week · 3-month program',
+    schemaCourseName: 'Middle School Math Program — Grades 6–8',
+    schemaDescription:
+      '3-month structured math program for Grades 6–8. Covers Pre-Algebra, Integrated Math 1, and Integrated Math 2. Live online small groups.',
+  },
+  'high-school': {
+    id: 'high-school',
+    path: '/courses/math/high-school',
+    breadcrumbLabel: 'High School Math',
+    h1: 'High school math programs — Grades 9–12',
+    intro: 'Algebra 2 through AP Calculus — course-specific, not general review.',
+    body: 'High school math moves at pace. Our programs are built around the course your child is actually in — not a broad review of everything.',
+    coursesIncluded: MATH_HUB_COPY.gradeBands.cards[2].coursesIncluded,
+    packageLine: 'From $189/month · 75 min, once a week · 3-month program',
+    schemaCourseName: 'High School Math Program — Grades 9–12',
+    schemaDescription:
+      '3-month structured math program for Grades 9–12. Covers Algebra 2, Pre-Calculus, AP Calculus AB/BC, AP Statistics, and SAT Math. Live online small groups.',
+  },
+};
+
+export const MATH_HUB_METADATA = {
+  '/courses/math': {
+    title: 'Math Tutoring Programs Online — Grades 1–12 | GrowWise',
+    description:
+      'Structured math programs for Grades 1–12. Live online small groups. Elementary, middle school, and high school tracks. 3-month curriculum packages. Book a free assessment.',
+    keywords:
+      'math tutoring online, online math program grades 1-12, elementary math tutoring, middle school math help, IM1 tutoring, high school math tutoring, AP calculus tutoring online, math small group online, 3-month math program, math tutoring small group',
+  },
+  '/courses/math/elementary': {
+    title: 'Elementary Math Tutoring Online — Grades 1–5 | GrowWise',
+    description:
+      '3-month elementary math program for Grades 1–5. Number sense, fractions, operations, and word problems. Live online small groups. Book a free assessment.',
+    keywords:
+      'elementary math tutoring online, grades 1-5 math program, number sense tutoring, fractions tutoring online',
+  },
+  '/courses/math/middle-school': {
+    title: 'Middle School Math Tutoring — Grades 6–8 | GrowWise',
+    description:
+      'Middle school math programs for Grades 6–8. Pre-Algebra, Integrated Math 1 & 2. Live online small groups. 3-month curriculum. Book a free assessment.',
+    keywords:
+      'middle school math tutoring, IM1 tutoring, IM2 tutoring, pre-algebra tutoring online, grades 6-8 math program',
+  },
+  '/courses/math/high-school': {
+    title: 'High School Math Tutoring Online — Grades 9–12 | GrowWise',
+    description:
+      'High school math programs: Algebra 2, Pre-Calculus, AP Calculus, AP Statistics, SAT Math. Course-specific 3-month programs. Book a free assessment.',
+    keywords:
+      'high school math tutoring online, AP calculus tutoring, algebra 2 tutoring, SAT math prep online, grades 9-12 math program',
+  },
+} as const;

--- a/src/lib/schema/elementary-math-faqs.ts
+++ b/src/lib/schema/elementary-math-faqs.ts
@@ -33,6 +33,16 @@ export const ELEMENTARY_MATH_VISIBLE_FAQS: FAQItem[] = [
       'You receive a progress report at the end of each month showing which concepts were covered, which mistake patterns were corrected, and what the next month will focus on. The diagnostic at program start gives you a baseline to compare against.',
   },
   {
+    question: 'What are the Beginner, Champ, and Pro levels?',
+    answer:
+      'They are the three curriculum levels within GrowWise Elementary Math. Beginner is for students who are below grade level and catching up. Champ is for students at grade level building consistency. Pro is for students already ahead who want to accelerate further. The free 45-minute assessment determines which level your child starts at — parents do not choose.',
+  },
+  {
+    question: 'How does a student move from one level to the next?',
+    answer:
+      'Every 3 months, students take a GrowWise Mastery Assessment. Students who score 90% or above advance to the next level. Students who score below 90% continue at their current level and keep building. There is no penalty for staying — the 90% threshold ensures students are genuinely ready before moving forward, not just ready on paper.',
+  },
+  {
     question: 'What is the paid trial session?',
     answer:
       'A single 60-minute instructional session where your child works with a GrowWise instructor on real grade-level problems. At the end we give you a debrief on what we found and which program fits. The $45 session fee is fully waived if you enroll within 7 days.',

--- a/src/lib/schema/elementary-math-faqs.ts
+++ b/src/lib/schema/elementary-math-faqs.ts
@@ -32,4 +32,14 @@ export const ELEMENTARY_MATH_VISIBLE_FAQS: FAQItem[] = [
     answer:
       'You receive a progress report at the end of each month showing which concepts were covered, which mistake patterns were corrected, and what the next month will focus on. The diagnostic at program start gives you a baseline to compare against.',
   },
+  {
+    question: 'What is the paid trial session?',
+    answer:
+      'A single 60-minute instructional session where your child works with a GrowWise instructor on real grade-level problems. At the end we give you a debrief on what we found and which program fits. The $45 session fee is fully waived if you enroll within 7 days.',
+  },
+  {
+    question: 'Is there a registration fee?',
+    answer:
+      'No registration fee through July 2026. After that a one-time registration fee applies. Enroll before July 2026 to lock in fee-free enrollment.',
+  },
 ]

--- a/src/lib/schema/elementary-math-faqs.ts
+++ b/src/lib/schema/elementary-math-faqs.ts
@@ -1,0 +1,35 @@
+import type { FAQItem } from '@/components/schema/FAQSchema'
+
+/** Visible accordion FAQs on /courses/math/elementary — single source for UI + JSON-LD in layout */
+export const ELEMENTARY_MATH_VISIBLE_FAQS: FAQItem[] = [
+  {
+    question: 'What grades does the elementary math program cover?',
+    answer:
+      'Grades 1–5. Students are grouped by skill level from the diagnostic assessment, not strictly by grade level. A Grade 3 student working at a Grade 2 level in fractions would start at the Grade 2 fraction entry point.',
+  },
+  {
+    question: 'My child is in Grade 4 but really struggling — is it too late to fix?',
+    answer:
+      'No. The gaps that appear in Grade 4 and 5 are almost always fixable in 4–8 weeks of targeted instruction once the root concept is identified. The diagnostic finds it; the program closes it.',
+  },
+  {
+    question: 'How do you group students if they are from different grades?',
+    answer:
+      'Grouping is by skill profile from the diagnostic. A Grade 3 and a Grade 4 student with the same gap in fraction fundamentals would be placed together. Grade level alone is not the grouping criterion.',
+  },
+  {
+    question: "What if my child's school uses a different curriculum than Common Core?",
+    answer:
+      'We align to the underlying mathematical concepts, which are consistent across most K–5 curricula. The diagnostic tells us where your child\'s specific gaps are — not just what their school has or hasn\'t covered.',
+  },
+  {
+    question: 'Will my child fall behind in school while doing this program?',
+    answer:
+      'No. The program runs alongside school. Students attend their regular class. The GrowWise sessions target the gaps that are making school harder — they do not replace school instruction.',
+  },
+  {
+    question: 'How do I know if the program is working?',
+    answer:
+      'You receive a progress report at the end of each month showing which concepts were covered, which mistake patterns were corrected, and what the next month will focus on. The diagnostic at program start gives you a baseline to compare against.',
+  },
+]

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -83,12 +83,39 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/courses/math': {
-    title: 'K-12 Math Tutoring in Dublin, CA | GrowWise',
+    title: 'Math Tutoring Programs Online — Grades 1–12 | GrowWise',
     description:
-      'Expert math tutoring for Grades 1-12 in Dublin, CA. Elementary to AP-level. DUSD-aligned, small groups, personalized plans. Book your free assessment.',
+      'Structured math programs for Grades 1–12. Live online small groups. Elementary, middle school, and high school tracks. Book a free assessment.',
     keywords:
-      'math tutoring Dublin CA, math tutor Dublin, Grades 1-12 math courses, grade-level math, accelerated math, integrated math, DUSD math, PUSD math, algebra tutoring, geometry tutoring, pre-calculus, elementary math, middle school math, high school math, math classes Dublin CA, math enrichment Dublin CA, DUSD accelerated math, math help Dublin, math tutoring near me',
+      'math tutoring online, online math program grades 1-12, elementary math tutoring, middle school math help, IM1 tutoring, high school math tutoring, AP calculus tutoring online, math small group online, 3-month math program, math tutoring small group',
     path: '/courses/math',
+  },
+
+  '/courses/math/elementary': {
+    title: 'Elementary Math Tutoring Online — Grades 1–5 | GrowWise',
+    description:
+      'Structured math programs for Grades 1–5. Number sense, fractions, word problem reasoning. Live online small groups. Diagnostic-first. 3-month programs.',
+    keywords:
+      'elementary math tutoring online, grade 1-5 math help, fractions tutoring grade 4, math word problem help elementary, grade 3 math struggles, place value tutoring, elementary math small group online, math program grades 1 5',
+    path: '/courses/math/elementary',
+  },
+
+  '/courses/math/middle-school': {
+    title: 'Middle School Math Tutoring — Grades 6–8 | GrowWise',
+    description:
+      'Middle school math programs for Grades 6–8. Pre-Algebra, Integrated Math 1 & 2. Live online small groups. 3-month curriculum. Book a free assessment.',
+    keywords:
+      'middle school math tutoring, IM1 tutoring, IM2 tutoring, pre-algebra tutoring online, grades 6-8 math program',
+    path: '/courses/math/middle-school',
+  },
+
+  '/courses/math/high-school': {
+    title: 'High School Math Tutoring Online — Grades 9–12 | GrowWise',
+    description:
+      'High school math programs: Algebra 2, Pre-Calculus, AP Calculus, AP Statistics, SAT Math. Course-specific 3-month programs. Book a free assessment.',
+    keywords:
+      'high school math tutoring online, AP calculus tutoring, algebra 2 tutoring, SAT math prep online, grades 9-12 math program',
+    path: '/courses/math/high-school',
   },
 
   '/courses/english': {


### PR DESCRIPTION
## Summary

Replaces the minimal stub at `/courses/math/elementary` with the full spec-driven page for the GrowWise elementary math program.

## What's changed

### New files
- `src/app/[locale]/courses/math/elementary/layout.tsx` — server component: `generateMetadata`, Course JSON-LD, BreadcrumbList JSON-LD, FAQPage JSON-LD via `FAQSchema`
- `src/app/[locale]/courses/math/elementary/page.tsx` — thin `'use client'` wrapper → `<ElementaryMathPage />`
- `src/components/ElementaryMathPage.tsx` — full 10-section page component
- `src/lib/schema/elementary-math-faqs.ts` — `ELEMENTARY_MATH_VISIBLE_FAQS` (6 FAQs, single source for accordion UI + JSON-LD)

### Modified
- `src/lib/seo/metadataConfig.ts` — updated `/courses/math/elementary` entry with spec-exact title, description, keywords

## Page sections

1. Hero — H1, subheading, trust chips, dual CTA (FreeAssessmentModal + Self-Check)
2. Compounding gap explainer
3. Signs by grade (Grade 1–2, 3–4, 5 cards)
4. 5 JTBD situations with contextual CTAs (assessment modal / self-check / summer / advisor)
5. Curriculum scope (3-column by grade band)
6. Program details + pricing card
7. "What this is not" (dark section)
8. Dublin / Tri-Valley geo callout
9. Middle-school transition link
10. FAQ accordion (`CourseFAQ`, `includeStructuredData={false}`)
11. Final CTA block (modal + Self-Check + phone)

## SEO
- 3 server-rendered JSON-LD scripts: Course, BreadcrumbList, FAQPage
- Metadata from centralized `metadataConfig`
- Canonical: `/courses/math/elementary`

## Testing
- No TypeScript errors in new files (`tsc --noEmit --skipLibCheck`)
- Navigate to `/en/courses/math/elementary` and verify all 10 sections render
- "Book free assessment" opens `FreeAssessmentModal`
- FAQ accordion expands/collapses
- View source — confirm 3 `<script type="application/ld+json">` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)