### PR TITLE
feat(math-hub): FAQ deploy canary for production verification

### DIFF
--- a/src/lib/math-hub-copy.ts
+++ b/src/lib/math-hub-copy.ts
@@ -348,6 +348,11 @@ export const MATH_HUB_COPY = {
         answer:
           'Use the free Self-Check or book a free 45-minute assessment. The assessment takes about 45 minutes and gives you a clear answer before you commit to anything.',
       },
+      {
+        question: 'Where did the old /courses/math pages go?',
+        answer:
+          'Math programs now live at /academic/math. Choose a grade band: /academic/math/elementary, /academic/math/middle-school, or /academic/math/high-school. Older /courses/math links redirect here automatically.',
+      },
     ] as const,
   },
   cta: {

--- a/src/lib/schema/__tests__/math-hub-jsonld.test.ts
+++ b/src/lib/schema/__tests__/math-hub-jsonld.test.ts
@@ -23,10 +23,10 @@ describe('math-hub-jsonld', () => {
       expect(urls).toContain(`${BASE_URL}/academic/math/high-school`);
     });
 
-    it('FAQPage has 6 questions', () => {
+    it('FAQPage has 7 questions', () => {
       const faq = nodes.find((n) => n['@type'] === 'FAQPage') as Record<string, unknown>;
       const mainEntity = faq.mainEntity as unknown[];
-      expect(mainEntity).toHaveLength(6);
+      expect(mainEntity).toHaveLength(7);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a 7th math hub FAQ explaining the move from `/courses/math` to `/academic/math` and grade-band URLs
- Update JSON-LD test to expect 7 FAQ items

## Why
Small visible change to confirm Vercel production deploys latest code after Git reconnect to `growwise360/growwise_newui`.

## Test plan
- [x] `npm test -- --testPathPatterns=math-hub-jsonld`
- [ ] PR Gate passes
- [ ] After merge: verify https://growwiseschool.org/academic/math shows new FAQ
- [ ] Verify header.json shows Math / English Courses (not legacy Courses menu)

Made with [Cursor](https://cursor.com)