### PR TITLE
fix(high-school-math): remove Dublin from hero H1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ npm install
 cp .env.example .env.local   # then edit with your values
 npm run dev                  # http://localhost:3000
 ```
-
 Important env vars (examples):
 - `NEXT_PUBLIC_BACKEND_URL=https://<your-backend-domain>`
 - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...`

--- a/src/components/HighSchoolMathPage.tsx
+++ b/src/components/HighSchoolMathPage.tsx
@@ -340,9 +340,6 @@ const HighSchoolMathPage: React.FC = () => {
           <div className="text-center mb-16">
             <h1 className="text-4xl lg:text-6xl font-bold text-gray-800 mb-6 leading-tight">
               High School Math Tutoring
-              <span className="block bg-gradient-to-r from-[#1F396D] to-[#F16112] bg-clip-text text-transparent">
-                in Dublin, CA
-              </span>
             </h1>
             <div className="inline-flex items-center gap-3 bg-white/30 backdrop-blur-sm rounded-full px-6 py-3 mb-6 border border-gray-200/50">
               <GraduationCap className="w-5 h-5 text-[#F1894F]" />


### PR DESCRIPTION
## Summary
- Remove the gradient "in Dublin, CA" line from the H1 on `/academic/math/high-school`
- Hero title is now **High School Math Tutoring** only

## Test plan
- [ ] PR Gate passes
- [ ] After merge: https://growwiseschool.org/academic/math/high-school shows single-line H1 without "in Dublin, CA"

Made with [Cursor](https://cursor.com)