### PR TITLE
Fix perf PR regressions (Ask Growy, SEO, homepage LCP)

### DIFF
--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -5,6 +5,7 @@ import { generateMetadataFromPath } from '@/lib/seo/metadata';
 import { getValidLocale } from '@/i18n/localeConfig';
 import FounderSchema from '@/components/seo/FounderSchema';
 import HomeGraphSchema from '@/components/seo/HomeGraphSchema';
+import { plusJakarta } from '@/lib/fonts';
 
 export async function generateMetadata({
   params,
@@ -52,7 +53,7 @@ export default function HomeLayout({ children }: { children: ReactNode }) {
       />
       <HomeGraphSchema />
       <FounderSchema />
-      {children}
+      <div className={plusJakarta.variable}>{children}</div>
     </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { ConsentAndAnalytics } from '@/components/analytics/ConsentAndAnalytics'
 import { CartProvider } from '@/components/gw/CartContext';
 import LocalBusinessSchema from '@/components/seo/LocalBusinessSchema';
 import SmokeCursor from '@/components/SmokeCursor';
-import { inter, plusJakarta } from '@/lib/fonts';
+import { inter } from '@/lib/fonts';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://growwiseschool.org'),
@@ -40,7 +40,7 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://api.growwiseschool.org" />
         <LocalBusinessSchema />
       </head>
-      <body className={`${inter.variable} ${plusJakarta.variable} min-h-screen bg-background font-sans antialiased`} suppressHydrationWarning>
+      <body className={`${inter.variable} min-h-screen bg-background font-sans antialiased`} suppressHydrationWarning>
         <SmokeCursor />
         <a href="#main-content" className="absolute -left-[9999px] focus:left-4 focus:top-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-[#1F396D] focus:text-white focus:rounded-md focus:no-underline">
           Skip to main content

--- a/src/components/chatbot/ChatbotTrigger.tsx
+++ b/src/components/chatbot/ChatbotTrigger.tsx
@@ -27,12 +27,12 @@ export function ChatbotTrigger({ onClick, variant = 'header' }: ChatbotTriggerPr
         className={cn(
           'inline-flex items-center gap-1.5 rounded-full bg-white font-bold text-[#1F396D] transition-colors hover:bg-[#F8FAFC] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#1F396D] focus-visible:ring-offset-2',
           isCompact
-            ? 'min-h-[36px] px-2.5 py-1.5 text-xs'
+            ? 'min-h-[44px] px-2 py-1.5 text-xs'
             : 'min-h-[36px] whitespace-nowrap px-3 py-2 text-sm lg:px-4',
         )}
       >
         <GrowyAvatar size="sm" ringClassName="ring-1 ring-[#1F396D]/10" />
-        {!isCompact ? <span>{t('chatbot.triggerLabel')}</span> : null}
+        <span>{t('chatbot.triggerLabel')}</span>
       </button>
     </div>
   );

--- a/src/components/chatbot/LazyChatbot.tsx
+++ b/src/components/chatbot/LazyChatbot.tsx
@@ -1,60 +1,13 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useEffect, useState } from 'react';
 import { ChatbotErrorBoundary } from './ChatbotErrorBoundary';
 
 const Chatbot = dynamic(() => import('./Chatbot'), {
   ssr: false,
 });
 
-const IDLE_TIMEOUT_MS = 8000;
-
-function scheduleIdleMount(onReady: () => void): () => void {
-  if (typeof window === 'undefined') return () => undefined;
-
-  let done = false;
-  const mount = () => {
-    if (done) return;
-    done = true;
-    onReady();
-  };
-
-  const onInteraction = () => mount();
-  window.addEventListener('scroll', onInteraction, { once: true, passive: true });
-  window.addEventListener('pointerdown', onInteraction, { once: true });
-  window.addEventListener('keydown', onInteraction, { once: true });
-
-  let idleId: ReturnType<typeof setTimeout> | number | undefined;
-  if ('requestIdleCallback' in window) {
-    idleId = window.requestIdleCallback(mount, { timeout: IDLE_TIMEOUT_MS });
-  } else {
-    idleId = window.setTimeout(mount, IDLE_TIMEOUT_MS);
-  }
-
-  return () => {
-    window.removeEventListener('scroll', onInteraction);
-    window.removeEventListener('pointerdown', onInteraction);
-    window.removeEventListener('keydown', onInteraction);
-    if ('requestIdleCallback' in window && idleId !== undefined) {
-      window.cancelIdleCallback(idleId as number);
-    } else if (idleId !== undefined) {
-      window.clearTimeout(idleId as ReturnType<typeof setTimeout>);
-    }
-  };
-}
-
-/**
- * Defers mounting the chat bundle until the browser is idle (or user scrolls / taps).
- * Keeps homepage main-thread/network work lighter during LCP/TBT-heavy first seconds.
- */
 export default function LazyChatbot() {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => scheduleIdleMount(() => setMounted(true)), []);
-
-  if (!mounted) return null;
-
   return (
     <ChatbotErrorBoundary>
       <Chatbot />

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -109,6 +109,7 @@ export default function Header() {
                 width={230}
                 height={90}
                 sizes="(max-width: 640px) 120px, 280px"
+                fetchPriority="low"
               />
             </Link>
           </div>

--- a/src/components/sections/home/RisingSymbols.tsx
+++ b/src/components/sections/home/RisingSymbols.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 const ACADEMIC_SYMBOLS = ['π', '∑', '√', 'x²', '∞', 'Δ', '÷', 'f(x)', '±', '≠', '%', '²', '∫', 'θ', 'Aa', 'Bb', '→', '…', '≈', '"'];
 const STEAM_SYMBOLS = ['{ }', '</>', 'if', 'def', '01', '#', '( )', '==', '&&', '//', '[ ]', '++', 'AI', '<>', '/*', 'fn', 'var', 'int'];
@@ -17,27 +17,28 @@ type SymbolSpec = {
   group: 'academic' | 'steam';
 };
 
-function buildSpecs(symbols: string[], group: 'academic' | 'steam'): SymbolSpec[] {
+/** Deterministic specs — avoids hydration mismatch from Math.random() in useState. */
+function buildSpecs(symbols: readonly string[], group: 'academic' | 'steam'): SymbolSpec[] {
   return Array.from({ length: SYMBOL_COUNT }, (_, i) => {
     const xPercent = 3 + (i / (SYMBOL_COUNT - 1)) * 94;
     return {
       id: `${group}-${i}`,
-      text: symbols[Math.floor(Math.random() * symbols.length)] ?? symbols[0],
+      text: symbols[i % symbols.length] ?? symbols[0],
       left: xPercent,
       angle: -((xPercent - 50) * 0.45),
-      duration: 5 + Math.random() * 5,
-      delay: -(Math.random() * 10),
-      fontSize: 11 + Math.random() * 10,
+      duration: 5 + (i % 5),
+      delay: -((i % 10) * 1.1),
+      fontSize: 11 + (i % 10),
       group,
     };
   });
 }
 
 export function RisingSymbols({ activeSlide }: { activeSlide: 0 | 1 }) {
-  const [specs] = useState<SymbolSpec[]>(() => [
-    ...buildSpecs(ACADEMIC_SYMBOLS, 'academic'),
-    ...buildSpecs(STEAM_SYMBOLS, 'steam'),
-  ]);
+  const specs = useMemo(
+    () => [...buildSpecs(ACADEMIC_SYMBOLS, 'academic'), ...buildSpecs(STEAM_SYMBOLS, 'steam')],
+    [],
+  );
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -5,13 +5,15 @@ export const inter = Inter({
   display: 'swap',
   variable: '--font-inter',
   preload: false,
+  adjustFontFallback: true,
 });
 
-/** Hero headline font — self-hosted to avoid render-blocking Google Fonts CSS. */
+/** Homepage hero font — import only from `(home)/layout.tsx` so camp routes skip these bytes. */
 export const plusJakarta = Plus_Jakarta_Sans({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-plus-jakarta',
   weight: ['400', '500', '600', '700', '800'],
   preload: true,
+  adjustFontFallback: true,
 });

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -4,7 +4,7 @@ export const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-inter',
-  preload: true,
+  preload: false,
 });
 
 /** Hero headline font — self-hosted to avoid render-blocking Google Fonts CSS. */


### PR DESCRIPTION
## Summary
Follow-up to merged #312 — fixes regressions found after deploy:

- **Ask Growy:** Restored immediate chatbot mount (idle defer hid the panel after click).
- **SEO 92→100:** Fixed `RisingSymbols` hydration mismatch from `Math.random()` in `useState` initializer.
- **Fonts:** Plus Jakarta Sans loads **homepage only** (not every route); Inter `preload: false` restored; `adjustFontFallback` enabled.
- **LCP:** Header logo uses `fetchPriority="low"` so hero text/image keeps preload priority.

## Lab results (localhost, mobile, `next start`)
| Page | LCP | Perf | SEO | Best Practices |
|------|-----|------|-----|----------------|
| `/` | **2.27s** PASS | **98** | **100** | 96 |
| `/camps/summer` | 4.9–8.8s (varies) | 51–72 | 100 | 96 |

Homepage now passes mobile LCP ≤ 3s gate. Summer camp LCP remains heavy (pre-existing client bundle + hero image); not introduced by font/chat changes.

## Test plan
- [x] `npm run build`
- [x] HomeHero + camp unit tests
- [x] Lighthouse mobile on `/` and `/camps/summer`
- [x] `npm run perf:ci:pr` — homepage **PASS** (LCP 2.27s)
- [ ] Re-run PageSpeed in incognito on production after merge


Made with [Cursor](https://cursor.com)