### PR TITLE
feat(bulletin): weekly parent newsletter + summer resources hub updates

### DIFF
--- a/env.local.example
+++ b/env.local.example
@@ -109,6 +109,7 @@ META_CAPI_ACCESS_TOKEN=
 # BREVO_SENDER_NAME=GrowWise
 # BREVO_LIST_LOTTERY=   # numeric list id (summer camp guide leads + Meta leads). List id 11 is never attached in code (see BREVO_LIST_IDS_EXCLUDED_FROM_AUTOMATION in src/lib/brevo.ts).
 # BREVO_LIST_MATH_FINALS=15   # Brevo list for /api/math-finals-practice leads (automations; attributes: see upsertMathFinalsLeadInBrevo in src/lib/brevo.ts)
+# BREVO_LIST_BULLETIN=25   # GrowWise Bulletin newsletter (/bulletin). Sends welcome email + adds contact to list 25.
 # Summer camp guide email (/api/summer-camp-summercamp; legacy /api/summer-camp-lottery rewrites here): tries Brevo first; if Brevo returns an error, falls back to SMTP_* below.
 # If both fail, the API returns 503 (no fake success). See server logs for [summer-camp-guide] and [brevo].
 # Create Text contact attributes for Meta sync: CAMP_INTEREST, GRADE, FIRSTNAME, LASTNAME, PHONE, SOURCE, etc.

--- a/public/api/mock/en/footer.json
+++ b/public/api/mock/en/footer.json
@@ -41,6 +41,7 @@
         { "label": "How to Prevent Summer Slide", "href": "/resources/summer-slide-prevention", "active": true },
         { "label": "Why Khan Academy Summer Plans Fail", "href": "/resources/khan-academy-summer-doesnt-work", "active": true },
         { "label": "Summer Academic Program Checklist", "href": "/resources/summer-academic-program-checklist", "active": true },
+        { "label": "Affordable Summer Programs Dublin", "href": "/resources/affordable-summer-academic-programs-dublin-ca", "active": true },
         { "label": "IM1 Summer Prep (Dublin)", "href": "/resources/im1-summer-prep-dublin-ca", "active": true },
         { "label": "Summer Writing Programs Dublin", "href": "/resources/summer-writing-program-dublin-ca", "active": true },
         { "label": "View all guides →", "href": "/resources", "active": true, "highlight": true }
@@ -52,6 +53,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "About GrowWise", "href": "/about", "active": true },
+        { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Trusted by Dublin Neighbors", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },
         { "label": "Contact", "href": "/contact", "active": true },

--- a/public/api/mock/es/footer.json
+++ b/public/api/mock/es/footer.json
@@ -43,6 +43,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "Acerca de GrowWise", "href": "/about", "active": true },
+        { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Recomendado en Nextdoor", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },
         { "label": "Contacto", "href": "/contact", "active": true },

--- a/public/api/mock/hi/footer.json
+++ b/public/api/mock/hi/footer.json
@@ -43,6 +43,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "About GrowWise", "href": "/about", "active": true },
+        { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Trusted by Dublin Neighbors", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },
         { "label": "संपर्क", "href": "/contact", "active": true },

--- a/public/api/mock/zh/footer.json
+++ b/public/api/mock/zh/footer.json
@@ -43,6 +43,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "关于 GrowWise", "href": "/about", "active": true },
+        { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Dublin 邻里推荐", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },
         { "label": "联系我们", "href": "/contact", "active": true },

--- a/src/app/[locale]/bulletin/layout.tsx
+++ b/src/app/[locale]/bulletin/layout.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { BULLETIN_DESCRIPTION, BULLETIN_PATH } from '@/data/bulletin-copy';
+import FounderSchema from '@/components/seo/FounderSchema';
+import { generateMetadataFromPath } from '@/lib/seo/metadata';
+import { buildBulletinPageGraphSchema } from '@/lib/schema/bulletin-jsonld';
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const metadata = generateMetadataFromPath(BULLETIN_PATH, locale);
+  return (
+    metadata ?? {
+      title: "How to Support Your K–12 Child's Learning | GrowWise Bulletin",
+      description: BULLETIN_DESCRIPTION,
+    }
+  );
+}
+
+export default async function BulletinLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const baseUrl = getCanonicalSiteUrl();
+  const graphSchema = buildBulletinPageGraphSchema(baseUrl, locale);
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(graphSchema) }} />
+      <FounderSchema />
+      {children}
+    </>
+  );
+}

--- a/src/app/[locale]/bulletin/page.tsx
+++ b/src/app/[locale]/bulletin/page.tsx
@@ -1,0 +1,5 @@
+import { BulletinLandingPage } from '@/components/marketing/BulletinLandingPage';
+
+export default function BulletinPage() {
+  return <BulletinLandingPage />;
+}

--- a/src/app/[locale]/resources/affordable-summer-academic-programs-dublin-ca/layout.tsx
+++ b/src/app/[locale]/resources/affordable-summer-academic-programs-dublin-ca/layout.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+import {
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH,
+} from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+import { buildAffordableSummerAcademicProgramsDublinCaJsonLd } from '@/lib/schema/affordable-summer-academic-programs-dublin-ca-jsonld'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const metadata = generateMetadataFromPath(AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH, locale)
+  return (
+    metadata ?? {
+      title: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.title,
+      description: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.description,
+    }
+  )
+}
+
+export default async function AffordableSummerAcademicProgramsDublinCaLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+  const jsonLd = buildAffordableSummerAcademicProgramsDublinCaJsonLd(baseUrl, locale)
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd.article) }}
+      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd.faq) }} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd.breadcrumb) }}
+      />
+      {children}
+    </>
+  )
+}

--- a/src/app/[locale]/resources/affordable-summer-academic-programs-dublin-ca/page.tsx
+++ b/src/app/[locale]/resources/affordable-summer-academic-programs-dublin-ca/page.tsx
@@ -1,0 +1,5 @@
+import { AffordableSummerAcademicProgramsDublinCaPage } from '@/components/resources/AffordableSummerAcademicProgramsDublinCaPage'
+
+export default function AffordableSummerAcademicProgramsDublinCaRoute() {
+  return <AffordableSummerAcademicProgramsDublinCaPage />
+}

--- a/src/app/api/bulletin/subscribe/route.ts
+++ b/src/app/api/bulletin/subscribe/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from 'next/server';
+import { FOUNDER_COPY } from '@/data/founder-copy';
+import {
+  addBulletinContactToBrevoList,
+  isBrevoTransactionalReady,
+  sendBrevoTransactionalEmail,
+} from '@/lib/brevo';
+import { buildBulletinWelcomeEmail } from '@/lib/bulletin-welcome-email';
+import { sendEmail, type SendEmailResult } from '@/lib/email';
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const BULLETIN_REPLY_TO = { email: FOUNDER_COPY.email, name: FOUNDER_COPY.name } as const;
+const BREVO_RETRY_DELAY_MS = 450;
+
+export const maxDuration = 60;
+export const runtime = 'nodejs';
+
+async function sendBulletinWelcomeWithFallback(opts: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}): Promise<SendEmailResult> {
+  if (isBrevoTransactionalReady()) {
+    let lastErr: string | undefined;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, BREVO_RETRY_DELAY_MS));
+      }
+      const brevo = await sendBrevoTransactionalEmail({
+        ...opts,
+        replyTo: BULLETIN_REPLY_TO,
+      });
+      if (brevo.success) return brevo;
+      lastErr = brevo.error;
+      console.error(
+        `[bulletin/subscribe] Brevo welcome email attempt ${attempt + 1}/2 failed:`,
+        brevo.error,
+      );
+    }
+    console.error('[bulletin/subscribe] Brevo failed after retry; SMTP fallback.', lastErr);
+  } else {
+    console.warn(
+      '[bulletin/subscribe] Brevo not configured (set BREVO_API_KEY + BREVO_SENDER_EMAIL); using SMTP only if configured.',
+    );
+  }
+
+  return sendEmail({
+    to: opts.to,
+    subject: opts.subject,
+    html: opts.html,
+    text: opts.text,
+    replyTo: BULLETIN_REPLY_TO.email,
+  });
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as { email?: string; recaptchaToken?: string };
+
+    const emailRaw = typeof body.email === 'string' ? body.email.trim() : '';
+    if (!emailRaw || !EMAIL_REGEX.test(emailRaw)) {
+      return NextResponse.json({ success: false, error: 'Please enter a valid email address.' }, { status: 400 });
+    }
+
+    const email = emailRaw.toLowerCase();
+    const siteUrl = getCanonicalSiteUrl();
+    const welcome = buildBulletinWelcomeEmail(siteUrl);
+
+    const welcomeResult = await sendBulletinWelcomeWithFallback({
+      to: email,
+      subject: welcome.subject,
+      html: welcome.html,
+      text: welcome.text,
+    });
+
+    if (!welcomeResult.success) {
+      const brevoReady = isBrevoTransactionalReady();
+      if (!brevoReady && process.env.NODE_ENV === 'development') {
+        console.warn('[bulletin/subscribe] Welcome email not sent in dev (no Brevo/SMTP); continuing.');
+      } else {
+        console.error('[bulletin/subscribe] Welcome email failed:', welcomeResult.error);
+        return NextResponse.json(
+          {
+            success: false,
+            error: `We could not send your welcome email. Please try again or email ${FOUNDER_COPY.email}.`,
+          },
+          { status: 503 },
+        );
+      }
+    }
+
+    const listResult = await addBulletinContactToBrevoList(email);
+
+    if (!listResult.success) {
+      const isConfigMissing =
+        listResult.error === 'BREVO_LIST_BULLETIN not set' || listResult.error === 'Brevo not configured';
+      if (isConfigMissing && process.env.NODE_ENV === 'development') {
+        console.warn('[bulletin/subscribe] Brevo list not configured in dev; welcome email may have sent.');
+        return NextResponse.json({
+          success: true,
+          devMode: true,
+          message: 'Check your inbox for a welcome note from GrowWise.',
+        });
+      }
+      console.warn('[bulletin/subscribe] Brevo list add failed (welcome email may have sent).', listResult.error);
+      return NextResponse.json(
+        { success: false, error: 'Unable to complete your subscription. Please try again later.' },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Check your inbox for a welcome note from GrowWise.',
+    });
+  } catch (err) {
+    console.error('[bulletin/subscribe] Unexpected error:', err);
+    return NextResponse.json(
+      { success: false, error: 'Something went wrong. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/marketing/BulletinLandingPage.tsx
+++ b/src/components/marketing/BulletinLandingPage.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRef } from 'react';
+import { ArrowRight, Mail, Quote } from 'lucide-react';
+import { useLocale } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { BulletinSubscribeForm } from '@/components/marketing/BulletinSubscribeForm';
+import { BULLETIN_COPY } from '@/data/bulletin-copy';
+import { publicPath } from '@/lib/publicPath';
+import { cn } from '@/lib/utils';
+
+const sectionClass = 'mx-auto max-w-5xl px-4 sm:px-6';
+const h2Class = 'font-heading text-2xl font-bold text-[#1F396D] sm:text-3xl';
+
+export function BulletinLandingPage() {
+  const locale = useLocale();
+  const heroFormRef = useRef<HTMLDivElement>(null);
+  const copy = BULLETIN_COPY;
+
+  const scrollToHeroForm = () => {
+    heroFormRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const input = document.getElementById('bulletin-hero-form-email');
+    if (input instanceof HTMLInputElement) {
+      window.setTimeout(() => input.focus(), 400);
+    }
+  };
+
+  return (
+    <main data-bulletin className="min-h-screen bg-background font-sans pb-24 md:pb-0">
+      {/* Hero */}
+      <section
+        className="border-b border-slate-100 bg-gradient-to-b from-slate-50/80 to-white pb-14 pt-10 sm:pb-20 sm:pt-14"
+        aria-labelledby="bulletin-hero-title"
+      >
+        <div className={sectionClass}>
+          <div className="mb-8 flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-amber-200/80 bg-amber-50/60 px-3 py-1.5 text-xs font-semibold text-[#1F396D]">
+              <span className="h-2 w-2 rounded-full bg-[#F16112]" aria-hidden />
+              {copy.eyebrow}
+            </span>
+            <span className="rounded-full border border-[#1F396D]/15 bg-[#1F396D]/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-[#1F396D]">
+              {copy.badge}
+            </span>
+          </div>
+
+          <div className="grid items-center gap-10 lg:grid-cols-[1fr_220px] lg:gap-16">
+            <div className="max-w-xl">
+              <h1
+                id="bulletin-hero-title"
+                className="font-heading text-3xl font-bold leading-tight text-slate-900 sm:text-4xl md:text-[2.75rem] md:leading-[1.12]"
+              >
+                {copy.hero.h1}
+              </h1>
+              <p className="mt-5 text-base leading-relaxed text-slate-700 sm:text-[17px]">{copy.hero.subtext}</p>
+
+              <div ref={heroFormRef} className="mt-8">
+                <BulletinSubscribeForm
+                  formId="bulletin-hero-form"
+                  submitLabel={copy.hero.submitLabel}
+                  successMessage={copy.hero.successMessage}
+                  variant="light"
+                  layout="stacked"
+                />
+              </div>
+
+              <p className="mt-3 flex items-center gap-2 text-xs text-slate-500">
+                <span className="font-bold text-[#1F396D]" aria-hidden>
+                  ✓
+                </span>
+                {copy.hero.formNote}
+              </p>
+
+              <p className="mt-4 text-sm text-slate-700">
+                {copy.hero.contactIntro}{' '}
+                <Link
+                  href={publicPath('/contact', locale)}
+                  className="font-medium text-[#1F396D] underline decoration-[#1F396D]/30 underline-offset-2 hover:decoration-[#1F396D]"
+                >
+                  {copy.hero.contactLinkLabel}
+                </Link>
+              </p>
+            </div>
+
+            <aside className="flex flex-col items-center text-center lg:items-center">
+              <div className="relative h-[220px] w-[180px] overflow-hidden rounded-xl border-2 border-slate-200 bg-slate-50 shadow-sm">
+                <Image
+                  src={copy.founder.image}
+                  alt={copy.founder.imageAlt}
+                  fill
+                  sizes="180px"
+                  className="object-cover object-top"
+                  priority
+                />
+              </div>
+              <p className="mt-3 text-sm font-semibold text-slate-900">{copy.founder.name}</p>
+              <p className="mt-0.5 text-xs leading-relaxed text-slate-500">
+                {copy.founder.role}
+                <br />
+                {copy.founder.established}
+              </p>
+              <span className="mt-2.5 rounded-full bg-[#1F396D] px-2.5 py-1 text-[11px] font-semibold tracking-wide text-white">
+                {copy.founder.tag}
+              </span>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      {/* Schedule */}
+      <section className="py-12 sm:py-16" aria-labelledby="bulletin-schedule-heading">
+        <div className={sectionClass}>
+          <h2 id="bulletin-schedule-heading" className="text-[11px] font-bold uppercase tracking-[0.14em] text-[#1F396D]">
+            {copy.schedule.label}
+          </h2>
+          <ul className="mt-6 grid list-none gap-4 p-0 sm:grid-cols-3" role="list">
+            {copy.schedule.items.map((item) => (
+              <li key={item.day}>
+                <Card className="h-full overflow-hidden border-slate-200 shadow-none">
+                  <div className="h-[3px] bg-[#1F396D]" aria-hidden />
+                  <CardContent className="p-6">
+                    <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">{item.day}</p>
+                    <h3 className="font-heading mt-2 text-lg font-semibold leading-snug text-slate-900">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2.5 text-sm leading-relaxed text-slate-600">{item.description}</p>
+                  </CardContent>
+                </Card>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-5 rounded-lg border border-slate-200 bg-slate-50 px-5 py-3.5 text-center text-sm text-slate-600">
+            <strong className="font-semibold text-slate-700">{copy.schedule.trustLineBold}</strong>{' '}
+            {copy.schedule.trustLineRest}
+          </p>
+        </div>
+      </section>
+
+      {/* Proof band */}
+      <section className="bg-[#1F396D] py-10 sm:py-12" aria-label="GrowWise by the numbers">
+        <div className={cn(sectionClass, 'flex flex-wrap items-center gap-8 lg:gap-10')}>
+          {copy.proof.stats.map((stat, index) => (
+            <div key={stat.label} className="flex items-center gap-8 lg:gap-10">
+              {index > 0 ? (
+                <div className="hidden h-11 w-px bg-white/20 sm:block" aria-hidden />
+              ) : null}
+              <div>
+                <p className="font-heading text-3xl font-bold leading-none text-white">{stat.value}</p>
+                <p className="mt-1 text-xs text-white/70">{stat.label}</p>
+              </div>
+            </div>
+          ))}
+          <div className="hidden h-11 w-px bg-white/20 sm:block" aria-hidden />
+          <blockquote className="min-w-[200px] flex-1">
+            <Quote className="mb-2 h-5 w-5 text-white/40" aria-hidden />
+            <p className="font-heading text-[15px] italic leading-relaxed text-white/90">&ldquo;{copy.proof.quote}&rdquo;</p>
+            <footer className="mt-2 text-[11px] tracking-wide text-white/55">{copy.proof.attribution}</footer>
+          </blockquote>
+        </div>
+      </section>
+
+      {/* Sample issue */}
+      <section className="border-t border-slate-100 py-14 sm:py-16" aria-labelledby="bulletin-sample-heading">
+        <div className={cn(sectionClass, 'grid items-center gap-10 lg:grid-cols-2 lg:gap-14')}>
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-[#1F396D]">{copy.sample.label}</p>
+            <h2 id="bulletin-sample-heading" className={cn(h2Class, 'mt-3')}>
+              {copy.sample.heading}
+            </h2>
+            {copy.sample.paragraphs.map((paragraph) => (
+              <p key={paragraph.slice(0, 24)} className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-[15px]">
+                {paragraph}
+              </p>
+            ))}
+          </div>
+          <Card className="overflow-hidden border-slate-200 shadow-md shadow-slate-200/40">
+            <div className="flex items-center gap-2 border-b border-amber-100 bg-amber-50/80 px-4 py-3">
+              <span className="h-2 w-2 rounded-full bg-[#F16112] ring-1 ring-amber-400/60" aria-hidden />
+              <span className="text-[11px] font-bold uppercase tracking-wider text-amber-900/80">
+                {copy.sample.cardTag}
+              </span>
+            </div>
+            <CardContent className="p-6">
+              <h3 className="font-heading text-lg font-semibold leading-snug text-slate-900">{copy.sample.cardTitle}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-slate-600">{copy.sample.cardExcerpt}</p>
+              <Link
+                href={publicPath(copy.sample.cardHref, locale)}
+                className="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-[#1F396D] hover:text-[#F16112]"
+              >
+                {copy.sample.cardLinkLabel}
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+              {copy.sample.relatedGuides.length > 0 ? (
+                <ul className="mt-6 space-y-2 border-t border-slate-100 pt-5">
+                  {copy.sample.relatedGuides.map((guide) => (
+                    <li key={guide.href}>
+                      <Link
+                        href={publicPath(guide.href, locale)}
+                        className="text-sm font-medium text-[#1F396D] underline decoration-[#1F396D]/25 underline-offset-2 hover:text-[#F16112] hover:decoration-[#F16112]"
+                      >
+                        {guide.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* Featured parent guides */}
+      <section className="border-t border-slate-100 bg-slate-50/60 py-14 sm:py-16" aria-labelledby="bulletin-guides-heading">
+        <div className={sectionClass}>
+          <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-[#1F396D]">{copy.featuredGuides.label}</p>
+          <h2 id="bulletin-guides-heading" className={cn(h2Class, 'mt-3')}>
+            {copy.featuredGuides.heading}
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-600 sm:text-[15px]">
+            {copy.featuredGuides.subtext}
+          </p>
+          <ul className="mt-8 grid list-none gap-4 p-0 sm:grid-cols-3" role="list">
+            {copy.featuredGuides.items.map((guide) => (
+              <li key={guide.href}>
+                <Card className="h-full border-slate-200 shadow-none transition-shadow hover:shadow-md">
+                  <CardContent className="flex h-full flex-col p-5">
+                    <h3 className="font-heading text-base font-semibold leading-snug text-[#1F396D] sm:text-lg">
+                      <Link href={publicPath(guide.href, locale)} className="hover:text-[#F16112] hover:underline">
+                        {guide.title}
+                      </Link>
+                    </h3>
+                    <p className="mt-2 flex-1 text-sm leading-relaxed text-slate-600">{guide.description}</p>
+                    <p className="mt-3 text-xs font-medium text-slate-500">{guide.readTime}</p>
+                    <Link
+                      href={publicPath(guide.href, locale)}
+                      className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-[#F16112] hover:text-[#d54f0a]"
+                    >
+                      Read guide
+                      <ArrowRight className="h-4 w-4" aria-hidden />
+                    </Link>
+                  </CardContent>
+                </Card>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-8 text-center">
+            <Link
+              href={publicPath(copy.featuredGuides.hubHref, locale)}
+              className="inline-flex items-center gap-1 text-sm font-semibold text-[#1F396D] underline decoration-[#1F396D]/30 underline-offset-2 hover:decoration-[#1F396D]"
+            >
+              {copy.featuredGuides.hubLinkLabel}
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <section
+        className="border-t border-[#183056] bg-[#1F396D] py-14 text-white sm:py-16"
+        aria-labelledby="bulletin-bottom-cta-heading"
+      >
+        <div className={cn(sectionClass, 'max-w-xl text-center')}>
+          <h2 id="bulletin-bottom-cta-heading" className="font-heading text-2xl font-bold sm:text-[2rem]">
+            {copy.bottomCta.heading}{' '}
+            <em className="not-italic text-[#F1894F]">{copy.bottomCta.headingEmphasis}</em>
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-white/80 sm:text-[15px]">{copy.bottomCta.subtext}</p>
+          <div className="mt-8">
+            <BulletinSubscribeForm
+              formId="bulletin-bottom-form"
+              submitLabel={copy.bottomCta.submitLabel}
+              successMessage={copy.hero.successMessage}
+              variant="dark"
+              layout="inline"
+              className="text-left"
+            />
+          </div>
+          <p className="mt-4 text-xs text-white/50">{copy.bottomCta.note}</p>
+        </div>
+      </section>
+
+      {/* Mobile sticky */}
+      <div
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 p-3 shadow-lg backdrop-blur sm:hidden"
+        aria-label="Subscribe to bulletin"
+      >
+        <Button
+          type="button"
+          onClick={scrollToHeroForm}
+          className="min-h-[44px] w-full rounded-lg bg-[#F16112] font-semibold text-white hover:bg-[#d54f0a]"
+        >
+          <Mail className="mr-2 h-4 w-4" aria-hidden />
+          {copy.mobileSticky.label}
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/components/marketing/BulletinSubscribeForm.tsx
+++ b/src/components/marketing/BulletinSubscribeForm.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
+import { CheckCircle2, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { BULLETIN_COPY } from '@/data/bulletin-copy';
+import { getRecaptchaToken } from '@/lib/recaptcha';
+import { publicPath } from '@/lib/publicPath';
+import { cn } from '@/lib/utils';
+
+const PM_NO_INJECT = { 'data-lpignore': 'true' } as const;
+
+export interface BulletinSubscribeFormProps {
+  /** Unique id prefix for form fields (hero vs bottom). */
+  formId: string;
+  submitLabel: string;
+  successMessage: string;
+  /** Light (default) or dark (navy bottom CTA band). */
+  variant?: 'light' | 'dark';
+  /** Stack button below input (hero) or inline (bottom CTA). */
+  layout?: 'stacked' | 'inline';
+  className?: string;
+}
+
+export function BulletinSubscribeForm({
+  formId,
+  submitLabel,
+  successMessage,
+  variant = 'light',
+  layout = 'stacked',
+  className,
+}: BulletinSubscribeFormProps) {
+  const locale = useLocale();
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDark = variant === 'dark';
+  const inputId = `${formId}-email`;
+
+  const onSubmit = useCallback(
+    async (ev: React.FormEvent) => {
+      ev.preventDefault();
+      setError(null);
+
+      const trimmed = email.trim();
+      if (!trimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+        setError('Please enter a valid email address.');
+        return;
+      }
+
+      setSubmitting(true);
+      try {
+        const recaptchaToken = await getRecaptchaToken('bulletin_subscribe');
+        const res = await fetch('/api/bulletin/subscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: trimmed,
+            recaptchaToken: recaptchaToken ?? undefined,
+          }),
+        });
+        const data = (await res.json().catch(() => ({}))) as { success?: boolean; error?: string };
+
+        if (!res.ok || !data.success) {
+          setError(data.error || 'Something went wrong. Please try again.');
+          return;
+        }
+
+        setSuccess(true);
+        setEmail('');
+      } catch {
+        setError('Network error. Please try again.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [email],
+  );
+
+  if (success) {
+    return (
+      <div
+        className={cn(
+          'flex items-start gap-3 rounded-lg border p-4 text-sm font-medium',
+          isDark
+            ? 'border-emerald-700/50 bg-emerald-950/40 text-emerald-100'
+            : 'border-emerald-200 bg-emerald-50 text-emerald-900',
+          className,
+        )}
+        role="status"
+        aria-live="polite"
+      >
+        <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" aria-hidden />
+        <span>{successMessage}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <form
+        id={formId}
+        onSubmit={onSubmit}
+        className={cn(
+          layout === 'inline' ? 'flex flex-col gap-3 sm:flex-row sm:items-start' : 'flex flex-col gap-3',
+        )}
+        noValidate
+      >
+        <div className={cn(layout === 'inline' && 'flex-1')}>
+          <label htmlFor={inputId} className="sr-only">
+            Email address
+          </label>
+          <Input
+            id={inputId}
+            type="email"
+            name="email"
+            autoComplete="email"
+            required
+            placeholder={BULLETIN_COPY.form.emailPlaceholder}
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              if (error) setError(null);
+            }}
+            disabled={submitting}
+            className={cn(
+              'min-h-[48px] rounded-lg text-[15px]',
+              isDark
+                ? 'border-slate-600 bg-slate-900/60 text-white placeholder:text-slate-500 focus-visible:border-[#5baa7e] focus-visible:ring-[#5baa7e]/30'
+                : 'border-slate-200 bg-white focus-visible:border-[#1F396D] focus-visible:ring-[#1F396D]/20',
+            )}
+            {...PM_NO_INJECT}
+          />
+        </div>
+        <Button
+          type="submit"
+          disabled={submitting}
+          className={cn(
+            'min-h-[48px] rounded-lg px-6 text-[15px] font-semibold text-white hover:bg-[#d54f0a]',
+            layout === 'inline' && 'shrink-0',
+            'bg-[#F16112]',
+          )}
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+              Subscribing…
+            </>
+          ) : (
+            submitLabel
+          )}
+        </Button>
+      </form>
+
+      {error ? (
+        <p className="mt-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <p
+        className={cn(
+          'mt-3 text-xs leading-relaxed',
+          isDark ? 'text-slate-400' : 'text-slate-500',
+        )}
+      >
+        {BULLETIN_COPY.form.privacyNote}{' '}
+        <Link
+          href={publicPath('/privacy-policy', locale)}
+          className={cn(
+            'underline hover:no-underline',
+            isDark ? 'text-slate-300' : 'text-[#1F396D]',
+          )}
+        >
+          Privacy policy
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/components/resources/AffordableSummerAcademicProgramsDublinCaPage.tsx
+++ b/src/components/resources/AffordableSummerAcademicProgramsDublinCaPage.tsx
@@ -1,0 +1,245 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useLocale } from 'next-intl'
+import { ResourceArticlePage } from '@/components/resources/ResourceArticlePage'
+import {
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_RELATED,
+} from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
+import { publicPath } from '@/lib/publicPath'
+
+const ARTICLE_HERO_IMAGE = '/assets/camps/acabanner.webp'
+
+function ArticleLink({ href, children }: { href: string; children: React.ReactNode }) {
+  const locale = useLocale()
+  return (
+    <Link href={publicPath(href, locale)} className="font-semibold text-[#F16112] underline-offset-2 hover:underline">
+      {children}
+    </Link>
+  )
+}
+
+export function AffordableSummerAcademicProgramsDublinCaPage() {
+  return (
+    <ResourceArticlePage
+      slug="affordable-summer-academic-programs-dublin-ca"
+      category={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.category}
+      categoryLabel={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.categoryLabel}
+      h1={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.h1}
+      readTime={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.readTime}
+      updated={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.updated}
+      faqs={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS}
+      relatedArticles={AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_RELATED}
+      ctaHeading="Review GrowWise academic summer programs"
+      ctaSubtext="See schedules, tracks, and enrollment details for Dublin, CA and Tri-Valley families."
+      ctas={[
+        { href: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.ctaUrl, label: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.ctaText },
+        { href: '/book-assessment', label: 'Book Free Assessment' },
+        { href: '/self-check', label: 'Self-Check' },
+        { href: '/contact', label: 'Contact Us' },
+      ]}
+    >
+      <p>
+        Affordable summer academic programs in Dublin, CA and the Tri-Valley are not always the lowest-priced
+        options — they are programs that deliver clear instructional value for the time and money you invest. The
+        best fit depends on class size, structured outcomes, and whether the program addresses your child&apos;s
+        grade-level needs rather than generic activity time.
+      </p>
+
+      <p>
+        Summer programs in Dublin, Pleasanton, San Ramon, and nearby Tri-Valley communities can vary widely. Some
+        are built mainly for childcare. Some focus on enrichment. Some are academic. Some are project-based. Some
+        are structured. Some are mostly activity time.
+      </p>
+
+      <p>
+        For parents, the question is not only, &quot;What does it cost?&quot; The better question is: &quot;What is
+        my child actually getting from the program?&quot; An affordable summer program should not simply mean the
+        lowest price. It should mean the program gives meaningful value for the time, money, and trust a parent is
+        investing.
+      </p>
+
+      <h2>What Summer Academic Programs Usually Include</h2>
+
+      <p>Academic summer programs may focus on:</p>
+
+      <ul>
+        <li>Math readiness</li>
+        <li>Reading support</li>
+        <li>Writing skills</li>
+        <li>Problem-solving</li>
+        <li>Study habits</li>
+        <li>Grade-level review</li>
+        <li>Advanced enrichment</li>
+        <li>School-year preparation</li>
+      </ul>
+
+      <p>
+        Some programs are full-day. Some are half-day. Some run weekly. Some are built as multi-week academic
+        sprints. The right fit depends on your child&apos;s age, current academic needs, and summer schedule.
+      </p>
+
+      <h2>The False Economy of Cheap Programs</h2>
+
+      <p>
+        A lower-cost program can be a good choice if it is safe, structured, and aligned with your goals. But cheap
+        does not always mean valuable.
+      </p>
+
+      <p>Parents should be cautious when a program has:</p>
+
+      <ul>
+        <li>No clear learning goal</li>
+        <li>Very large groups</li>
+        <li>Generic worksheets</li>
+        <li>No assessment</li>
+        <li>No instructor feedback</li>
+        <li>No explanation of what students will learn</li>
+        <li>No clear connection to grade-level skills</li>
+      </ul>
+
+      <p>
+        If the child spends the week busy but does not build any measurable skill, the program may not be a good
+        value. That does not mean every program needs to be intense. But parents should know what they are paying
+        for. Use our{' '}
+        <ArticleLink href="/resources/summer-academic-program-checklist">
+          summer academic program checklist
+        </ArticleLink>{' '}
+        to compare options before you enroll.
+      </p>
+
+      <h2>What &quot;Affordable&quot; Should Actually Mean</h2>
+
+      <p>A good value program is not always the cheapest one. When comparing summer programs, look at:</p>
+
+      <ul>
+        <li>Cost per session</li>
+        <li>Number of instructional hours</li>
+        <li>Class size</li>
+        <li>Instructor quality</li>
+        <li>Program structure</li>
+        <li>Skill focus</li>
+        <li>Parent communication</li>
+        <li>Whether the program addresses your child&apos;s actual needs</li>
+      </ul>
+
+      <p>
+        For example, a program with a slightly higher weekly cost may still be a better value if it includes
+        structured instruction, smaller groups, and targeted academic support.
+      </p>
+
+      <h2>Childcare vs. Academic Support</h2>
+
+      <p>Some parents need summer coverage. That is valid. But if the goal is academic growth, parents should look for more than supervision.</p>
+
+      <p>Ask:</p>
+
+      <ul>
+        <li>Will my child be assessed?</li>
+        <li>What skills will be taught?</li>
+        <li>How are students grouped?</li>
+        <li>Is the program grade-specific?</li>
+        <li>Will students receive feedback?</li>
+        <li>Is the work aligned to school-year expectations?</li>
+        <li>How will I know if my child improved?</li>
+      </ul>
+
+      <p>
+        These questions help separate academic programs from general activity programs. If summer learning loss is a
+        concern, read our guide on{' '}
+        <ArticleLink href="/resources/summer-slide-dublin-ca">the summer slide in Dublin, CA</ArticleLink>.
+      </p>
+
+      <h2>Why Class Size Matters</h2>
+
+      <p>Class size affects attention. A large group may be fine for general activities, but academic support requires visibility.</p>
+
+      <p>The instructor needs to notice:</p>
+
+      <ul>
+        <li>Where the student hesitates</li>
+        <li>Which mistakes repeat</li>
+        <li>Whether the child understands or is guessing</li>
+        <li>How the child explains their reasoning</li>
+        <li>Whether the work is too easy or too hard</li>
+      </ul>
+
+      <p>Smaller academic groups make this more possible.</p>
+
+      <h2>Why Outcomes Matter More Than Activities</h2>
+
+      <p>A summer academic program should be able to explain its purpose clearly. For example:</p>
+
+      <ul>
+        <li>Is the goal to close math gaps?</li>
+        <li>Improve reading fluency?</li>
+        <li>Strengthen writing structure?</li>
+        <li>Prepare for the next grade?</li>
+        <li>Build problem-solving confidence?</li>
+        <li>Give advanced students more challenge?</li>
+      </ul>
+
+      <p>
+        If the goal is unclear, the outcome will likely be unclear too. Parents should not have to guess what the
+        program is designed to accomplish.
+      </p>
+
+      <h2>GrowWise Academic Summer Programs</h2>
+
+      <div className="relative my-8 aspect-[16/9] overflow-hidden rounded-xl border border-slate-200 bg-slate-50">
+        <Image
+          src={ARTICLE_HERO_IMAGE}
+          alt="Small-group academic summer program for K-12 students in Dublin, CA"
+          fill
+          sizes="(max-width: 768px) 100vw, 672px"
+          className="object-cover"
+        />
+      </div>
+
+      <p>
+        GrowWise offers academic summer programs in Dublin, CA for students who need focused support in math,
+        reading, and writing. Programs are designed to help students use summer time productively through structured
+        learning, small-group instruction, and grade-level readiness.
+      </p>
+
+      <p>
+        Instead of offering random worksheets or generic review, GrowWise programs focus on identifying student
+        needs and helping them build stronger academic foundations. Parents can review current program details,
+        schedules, and enrollment information on the{' '}
+        <ArticleLink href="/camps/academic-summer-programs-dublin-ca">academic summer programs page</ArticleLink>.
+        For year-round support, see our{' '}
+        <ArticleLink href="/resources/tutoring-dublin-ca">Dublin tutoring guide</ArticleLink> or{' '}
+        <ArticleLink href="/book-assessment">book a free assessment</ArticleLink>.
+      </p>
+
+      <h2>How to Evaluate the Best Fit</h2>
+
+      <p>Before enrolling, ask yourself:</p>
+
+      <ul>
+        <li>Does my child need academic support, enrichment, or childcare?</li>
+        <li>Is the program aligned with my child&apos;s grade level?</li>
+        <li>Does the program explain what students will learn?</li>
+        <li>Is there an assessment or placement process?</li>
+        <li>Will the instructor know my child&apos;s needs?</li>
+        <li>Is the price connected to real instructional value?</li>
+      </ul>
+
+      <p>The right summer program should feel clear, structured, and purposeful.</p>
+
+      <h2>Final Thought</h2>
+
+      <p>Affordable does not mean low-quality. And expensive does not automatically mean better.</p>
+
+      <p>
+        The best summer academic program is the one that gives your child the right support, at the right level, with
+        a clear purpose. For families in Dublin, Pleasanton, San Ramon, and nearby Tri-Valley communities, summer
+        can be a strong time to address academic gaps before the next school year begins.
+      </p>
+    </ResourceArticlePage>
+  )
+}

--- a/src/components/resources/CarelessMathMistakesPage.tsx
+++ b/src/components/resources/CarelessMathMistakesPage.tsx
@@ -10,6 +10,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { Button } from '@/components/ui/button'
+import { ResourceBulletinCta } from '@/components/resources/ResourceBulletinCta'
 import {
   CARELESS_MATH_MISTAKES_CTA,
   CARELESS_MATH_MISTAKES_FAQS,
@@ -346,6 +347,8 @@ export function CarelessMathMistakesPage() {
               ))}
             </Accordion>
           </section>
+
+          <ResourceBulletinCta className="mt-12" />
 
           <section className="mt-12 border-t border-slate-200 pt-10" aria-labelledby="related-guide">
             <h2 id="related-guide" className="font-heading text-lg font-bold text-[#1F396D]">

--- a/src/components/resources/ResourceArticlePage.tsx
+++ b/src/components/resources/ResourceArticlePage.tsx
@@ -10,8 +10,9 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { Button } from '@/components/ui/button'
+import { ResourceBulletinCta } from '@/components/resources/ResourceBulletinCta'
 import type { ResourceCategory } from '@/data/resources-hub'
-import { RESOURCES_PATH } from '@/data/resources-hub'
+import { RESOURCES_PATH, resourceCategoryTagClass } from '@/data/resources-hub'
 import type { ResourceArticleCta, ResourceArticleFaq, ResourceArticleRelated } from '@/data/resources/types'
 import { getDefaultOpenFaqValues } from '@/lib/faq-accordion'
 import { publicPath } from '@/lib/publicPath'
@@ -20,16 +21,6 @@ import { cn } from '@/lib/utils'
 const sectionClass = 'mx-auto max-w-3xl px-4 sm:px-6'
 const h2Class = 'font-heading text-2xl font-bold text-[#1F396D] sm:text-3xl'
 const bodyClass = 'text-base leading-relaxed text-slate-700 sm:text-lg'
-
-function categoryTagClass(category: ResourceCategory): string {
-  if (category === 'steam') {
-    return 'bg-[#F16112]/10 text-[#C45A1A] ring-1 ring-[#F16112]/20'
-  }
-  if (category === 'local') {
-    return 'bg-slate-100 text-slate-700 ring-1 ring-slate-200'
-  }
-  return 'bg-[#1F396D]/10 text-[#1F396D] ring-1 ring-[#1F396D]/15'
-}
 
 type Props = {
   slug: string
@@ -81,7 +72,7 @@ export function ResourceArticlePage({
           <span
             className={cn(
               'mt-6 inline-flex rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wide',
-              categoryTagClass(category),
+              resourceCategoryTagClass(category),
             )}
           >
             {categoryLabel}
@@ -143,6 +134,8 @@ export function ResourceArticlePage({
             </ul>
           </aside>
         ) : null}
+
+        <ResourceBulletinCta className={cn(sectionClass, 'mt-12')} />
       </article>
 
       <section className="border-t border-slate-100 bg-white py-12 sm:py-16" aria-labelledby={`${slug}-faq-heading`}>

--- a/src/components/resources/ResourceBulletinCta.tsx
+++ b/src/components/resources/ResourceBulletinCta.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import Link from 'next/link'
+import { Mail } from 'lucide-react'
+import { useLocale } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import { RESOURCE_BULLETIN_CTA } from '@/data/resource-bulletin-cta'
+import { publicPath } from '@/lib/publicPath'
+import { cn } from '@/lib/utils'
+
+type ResourceBulletinCtaProps = {
+  className?: string
+}
+
+export function ResourceBulletinCta({ className }: ResourceBulletinCtaProps) {
+  const locale = useLocale()
+  const bulletinHref = publicPath(RESOURCE_BULLETIN_CTA.href, locale)
+
+  return (
+    <aside
+      className={cn(
+        'rounded-2xl border border-amber-200/80 bg-gradient-to-br from-amber-50/90 to-white p-6 sm:p-8',
+        className,
+      )}
+      aria-labelledby="resource-bulletin-cta-heading"
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#1F396D]/10 text-[#1F396D]"
+          aria-hidden
+        >
+          <Mail className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 id="resource-bulletin-cta-heading" className="font-heading text-lg font-bold text-[#1F396D] sm:text-xl">
+            {RESOURCE_BULLETIN_CTA.heading}
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600 sm:text-[15px]">{RESOURCE_BULLETIN_CTA.subtext}</p>
+          <Button
+            asChild
+            className="mt-4 min-h-[48px] rounded-lg bg-[#F16112] px-5 text-sm font-semibold text-white hover:bg-[#d54f0a]"
+          >
+            <Link href={bulletinHref}>{RESOURCE_BULLETIN_CTA.buttonLabel}</Link>
+          </Button>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/resources/ResourcesHubPage.tsx
+++ b/src/components/resources/ResourcesHubPage.tsx
@@ -9,26 +9,18 @@ import {
   RESOURCE_GUIDES,
   RESOURCES_CTA,
   RESOURCES_HERO,
-  type ResourceCategory,
+  resourceCategoryTagClass,
   type ResourceFilterId,
 } from '@/data/resources-hub'
+import { RESOURCE_BULLETIN_CTA } from '@/data/resource-bulletin-cta'
 import { publicPath } from '@/lib/publicPath'
 import { cn } from '@/lib/utils'
-
-function categoryTagClass(category: ResourceCategory): string {
-  if (category === 'steam') {
-    return 'bg-[#F16112]/10 text-[#C45A1A] ring-1 ring-[#F16112]/20'
-  }
-  if (category === 'local') {
-    return 'bg-slate-100 text-slate-700 ring-1 ring-slate-200'
-  }
-  return 'bg-[#1F396D]/10 text-[#1F396D] ring-1 ring-[#1F396D]/15'
-}
 
 export function ResourcesHubPage() {
   const locale = useLocale()
   const [activeFilter, setActiveFilter] = useState<ResourceFilterId>('all')
   const bookAssessmentHref = publicPath('/book-assessment', locale)
+  const bulletinHref = publicPath(RESOURCE_BULLETIN_CTA.href, locale)
 
   const visibleGuides = useMemo(() => {
     if (activeFilter === 'all') return RESOURCE_GUIDES
@@ -73,6 +65,23 @@ export function ResourcesHubPage() {
         </div>
       </section>
 
+      <section className="border-b border-amber-100 bg-amber-50/50 py-8 sm:py-10" aria-labelledby="resources-bulletin-promo">
+        <div className="mx-auto flex max-w-4xl flex-col items-center gap-4 px-4 text-center sm:px-6 md:flex-row md:text-left">
+          <div className="flex-1">
+            <h2 id="resources-bulletin-promo" className="font-heading text-lg font-bold text-[#1F396D] sm:text-xl">
+              {RESOURCE_BULLETIN_CTA.heading}
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600 sm:text-[15px]">{RESOURCE_BULLETIN_CTA.subtext}</p>
+          </div>
+          <Button
+            asChild
+            className="min-h-[48px] shrink-0 rounded-lg bg-[#F16112] px-6 text-sm font-semibold text-white hover:bg-[#d54f0a]"
+          >
+            <Link href={bulletinHref}>{RESOURCE_BULLETIN_CTA.buttonLabel}</Link>
+          </Button>
+        </div>
+      </section>
+
       <section className="bg-white py-12 sm:py-16" aria-label="Parent guides">
         <div className="mx-auto max-w-6xl px-4 sm:px-6">
           <ul className="grid list-none gap-6 p-0 sm:grid-cols-2 lg:grid-cols-3" role="list">
@@ -82,7 +91,7 @@ export function ResourcesHubPage() {
                   <span
                     className={cn(
                       'inline-flex w-fit rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wide',
-                      categoryTagClass(guide.category),
+                      resourceCategoryTagClass(guide.category),
                     )}
                   >
                     {guide.categoryLabel}

--- a/src/data/bulletin-copy.ts
+++ b/src/data/bulletin-copy.ts
@@ -1,0 +1,140 @@
+import { FOUNDER_COPY } from '@/data/founder-copy'
+import { CARELESS_MATH_MISTAKES_PATH } from '@/data/resources/careless-math-mistakes-copy'
+import { HOMEWORK_INDEPENDENCE_PATH } from '@/data/resources/homework-independence-copy'
+import { READING_FLUENCY_VS_COMPREHENSION_PATH } from '@/data/resources/reading-fluency-vs-comprehension-copy'
+import { RESOURCES_PATH } from '@/data/resources-hub'
+
+export const BULLETIN_PATH = '/bulletin' as const
+
+export const BULLETIN_DESCRIPTION =
+  "What I learn teaching students every day, I share with you. Every Tuesday, Thursday and Saturday. Free. Why this works for both:"
+
+export type BulletinScheduleItem = {
+  day: string
+  title: string
+  description: string
+}
+
+export const BULLETIN_COPY = {
+  eyebrow: 'Free for K–12 parents · 3× per week',
+  badge: 'Weekly Bulletin',
+  hero: {
+    h1: "How to Support Your K–12 Child's Learning — Weekly Insights from a GrowWise Educator",
+    subtext:
+      'What I learn teaching students every day, I share with you. Every Tuesday, Thursday and Saturday. Free.',
+    submitLabel: 'Send me the GrowWise Bulletin →',
+    formNote: 'No spam. Unsubscribe in one click. Sent Tue, Thu & Sat.',
+    successMessage: "You're in. Check your inbox for a welcome note — your first bulletin arrives this Tuesday.",
+    contactIntro: 'Have a question about your child?',
+    contactLinkLabel: 'Contact Anshika',
+  },
+  founder: {
+    name: FOUNDER_COPY.name,
+    role: FOUNDER_COPY.role,
+    image: FOUNDER_COPY.image,
+    imageAlt: `${FOUNDER_COPY.name}, Founder of GrowWise`,
+    tag: 'SBA Women-Owned',
+    established: 'Est. 2024',
+  },
+  schedule: {
+    label: 'Why this works for both:',
+    items: [
+      {
+        day: 'Every Tuesday',
+        title: 'The Parent Insight',
+        description:
+          'One practical lesson from our classrooms — math mistakes, reading gaps, writing habits, and what actually helps students improve.',
+      },
+      {
+        day: 'Every Thursday',
+        title: 'The Student Spotlight',
+        description:
+          'A real student progress story. Where the student started, what changed, and what helped. No fluff.',
+      },
+      {
+        day: 'Every Saturday',
+        title: 'The Weekly Bulletin',
+        description:
+          'Open seats, assessment slots, workshops, camps, and early access before public posting.',
+      },
+    ] satisfies BulletinScheduleItem[],
+    trustLineBold: 'No daily spam. No generic parenting advice.',
+    trustLineRest: 'Just useful academic updates from GrowWise.',
+  },
+  proof: {
+    stats: [
+      { value: 'Every day', label: 'GrowWise + schools I teach in' },
+      { value: 'Top 5', label: 'Tutoring centers, Dublin CA' },
+      { value: 'K–12', label: 'Math · English · STEAM · AI' },
+    ],
+    quote: "My son actually looks forward to class now. I didn't think that was possible.",
+    attribution: '— Verified parent review',
+  },
+  sample: {
+    label: 'What a typical Tuesday looks like',
+    heading: 'Real insights. Not marketing.',
+    paragraphs: [
+      "Parents tell us they forward Tuesday emails to their partner — not because we asked, but because it answered a question they'd been sitting with for months.",
+      "Here's an example from a recent issue.",
+    ],
+    cardTag: 'Tuesday · The Parent Insight',
+    cardTitle: 'Why your child keeps making the same math mistake',
+    cardExcerpt:
+      "Most parents call it careless. After reviewing thousands of student papers, what looks careless is almost always a pattern. Here's what it actually means — and what to do before it compounds.",
+    cardLinkLabel: 'Read the full guide',
+    cardHref: CARELESS_MATH_MISTAKES_PATH,
+    relatedGuides: [
+      {
+        title: 'How to Stop Sitting Next to Your Child Every Homework Night',
+        href: HOMEWORK_INDEPENDENCE_PATH,
+      },
+      {
+        title: 'Reading Fluency vs. Reading Comprehension',
+        href: READING_FLUENCY_VS_COMPREHENSION_PATH,
+      },
+    ],
+  },
+  featuredGuides: {
+    label: 'More parent guides',
+    heading: 'Free guides for K–12 parents',
+    subtext: 'Research-backed articles on math mistakes, homework habits, reading gaps, and more.',
+    hubLinkLabel: 'Browse all parent guides',
+    hubHref: RESOURCES_PATH,
+    items: [
+      {
+        title: 'Why Kids Make Careless Math Mistakes (And How to Fix It)',
+        description: "It's rarely a knowledge problem. Here's the exact pattern and how to break it.",
+        href: CARELESS_MATH_MISTAKES_PATH,
+        readTime: '6 min read',
+      },
+      {
+        title: 'How to Stop Sitting Next to Your Child Every Homework Night',
+        description: 'The system that builds independence in 6–8 weeks — without the fights.',
+        href: HOMEWORK_INDEPENDENCE_PATH,
+        readTime: '5 min read',
+      },
+      {
+        title: 'Reading Fluency vs. Reading Comprehension',
+        description:
+          'Your child can decode every word but still not understand what they read. Learn how to tell the gaps apart.',
+        href: READING_FLUENCY_VS_COMPREHENSION_PATH,
+        readTime: '6 min read',
+      },
+    ],
+  },
+  bottomCta: {
+    heading: 'Join parents who read this',
+    headingEmphasis: 'every week.',
+    subtext:
+      "There are things I can help your child with that you simply can't — not because you're not a great parent, but because this is all I do, all day. This bulletin is where I share that. Free, every week.",
+    submitLabel: 'Join free →',
+    note: 'No spam · Unsubscribe anytime · 3× per week',
+  },
+  mobileSticky: {
+    label: 'Join free →',
+  },
+  form: {
+    emailPlaceholder: 'Your email address',
+    privacyNote: 'By subscribing, you agree to receive emails from GrowWise. Unsubscribe anytime.',
+  },
+} as const

--- a/src/data/founder-copy.ts
+++ b/src/data/founder-copy.ts
@@ -2,6 +2,7 @@
 export const FOUNDER_COPY = {
   name: 'Anshika Verma',
   role: 'Founder & Educational Director',
+  email: 'anshikaverma@thegrowwise.com',
   image: '/assets/founder-anshika-verma.jpg',
   quote: 'Teach a child how to learn and everything changes.',
   shortBio:

--- a/src/data/resource-bulletin-cta.ts
+++ b/src/data/resource-bulletin-cta.ts
@@ -1,0 +1,9 @@
+import { BULLETIN_PATH } from '@/data/bulletin-copy'
+
+export const RESOURCE_BULLETIN_CTA = {
+  heading: 'Get insights like this weekly — free',
+  subtext:
+    'Classroom lessons and student stories from a GrowWise educator, in your inbox Tue, Thu & Sat. No spam.',
+  buttonLabel: 'Join the GrowWise Bulletin →',
+  href: BULLETIN_PATH,
+} as const

--- a/src/data/resources-hub.ts
+++ b/src/data/resources-hub.ts
@@ -1,6 +1,6 @@
 export const RESOURCES_PATH = '/resources' as const
 
-export type ResourceCategory = 'academic' | 'steam' | 'sat-prep' | 'local'
+export type ResourceCategory = 'academic' | 'stem' | 'sat-prep' | 'local' | 'summer-learning'
 
 export type ResourceFilterId = 'all' | ResourceCategory
 
@@ -17,10 +17,27 @@ export type ResourceGuide = {
 export const RESOURCE_FILTERS: ReadonlyArray<{ id: ResourceFilterId; label: string }> = [
   { id: 'all', label: 'All' },
   { id: 'academic', label: 'Academic' },
-  { id: 'steam', label: 'STEAM & Coding' },
+  { id: 'summer-learning', label: 'Summer Learning' },
+  { id: 'stem', label: 'STEM' },
   { id: 'sat-prep', label: 'SAT Prep' },
   { id: 'local', label: 'Local' },
 ]
+
+export function resourceCategoryTagClass(category: ResourceCategory): string {
+  if (category === 'stem') {
+    return 'bg-[#F16112]/10 text-[#C45A1A] ring-1 ring-[#F16112]/20'
+  }
+  if (category === 'summer-learning') {
+    return 'bg-amber-50 text-amber-900 ring-1 ring-amber-200/80'
+  }
+  if (category === 'local') {
+    return 'bg-slate-100 text-slate-700 ring-1 ring-slate-200'
+  }
+  if (category === 'sat-prep') {
+    return 'bg-violet-50 text-violet-900 ring-1 ring-violet-200/80'
+  }
+  return 'bg-[#1F396D]/10 text-[#1F396D] ring-1 ring-[#1F396D]/15'
+}
 
 export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   {
@@ -63,8 +80,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'what-is-vibe-coding',
-    category: 'steam',
-    categoryLabel: 'STEAM & CODING',
+    category: 'stem',
+    categoryLabel: 'STEM',
     title: 'What is Vibe Coding — And Should Your Child Learn It?',
     description: "The 2026 coding trend explained for parents who didn't grow up coding.",
     readTime: '5 min read',
@@ -72,8 +89,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'python-vs-scratch',
-    category: 'steam',
-    categoryLabel: 'STEAM & CODING',
+    category: 'stem',
+    categoryLabel: 'STEM',
     title: 'Python vs Scratch: Which Should My Child Learn First?',
     description: 'Age-by-age breakdown. What each teaches and when to switch.',
     readTime: '4 min read',
@@ -90,8 +107,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'summer-slide-dublin-ca',
-    category: 'local',
-    categoryLabel: 'LOCAL',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
     title: 'The Summer Slide Is Real: What Dublin Parents Need to Know',
     description: 'How students lose months of academic progress every summer — and what structured programs do differently.',
     readTime: '5 min read',
@@ -99,8 +116,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'summer-slide-prevention',
-    category: 'academic',
-    categoryLabel: 'ACADEMIC',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
     title: 'How to Prevent Summer Slide: What Actually Works (And What Parents Waste Money On)',
     description: "Summer learning loss is real. Here's what actually prevents it — and why most summer plans fail by July.",
     readTime: '5 min read',
@@ -108,8 +125,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'khan-academy-summer-doesnt-work',
-    category: 'academic',
-    categoryLabel: 'ACADEMIC',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
     title: "Why \"We'll Do Khan Academy This Summer\" Almost Never Works (And What Does)",
     description:
       "Self-paced online learning has a completion problem. Here's why most at-home summer learning plans fail by July — and what the research says actually works.",
@@ -118,8 +135,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'im1-summer-prep-dublin-ca',
-    category: 'local',
-    categoryLabel: 'LOCAL',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
     title: 'Is Your Child Ready for IM1? An Honest Summer Prep Guide for Dublin & Tri-Valley Families',
     description:
       'IM1 starts in September. Here are the skills students need before day one — and the gaps most Dublin and Pleasanton kids arrive with. Prep starts July 20.',
@@ -128,8 +145,8 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   },
   {
     id: 'summer-academic-program-checklist',
-    category: 'academic',
-    categoryLabel: 'ACADEMIC',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
     title: '5 Things to Look for in a Summer Academic Program (Before You Pay)',
     description:
       "Not all summer academic programs produce results. Here are five concrete things to evaluate before you enroll — and the questions most programs can't answer.",
@@ -137,9 +154,19 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
     href: '/resources/summer-academic-program-checklist',
   },
   {
+    id: 'affordable-summer-academic-programs-dublin-ca',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
+    title: 'Affordable Summer Academic Programs in Dublin, CA: What\'s Available and What to Expect',
+    description:
+      'Compare summer academic programs in Dublin, CA and learn how to evaluate true value based on class size, outcomes, structure, and skill-building.',
+    readTime: '6 min read',
+    href: '/resources/affordable-summer-academic-programs-dublin-ca',
+  },
+  {
     id: 'summer-writing-program-dublin-ca',
-    category: 'local',
-    categoryLabel: 'LOCAL',
+    category: 'summer-learning',
+    categoryLabel: 'SUMMER LEARNING',
     title: 'Summer Writing Programs in Dublin, CA: What to Expect and How to Choose',
     description:
       "Most kids never receive direct writing instruction. Here's what good writing programs actually teach — and what to look for in Tri-Valley summer options.",

--- a/src/data/resources/affordable-summer-academic-programs-dublin-ca.ts
+++ b/src/data/resources/affordable-summer-academic-programs-dublin-ca.ts
@@ -1,0 +1,110 @@
+import type { ResourceArticleFaq, ResourceArticleMeta, ResourceArticleRelated } from '@/data/resources/types'
+
+export const AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH =
+  '/resources/affordable-summer-academic-programs-dublin-ca' as const
+
+export const AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER = {
+  title: "Affordable Summer Academic Programs in Dublin, CA: What's Available and What to Expect",
+  seoTitle: 'Affordable Summer Programs Dublin CA | Parent Guide',
+  metaDescription:
+    'Compare summer academic programs in Dublin, CA and learn how to evaluate true value based on class size, outcomes, structure, and skill-building.',
+  slug: 'affordable-summer-academic-programs-dublin-ca',
+  canonicalUrl: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH,
+  publishedDate: '2026-06-08',
+  modifiedDate: '2026-06-08',
+  author: 'GrowWise',
+  primaryKeyword: 'affordable summer programs Dublin CA',
+  secondaryKeywords: [
+    'academic summer camp Dublin Pleasanton',
+    'summer academic programs Tri-Valley',
+    'summer tutoring Dublin CA',
+  ],
+  audience: 'Summer Childcare Solver, Concerned Parent',
+  ctaText: 'See program details',
+  ctaUrl: '/camps/academic-summer-programs-dublin-ca',
+} as const
+
+export const AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META: ResourceArticleMeta = {
+  path: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH,
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
+  h1: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.title,
+  readTime: '6 min read',
+  updated: 'Updated June 2026',
+  title: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.seoTitle,
+  description: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.metaDescription,
+  keywords: [
+    AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.primaryKeyword,
+    ...AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.secondaryKeywords,
+  ].join(', '),
+  datePublished: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.publishedDate,
+  dateModified: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.modifiedDate,
+  seoTitle: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.seoTitle,
+  slug: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.slug,
+  canonicalUrl: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.canonicalUrl,
+  author: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.author,
+  primaryKeyword: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.primaryKeyword,
+  secondaryKeywords: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.secondaryKeywords,
+  audience: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.audience,
+  ctaText: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.ctaText,
+  ctaUrl: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FRONTMATTER.ctaUrl,
+}
+
+export const AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS: readonly ResourceArticleFaq[] = [
+  {
+    question: 'What is the best affordable summer academic program in Dublin, CA?',
+    answer:
+      'The best affordable program depends on your child\'s needs, not the lowest weekly price. Look for small groups, clear learning goals, instructor feedback, and grade-level alignment. Families in Dublin, Pleasanton, and San Ramon often compare Tri-Valley options on instructional hours and outcomes — not activity count alone.',
+  },
+  {
+    question: 'Are academic summer programs worth it?',
+    answer:
+      'They can be worth it when they provide targeted instruction instead of generic worksheets or unsupervised time. Worthwhile programs explain what students will learn, track progress, and address real gaps before the next school year. If the goal is only childcare, a cheaper activity program may be enough.',
+  },
+  {
+    question: 'Should I choose a cheaper summer program?',
+    answer:
+      'Choose based on value, not price alone. A lower-cost program may work if it has a clear learning purpose, safe structure, and appropriate supervision. If you need academic growth, verify that lower cost is not coming from very large groups or untrained instructors on staff.',
+  },
+  {
+    question: 'What should I ask before enrolling in a summer program?',
+    answer:
+      'Ask about class size, assessment or placement, instructor experience, weekly curriculum, and how progress is communicated. For academic programs in Dublin, CA, also ask whether content aligns to your child\'s school pathway. Strong programs answer these questions specifically — not with general marketing language.',
+  },
+  {
+    question: 'How do I tell academic support from childcare?',
+    answer:
+      'Childcare-focused programs prioritize supervision, activities, and coverage hours. Academic programs should explain skills taught, how students are grouped, and whether instructors adjust based on student errors. If no one can describe learning outcomes, you are likely paying for activity time — not instructional support.',
+  },
+  {
+    question: 'Does GrowWise publish summer program details online?',
+    answer:
+      'Yes. GrowWise lists schedules, tracks, and enrollment details on its academic summer programs page for Dublin, CA families. You can review program structure before contacting the center. Details are updated regularly for Tri-Valley families in Dublin, Pleasanton, and San Ramon.',
+  },
+] as const
+
+export const AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_JSONLD_FAQS: readonly ResourceArticleFaq[] =
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS
+
+export const AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_RELATED: readonly ResourceArticleRelated[] = [
+  {
+    title: '5 Things to Look for in a Summer Academic Program',
+    href: '/resources/summer-academic-program-checklist',
+    description: 'Five evaluation questions before you pay.',
+  },
+  {
+    title: 'The Summer Slide Is Real: What Dublin Parents Need to Know',
+    href: '/resources/summer-slide-dublin-ca',
+    description: 'Why structured summer learning matters in the Tri-Valley.',
+  },
+  {
+    title: 'Best Tutoring Options in Dublin, CA',
+    href: '/resources/tutoring-dublin-ca',
+    description: 'Compare K–12 tutoring and summer paths in Dublin.',
+  },
+  {
+    title: 'GrowWise Academic Summer Programs',
+    href: '/camps/academic-summer-programs-dublin-ca',
+    description: 'Schedules, tracks, and enrollment for Dublin, CA.',
+  },
+]

--- a/src/data/resources/im1-summer-prep-dublin-ca.ts
+++ b/src/data/resources/im1-summer-prep-dublin-ca.ts
@@ -4,8 +4,8 @@ export const IM1_SUMMER_PREP_DUBLIN_CA_PATH = '/resources/im1-summer-prep-dublin
 
 export const IM1_SUMMER_PREP_DUBLIN_CA_META: ResourceArticleMeta = {
   path: IM1_SUMMER_PREP_DUBLIN_CA_PATH,
-  category: 'local',
-  categoryLabel: 'LOCAL',
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
   h1: 'Is Your Child Ready for IM1? An Honest Summer Prep Guide for Dublin & Tri-Valley Families',
   readTime: '6 min read',
   updated: 'Updated May 2026',

--- a/src/data/resources/index.ts
+++ b/src/data/resources/index.ts
@@ -1,3 +1,4 @@
+import { AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH } from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
 import { CARELESS_MATH_MISTAKES_PATH } from '@/data/resources/careless-math-mistakes-copy'
 import { HOMEWORK_INDEPENDENCE_PATH } from '@/data/resources/homework-independence-copy'
 import { IM1_SUMMER_PREP_DUBLIN_CA_PATH } from '@/data/resources/im1-summer-prep-dublin-ca'
@@ -25,6 +26,7 @@ export const RESOURCE_ARTICLE_PATHS = [
   KHAN_ACADEMY_SUMMER_DOESNT_WORK_PATH,
   IM1_SUMMER_PREP_DUBLIN_CA_PATH,
   SUMMER_ACADEMIC_PROGRAM_CHECKLIST_PATH,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH,
   SUMMER_WRITING_PROGRAM_DUBLIN_CA_PATH,
   TUTORING_DUBLIN_CA_PATH,
 ] as const

--- a/src/data/resources/khan-academy-summer-doesnt-work.ts
+++ b/src/data/resources/khan-academy-summer-doesnt-work.ts
@@ -4,8 +4,8 @@ export const KHAN_ACADEMY_SUMMER_DOESNT_WORK_PATH = '/resources/khan-academy-sum
 
 export const KHAN_ACADEMY_SUMMER_DOESNT_WORK_META: ResourceArticleMeta = {
   path: KHAN_ACADEMY_SUMMER_DOESNT_WORK_PATH,
-  category: 'academic',
-  categoryLabel: 'ACADEMIC',
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
   h1: 'Why "We\'ll Do Khan Academy This Summer" Almost Never Works (And What Does)',
   readTime: '5 min read',
   updated: 'Updated May 2026',

--- a/src/data/resources/python-vs-scratch-copy.ts
+++ b/src/data/resources/python-vs-scratch-copy.ts
@@ -4,8 +4,8 @@ export const PYTHON_VS_SCRATCH_PATH = '/resources/python-vs-scratch' as const
 
 export const PYTHON_VS_SCRATCH_META: ResourceArticleMeta = {
   path: PYTHON_VS_SCRATCH_PATH,
-  category: 'steam',
-  categoryLabel: 'STEAM & CODING',
+  category: 'stem',
+  categoryLabel: 'STEM',
   h1: 'Python vs Scratch: Which Should Your Child Learn First?',
   readTime: '4 min read',
   updated: 'Updated May 2026',

--- a/src/data/resources/summer-academic-program-checklist.ts
+++ b/src/data/resources/summer-academic-program-checklist.ts
@@ -4,8 +4,8 @@ export const SUMMER_ACADEMIC_PROGRAM_CHECKLIST_PATH = '/resources/summer-academi
 
 export const SUMMER_ACADEMIC_PROGRAM_CHECKLIST_META: ResourceArticleMeta = {
   path: SUMMER_ACADEMIC_PROGRAM_CHECKLIST_PATH,
-  category: 'academic',
-  categoryLabel: 'ACADEMIC',
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
   h1: '5 Things to Look for in a Summer Academic Program (Before You Pay)',
   readTime: '5 min read',
   updated: 'Updated May 2026',
@@ -65,6 +65,11 @@ export const SUMMER_ACADEMIC_PROGRAM_CHECKLIST_JSONLD_FAQS: readonly ResourceArt
 ] as const
 
 export const SUMMER_ACADEMIC_PROGRAM_CHECKLIST_RELATED: readonly ResourceArticleRelated[] = [
+  {
+    title: 'Affordable Summer Academic Programs in Dublin, CA',
+    href: '/resources/affordable-summer-academic-programs-dublin-ca',
+    description: 'Compare value, class size, and outcomes before you enroll.',
+  },
   {
     title: 'Why "We\'ll Do Khan Academy This Summer" Almost Never Works',
     href: '/resources/khan-academy-summer-doesnt-work',

--- a/src/data/resources/summer-slide-dublin-ca.ts
+++ b/src/data/resources/summer-slide-dublin-ca.ts
@@ -4,8 +4,8 @@ export const SUMMER_SLIDE_DUBLIN_CA_PATH = '/resources/summer-slide-dublin-ca' a
 
 export const SUMMER_SLIDE_DUBLIN_CA_META: ResourceArticleMeta = {
   path: SUMMER_SLIDE_DUBLIN_CA_PATH,
-  category: 'local',
-  categoryLabel: 'LOCAL',
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
   h1: 'The Summer Slide Is Real: What Dublin Parents Need to Know Before June Ends',
   readTime: '5 min read',
   updated: 'Updated May 2026',

--- a/src/data/resources/summer-slide-prevention.ts
+++ b/src/data/resources/summer-slide-prevention.ts
@@ -4,8 +4,8 @@ export const SUMMER_SLIDE_PREVENTION_PATH = '/resources/summer-slide-prevention'
 
 export const SUMMER_SLIDE_PREVENTION_META: ResourceArticleMeta = {
   path: SUMMER_SLIDE_PREVENTION_PATH,
-  category: 'academic',
-  categoryLabel: 'ACADEMIC',
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
   h1: 'How to Prevent Summer Slide: What Actually Works (And What Parents Waste Money On)',
   readTime: '5 min read',
   updated: 'Updated May 2026',

--- a/src/data/resources/summer-writing-program-dublin-ca.ts
+++ b/src/data/resources/summer-writing-program-dublin-ca.ts
@@ -4,8 +4,8 @@ export const SUMMER_WRITING_PROGRAM_DUBLIN_CA_PATH = '/resources/summer-writing-
 
 export const SUMMER_WRITING_PROGRAM_DUBLIN_CA_META: ResourceArticleMeta = {
   path: SUMMER_WRITING_PROGRAM_DUBLIN_CA_PATH,
-  category: 'local',
-  categoryLabel: 'LOCAL',
+  category: 'summer-learning',
+  categoryLabel: 'SUMMER LEARNING',
   h1: 'Summer Writing Programs in Dublin, CA: What to Expect and How to Choose',
   readTime: '6 min read',
   updated: 'Updated May 2026',
@@ -75,6 +75,11 @@ export const SUMMER_WRITING_PROGRAM_DUBLIN_CA_JSONLD_FAQS: readonly ResourceArti
 ] as const
 
 export const SUMMER_WRITING_PROGRAM_DUBLIN_CA_RELATED: readonly ResourceArticleRelated[] = [
+  {
+    title: 'Affordable Summer Academic Programs in Dublin, CA',
+    href: '/resources/affordable-summer-academic-programs-dublin-ca',
+    description: 'Compare Tri-Valley summer academic options and value.',
+  },
   {
     title: 'Self-Check: Is Your Child Ready?',
     href: '/self-check',

--- a/src/data/resources/tutoring-dublin-ca.ts
+++ b/src/data/resources/tutoring-dublin-ca.ts
@@ -53,6 +53,11 @@ export const TUTORING_DUBLIN_CA_FAQS: readonly ResourceArticleFaq[] = [
 
 export const TUTORING_DUBLIN_CA_RELATED: readonly ResourceArticleRelated[] = [
   {
+    title: 'Affordable Summer Academic Programs in Dublin, CA',
+    href: '/resources/affordable-summer-academic-programs-dublin-ca',
+    description: 'How to compare summer program value in the Tri-Valley.',
+  },
+  {
     title: 'When Should My Child Start SAT Prep?',
     href: '/resources/when-to-start-sat-prep',
     description: 'Grade 8, 9, or 10? The answer depends on one thing most parents miss.',

--- a/src/data/resources/types.ts
+++ b/src/data/resources/types.ts
@@ -26,6 +26,16 @@ export type ResourceArticleMeta = {
   keywords: string
   datePublished: string
   dateModified: string
+  /** Optional extended frontmatter (Article 12+ template) */
+  seoTitle?: string
+  slug?: string
+  canonicalUrl?: string
+  author?: string
+  primaryKeyword?: string
+  secondaryKeywords?: readonly string[]
+  audience?: string
+  ctaText?: string
+  ctaUrl?: string
 }
 
 export type ResourceArticleCta = {

--- a/src/data/resources/what-is-vibe-coding-copy.ts
+++ b/src/data/resources/what-is-vibe-coding-copy.ts
@@ -4,8 +4,8 @@ export const WHAT_IS_VIBE_CODING_PATH = '/resources/what-is-vibe-coding' as cons
 
 export const WHAT_IS_VIBE_CODING_META: ResourceArticleMeta = {
   path: WHAT_IS_VIBE_CODING_PATH,
-  category: 'steam',
-  categoryLabel: 'STEAM & CODING',
+  category: 'stem',
+  categoryLabel: 'STEM',
   h1: 'What Is Vibe Coding — And Should Your Child Learn It?',
   readTime: '5 min read',
   updated: 'Updated May 2026',

--- a/src/lib/__tests__/affordable-summer-academic-programs-dublin-ca-seo.test.ts
+++ b/src/lib/__tests__/affordable-summer-academic-programs-dublin-ca-seo.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META,
+} from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
+import { getMetadataConfig } from '@/lib/seo/metadataConfig'
+
+const UI_ROOT = path.join(__dirname, '..', '..')
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(UI_ROOT, relativePath), 'utf8')
+}
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+describe('affordable-summer-academic-programs-dublin-ca SEO/AEO', () => {
+  it('has metadata within length limits', () => {
+    const config = getMetadataConfig('/resources/affordable-summer-academic-programs-dublin-ca')
+    expect(config).not.toBeNull()
+    expect(config!.title.length).toBeLessThanOrEqual(60)
+    expect(config!.description.length).toBeLessThanOrEqual(150)
+  })
+
+  it('has six FAQs with answers between 40 and 70 words', () => {
+    expect(AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS).toHaveLength(6)
+    for (const faq of AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS) {
+      const count = wordCount(faq.answer)
+      expect(count).toBeGreaterThanOrEqual(40)
+      expect(count).toBeLessThanOrEqual(70)
+    }
+  })
+
+  it('page component includes required internal links', () => {
+    const source = readSource('components/resources/AffordableSummerAcademicProgramsDublinCaPage.tsx')
+    expect(source).toContain('/camps/academic-summer-programs-dublin-ca')
+    expect(source).toContain('/resources/summer-academic-program-checklist')
+    expect(source).toContain('/resources/summer-slide-dublin-ca')
+    expect(source).toContain('/resources/tutoring-dublin-ca')
+    expect(source).toContain('/book-assessment')
+  })
+
+  it('layout injects three JSON-LD scripts', () => {
+    const source = readSource(
+      'app/[locale]/resources/affordable-summer-academic-programs-dublin-ca/layout.tsx',
+    )
+    expect(source).toContain('jsonLd.article')
+    expect(source).toContain('jsonLd.faq')
+    expect(source).toContain('jsonLd.breadcrumb')
+    expect(source.match(/application\/ld\+json/g)?.length).toBe(3)
+  })
+
+  it('uses Article type in JSON-LD builder', () => {
+    const source = readSource('lib/schema/affordable-summer-academic-programs-dublin-ca-jsonld.ts')
+    expect(source).toContain("'@type': 'Article'")
+    expect(source).not.toContain('BlogPosting')
+  })
+
+  it('meta h1 matches article title frontmatter', () => {
+    expect(AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.h1).toContain('Affordable Summer Academic Programs')
+    expect(AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.datePublished).toBe('2026-06-08')
+  })
+})

--- a/src/lib/__tests__/bulletin-resource-cross-links.test.ts
+++ b/src/lib/__tests__/bulletin-resource-cross-links.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const UI_ROOT = path.join(__dirname, '..', '..')
+
+function readComponent(relativePath: string): string {
+  return fs.readFileSync(path.join(UI_ROOT, relativePath), 'utf8')
+}
+
+describe('bulletin resource cross-links', () => {
+  it('links bulletin page to resources hub and featured guides', () => {
+    const landingPage = readComponent('components/marketing/BulletinLandingPage.tsx')
+    const copy = readComponent('data/bulletin-copy.ts')
+
+    expect(landingPage).toContain('featuredGuides')
+    expect(landingPage).toContain('hubHref')
+    expect(copy).toContain('/resources/homework-independence')
+    expect(copy).toContain('/resources/reading-fluency-vs-comprehension')
+    expect(copy).toContain('/resources/careless-math-mistakes')
+    expect(copy).toContain("RESOURCES_PATH")
+  })
+
+  it('links resource articles back to bulletin via shared CTA', () => {
+    const articlePage = readComponent('components/resources/ResourceArticlePage.tsx')
+    const carelessPage = readComponent('components/resources/CarelessMathMistakesPage.tsx')
+    const resourcesHub = readComponent('components/resources/ResourcesHubPage.tsx')
+    const ctaData = readComponent('data/resource-bulletin-cta.ts')
+
+    expect(articlePage).toContain('ResourceBulletinCta')
+    expect(carelessPage).toContain('ResourceBulletinCta')
+    expect(resourcesHub).toContain('RESOURCE_BULLETIN_CTA')
+    expect(resourcesHub).toContain('bulletinHref')
+    expect(ctaData).toContain('BULLETIN_PATH')
+  })
+})

--- a/src/lib/__tests__/bulletin-welcome-email.test.ts
+++ b/src/lib/__tests__/bulletin-welcome-email.test.ts
@@ -1,0 +1,13 @@
+import { buildBulletinWelcomeEmail } from '@/lib/bulletin-welcome-email'
+
+describe('bulletin-welcome-email', () => {
+  it('builds subject and body with bulletin schedule and sample link', () => {
+    const email = buildBulletinWelcomeEmail('https://growwiseschool.org')
+    expect(email.subject).toBe('Welcome to the GrowWise Bulletin')
+    expect(email.html).toContain('Tuesday')
+    expect(email.html).toContain('careless-math-mistakes')
+    expect(email.text).toContain('/contact')
+    expect(email.html).toContain('Contact Anshika')
+    expect(email.html).not.toContain('book-assessment')
+  })
+})

--- a/src/lib/__tests__/resources-hub-categories.test.ts
+++ b/src/lib/__tests__/resources-hub-categories.test.ts
@@ -1,0 +1,33 @@
+import {
+  RESOURCE_FILTERS,
+  RESOURCE_GUIDES,
+  resourceCategoryTagClass,
+} from '@/data/resources-hub'
+
+describe('resources-hub categories', () => {
+  it('includes Summer Learning and STEM filters', () => {
+    const filterIds = RESOURCE_FILTERS.map((filter) => filter.id)
+    expect(filterIds).toContain('summer-learning')
+    expect(filterIds).toContain('stem')
+    expect(filterIds).not.toContain('steam')
+  })
+
+  it('tags six summer guides as summer-learning', () => {
+    const summerGuides = RESOURCE_GUIDES.filter((guide) => guide.category === 'summer-learning')
+    expect(summerGuides).toHaveLength(7)
+    expect(summerGuides.every((guide) => guide.categoryLabel === 'SUMMER LEARNING')).toBe(true)
+  })
+
+  it('tags coding guides as STEM', () => {
+    const stemGuides = RESOURCE_GUIDES.filter((guide) => guide.category === 'stem')
+    expect(stemGuides).toHaveLength(2)
+    expect(stemGuides.map((guide) => guide.id)).toEqual(
+      expect.arrayContaining(['what-is-vibe-coding', 'python-vs-scratch']),
+    )
+  })
+
+  it('styles summer-learning and stem category tags', () => {
+    expect(resourceCategoryTagClass('summer-learning')).toContain('amber')
+    expect(resourceCategoryTagClass('stem')).toContain('F16112')
+  })
+})

--- a/src/lib/__tests__/resources-internal-links.test.ts
+++ b/src/lib/__tests__/resources-internal-links.test.ts
@@ -129,7 +129,7 @@ describe('resources internal links', () => {
     );
   });
 
-  it('does not force academic camp links into STEAM resource articles', () => {
+  it('does not force academic camp links into STEM resource articles', () => {
     const vibeCoding = readComponent('components/resources/WhatIsVibeCodingPage.tsx');
     const pythonVsScratch = readComponent('components/resources/PythonVsScratchPage.tsx');
 

--- a/src/lib/brevo.ts
+++ b/src/lib/brevo.ts
@@ -3,6 +3,7 @@
  * Env: BREVO_API_KEY, BREVO_SENDER_EMAIL, BREVO_SENDER_NAME (optional),
  * BREVO_LIST_LOTTERY (numeric list id — summer camp guide leads + Meta Lead Ads upsert; legacy env name).
  * BREVO_LIST_MATH_FINALS (numeric list id — high school math finals practice form; triggers automations).
+ * BREVO_LIST_BULLETIN (numeric list id — GrowWise Bulletin newsletter signup at /bulletin).
  */
 
 import type { EmailAttachment, SendEmailResult } from '@/lib/email';
@@ -196,6 +197,76 @@ export async function addSummerCampLotteryContactToBrevoList(
   email: string,
 ): Promise<SendEmailResult> {
   return addSummerCampSummercampContactToBrevoList(email);
+}
+
+/** POST /v3/contacts — upsert newsletter subscriber and attach to `BREVO_LIST_BULLETIN`. */
+export async function addBulletinContactToBrevoList(email: string): Promise<SendEmailResult> {
+  const apiKey = getBrevoApiKey();
+  if (!apiKey) {
+    return { success: false, error: 'Brevo not configured' };
+  }
+
+  const listIdRaw = process.env.BREVO_LIST_BULLETIN?.trim();
+  if (!listIdRaw) {
+    console.warn('[brevo] BREVO_LIST_BULLETIN not set; skipping bulletin list add.');
+    return { success: false, error: 'BREVO_LIST_BULLETIN not set' };
+  }
+
+  const listId = Number.parseInt(listIdRaw, 10);
+  if (!Number.isFinite(listId)) {
+    console.warn('[brevo] BREVO_LIST_BULLETIN must be a numeric list id.');
+    return { success: false, error: 'Invalid BREVO_LIST_BULLETIN' };
+  }
+
+  const listIds = filterAutomationListIds([listId]);
+  if (!listIds) {
+    console.warn(
+      '[brevo] BREVO_LIST_BULLETIN is excluded from automation; upserting contact without list attachment.',
+      { listId },
+    );
+  }
+
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!normalizedEmail) {
+    return { success: false, error: 'No email' };
+  }
+
+  try {
+    const res = await fetchWithTimeout(`${BREVO_API_BASE}/contacts`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'api-key': apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: normalizedEmail,
+        attributes: { SOURCE: 'growwise_bulletin' },
+        ...(listIds ? { listIds } : {}),
+        updateEnabled: true,
+      }),
+    });
+
+    const raw = await res.text();
+    let parsed: { message?: string } = {};
+    try {
+      parsed = raw ? (JSON.parse(raw) as typeof parsed) : {};
+    } catch {
+      /* ignore */
+    }
+
+    if (!res.ok) {
+      const errMsg = parsed.message || raw || `HTTP ${res.status}`;
+      console.warn('[brevo] Bulletin list contact failed:', errMsg);
+      return { success: false, error: errMsg };
+    }
+
+    return { success: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Bulletin list add failed';
+    console.warn('[brevo] Bulletin list contact error:', error);
+    return { success: false, error };
+  }
 }
 
 /** Math finals practice form — fields synced to Brevo for list-based automations. */

--- a/src/lib/bulletin-welcome-email.ts
+++ b/src/lib/bulletin-welcome-email.ts
@@ -1,0 +1,96 @@
+/**
+ * GrowWise Bulletin welcome email — sent on POST /api/bulletin/subscribe.
+ */
+
+import { BULLETIN_PATH } from '@/data/bulletin-copy'
+import { CARELESS_MATH_MISTAKES_PATH } from '@/data/resources/careless-math-mistakes-copy'
+import { FOUNDER_COPY } from '@/data/founder-copy'
+
+export const BULLETIN_EMAIL_UTM = {
+  source: 'email',
+  medium: 'email',
+  campaign: 'growwise_bulletin_welcome',
+} as const
+
+function appendBulletinUtm(absoluteUrl: string, content: string): string {
+  let u: URL
+  try {
+    u = new URL(absoluteUrl)
+  } catch {
+    return absoluteUrl
+  }
+  u.searchParams.set('utm_source', BULLETIN_EMAIL_UTM.source)
+  u.searchParams.set('utm_medium', BULLETIN_EMAIL_UTM.medium)
+  u.searchParams.set('utm_campaign', BULLETIN_EMAIL_UTM.campaign)
+  u.searchParams.set('utm_content', content)
+  return u.toString()
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export interface BulletinWelcomeEmailContent {
+  subject: string
+  html: string
+  text: string
+}
+
+export function buildBulletinWelcomeEmail(siteUrl: string): BulletinWelcomeEmailContent {
+  const base = siteUrl.replace(/\/$/, '')
+  const sampleUrl = appendBulletinUtm(`${base}${CARELESS_MATH_MISTAKES_PATH}`, 'sample_article')
+  const contactUrl = appendBulletinUtm(`${base}/contact`, 'contact_anshika')
+  const bulletinUrl = appendBulletinUtm(`${base}${BULLETIN_PATH}`, 'bulletin_page')
+
+  const subject = 'Welcome to the GrowWise Bulletin'
+
+  const html = `
+    <div style="font-family: Arial, Helvetica, sans-serif; max-width: 600px; margin: 0 auto; color: #1e293b; line-height: 1.65;">
+      <p style="margin: 0 0 16px;">Hi there,</p>
+      <p style="margin: 0 0 20px;">You're subscribed to the <strong>GrowWise Bulletin</strong> — free weekly insights for K–12 parents from our classrooms.</p>
+      <p style="margin: 0 0 12px; font-weight: bold; color: #1F396D;">What to expect (3× per week):</p>
+      <p style="margin: 0 0 8px;"><strong>Tuesday</strong> — The Parent Insight: one practical lesson from our classrooms.</p>
+      <p style="margin: 0 0 8px;"><strong>Thursday</strong> — The Student Spotlight: a real progress story, no fluff.</p>
+      <p style="margin: 0 0 24px;"><strong>Saturday</strong> — The Weekly Bulletin: open seats, workshops, and early access.</p>
+      <p style="margin: 0 0 12px;">While you wait for Tuesday, here's a recent Parent Insight parents forwarded to each other:</p>
+      <p style="margin: 0 0 24px;">
+        <a href="${escapeHtml(sampleUrl)}" style="color: #1F396D; font-weight: bold;">Why your child keeps making the same math mistake →</a>
+      </p>
+      <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 24px 0;" />
+      <p style="margin: 0 0 16px;">Want a live conversation about your child? <a href="${escapeHtml(contactUrl)}" style="color: #F16112; font-weight: bold;">Contact Anshika →</a></p>
+      <p style="margin: 0 0 8px;">See you in your inbox,</p>
+      <p style="margin: 0;">
+        ${escapeHtml(FOUNDER_COPY.name)}<br />
+        ${escapeHtml(FOUNDER_COPY.role)}<br />
+        <a href="${escapeHtml(bulletinUrl)}" style="color: #1F396D;">growwiseschool.org/bulletin</a>
+      </p>
+    </div>
+  `.trim()
+
+  const text = [
+    'Hi there,',
+    '',
+    "You're subscribed to the GrowWise Bulletin — free weekly insights for K–12 parents from our classrooms.",
+    '',
+    'What to expect (3× per week):',
+    'Tuesday — The Parent Insight: one practical lesson from our classrooms.',
+    'Thursday — The Student Spotlight: a real progress story, no fluff.',
+    'Saturday — The Weekly Bulletin: open seats, workshops, and early access.',
+    '',
+    'While you wait for Tuesday, read a recent Parent Insight:',
+    sampleUrl,
+    '',
+    `Contact Anshika: ${contactUrl}`,
+    '',
+    'See you in your inbox,',
+    FOUNDER_COPY.name,
+    FOUNDER_COPY.role,
+    bulletinUrl,
+  ].join('\n')
+
+  return { subject, html, text }
+}

--- a/src/lib/schema/__tests__/affordable-summer-academic-programs-dublin-ca-jsonld.test.ts
+++ b/src/lib/schema/__tests__/affordable-summer-academic-programs-dublin-ca-jsonld.test.ts
@@ -1,0 +1,70 @@
+import {
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_JSONLD_FAQS,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META,
+} from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
+import {
+  buildAffordableSummerAcademicProgramsDublinCaJsonLd,
+  buildAffordableSummerArticleJsonLd,
+  buildAffordableSummerBreadcrumbJsonLd,
+  buildAffordableSummerFaqJsonLd,
+} from '@/lib/schema/affordable-summer-academic-programs-dublin-ca-jsonld'
+
+const BASE = 'https://growwiseschool.org'
+const PAGE =
+  'https://growwiseschool.org/resources/affordable-summer-academic-programs-dublin-ca'
+const RESOURCES = 'https://growwiseschool.org/resources'
+
+describe('affordable-summer-academic-programs-dublin-ca-jsonld', () => {
+  it('builds Article JSON-LD with exact template fields', () => {
+    const article = buildAffordableSummerArticleJsonLd(BASE, PAGE)
+    expect(article).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.h1,
+      description: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.description,
+      author: { '@type': 'Organization', name: 'GrowWise' },
+      publisher: { '@type': 'Organization', name: 'GrowWise', url: BASE },
+      datePublished: '2026-06-08',
+      dateModified: '2026-06-08',
+      mainEntityOfPage: { '@type': 'WebPage', '@id': PAGE },
+    })
+  })
+
+  it('builds FAQPage JSON-LD from visible FAQs only', () => {
+    const faq = buildAffordableSummerFaqJsonLd()
+    expect(faq['@type']).toBe('FAQPage')
+    expect(faq.mainEntity).toHaveLength(6)
+    expect(faq.mainEntity[0]).toMatchObject({
+      '@type': 'Question',
+      name: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS[0].question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS[0].answer,
+      },
+    })
+  })
+
+  it('matches JSON-LD FAQs to visible FAQs exactly', () => {
+    expect(AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_JSONLD_FAQS).toEqual(
+      AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_FAQS,
+    )
+  })
+
+  it('builds BreadcrumbList with Resources as step 2', () => {
+    const breadcrumb = buildAffordableSummerBreadcrumbJsonLd(BASE, RESOURCES, PAGE)
+    expect(breadcrumb.itemListElement).toHaveLength(3)
+    expect(breadcrumb.itemListElement[1]).toMatchObject({
+      position: 2,
+      name: 'Resources',
+      item: RESOURCES,
+    })
+  })
+
+  it('returns three separate JSON-LD objects', () => {
+    const jsonLd = buildAffordableSummerAcademicProgramsDublinCaJsonLd(BASE, 'en')
+    expect(jsonLd.article['@context']).toBe('https://schema.org')
+    expect(jsonLd.faq['@context']).toBe('https://schema.org')
+    expect(jsonLd.breadcrumb['@context']).toBe('https://schema.org')
+  })
+})

--- a/src/lib/schema/__tests__/bulletin-jsonld.test.ts
+++ b/src/lib/schema/__tests__/bulletin-jsonld.test.ts
@@ -1,0 +1,10 @@
+import { buildBulletinPageGraphSchema } from '@/lib/schema/bulletin-jsonld'
+
+describe('bulletin-jsonld', () => {
+  it('builds WebPage graph with breadcrumb', () => {
+    const graph = buildBulletinPageGraphSchema('https://growwiseschool.org', 'en')
+    expect(graph['@graph']).toHaveLength(2)
+    expect(graph['@graph'][0]).toMatchObject({ '@type': 'WebPage' })
+    expect(graph['@graph'][1]).toMatchObject({ '@type': 'BreadcrumbList' })
+  })
+})

--- a/src/lib/schema/affordable-summer-academic-programs-dublin-ca-jsonld.ts
+++ b/src/lib/schema/affordable-summer-academic-programs-dublin-ca-jsonld.ts
@@ -1,0 +1,88 @@
+import {
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_JSONLD_FAQS,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META,
+  AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH,
+} from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
+import { RESOURCES_PATH } from '@/data/resources-hub'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+
+export function buildAffordableSummerArticleJsonLd(baseUrl: string, pageUrl: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.h1,
+    description: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.description,
+    author: {
+      '@type': 'Organization',
+      name: 'GrowWise',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'GrowWise',
+      url: baseUrl,
+    },
+    datePublished: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.datePublished,
+    dateModified: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.dateModified,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': pageUrl,
+    },
+  }
+}
+
+export function buildAffordableSummerFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_JSONLD_FAQS.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  }
+}
+
+export function buildAffordableSummerBreadcrumbJsonLd(
+  baseUrl: string,
+  resourcesUrl: string,
+  pageUrl: string,
+) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: baseUrl,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Resources',
+        item: resourcesUrl,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_META.h1,
+        item: pageUrl,
+      },
+    ],
+  }
+}
+
+export function buildAffordableSummerAcademicProgramsDublinCaJsonLd(baseUrl: string, locale: string) {
+  const pageUrl = absoluteSiteUrl(AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH, locale, baseUrl)
+  const resourcesUrl = absoluteSiteUrl(RESOURCES_PATH, locale, baseUrl)
+
+  return {
+    article: buildAffordableSummerArticleJsonLd(baseUrl, pageUrl),
+    faq: buildAffordableSummerFaqJsonLd(),
+    breadcrumb: buildAffordableSummerBreadcrumbJsonLd(baseUrl, resourcesUrl, pageUrl),
+  }
+}

--- a/src/lib/schema/bulletin-jsonld.ts
+++ b/src/lib/schema/bulletin-jsonld.ts
@@ -1,0 +1,27 @@
+import { BULLETIN_COPY, BULLETIN_DESCRIPTION, BULLETIN_PATH } from '@/data/bulletin-copy'
+import { generateBreadcrumbSchema } from '@/lib/seo/structuredData'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+
+export function buildBulletinPageGraphSchema(baseUrl: string, locale: string) {
+  const pageUrl = absoluteSiteUrl(BULLETIN_PATH, locale, baseUrl)
+
+  const webPage = {
+    '@type': 'WebPage',
+    '@id': `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: BULLETIN_COPY.hero.h1,
+    description: BULLETIN_DESCRIPTION,
+    isPartOf: { '@type': 'WebSite', url: baseUrl, name: 'GrowWise School' },
+  }
+
+  const breadcrumbPage = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: 'GrowWise Bulletin', url: pageUrl },
+  ])
+  const breadcrumbList = { ...breadcrumbPage, '@id': `${pageUrl}#breadcrumb` }
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [webPage, breadcrumbList],
+  }
+}

--- a/src/lib/seo/__tests__/metadata-length-limits.test.ts
+++ b/src/lib/seo/__tests__/metadata-length-limits.test.ts
@@ -102,6 +102,7 @@ describe('Metadata length limits — TC-05 / TC-06', () => {
       '/resources/summer-slide-prevention',
       '/resources/khan-academy-summer-doesnt-work',
       '/resources/summer-academic-program-checklist',
+      '/resources/affordable-summer-academic-programs-dublin-ca',
       '/resources/im1-summer-prep-dublin-ca',
       '/resources/summer-writing-program-dublin-ca',
     ] as const)('title + description for %s', (path) => {

--- a/src/lib/seo/__tests__/seo-jsonld-route-audit.test.ts
+++ b/src/lib/seo/__tests__/seo-jsonld-route-audit.test.ts
@@ -10,6 +10,7 @@ import { buildCarelessMathMistakesPageGraphSchema } from '@/lib/schema/careless-
 import { buildPythonVsScratchPageGraphSchema } from '@/lib/schema/python-vs-scratch-jsonld'
 import { buildDublinCaPageGraphSchema } from '@/lib/schema/dublin-ca-local-business-jsonld'
 import { buildFromNextdoorPageGraphSchema } from '@/lib/schema/from-nextdoor-jsonld'
+import { buildBulletinPageGraphSchema } from '@/lib/schema/bulletin-jsonld'
 import { buildTutoringDublinCaArticleGraphSchema } from '@/lib/schema/tutoring-dublin-ca-jsonld'
 import { buildHomeworkIndependencePageGraphSchema } from '@/lib/schema/homework-independence-jsonld'
 import { buildWhenToStartSatPrepPageGraphSchema } from '@/lib/schema/when-to-start-sat-prep-jsonld'
@@ -78,6 +79,10 @@ const ROUTE_JSON_LD_AUDIT: Array<{ route: string; schemas: unknown[] }> = [
   {
     route: '/from-nextdoor',
     schemas: [buildFromNextdoorPageGraphSchema(BASE, LOCALE)],
+  },
+  {
+    route: '/bulletin',
+    schemas: [buildBulletinPageGraphSchema(BASE, LOCALE)],
   },
   {
     route: '/resources/tutoring-dublin-ca',

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -58,6 +58,16 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
     image: '/og-image.jpg',
   },
 
+  '/bulletin': {
+    title: "How to Support Your K–12 Child's Learning | GrowWise Bulletin",
+    description:
+      "What I learn teaching students every day, I share with you. Every Tuesday, Thursday and Saturday. Free. Why this works for both:",
+    keywords:
+      'GrowWise newsletter, parent education tips, K-12 tutoring updates, Dublin tutoring newsletter, student learning insights',
+    path: '/bulletin',
+    image: '/og-image.jpg',
+  },
+
   '/dublin-ca': {
     title: 'K-12 Tutoring & Coding Classes in Dublin, CA | GrowWise',
     description:
@@ -475,6 +485,16 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
     keywords:
       'summer academic program, summer school, summer tutoring program, summer math camp, summer reading program, best summer academic program, summer learning programs, program evaluation, class size summer camp, summer curriculum',
     path: '/resources/summer-academic-program-checklist',
+    type: 'article',
+  },
+
+  '/resources/affordable-summer-academic-programs-dublin-ca': {
+    title: 'Affordable Summer Programs Dublin CA | Parent Guide',
+    description:
+      'Compare summer academic programs in Dublin, CA and learn how to evaluate true value based on class size, outcomes, structure, and skill-building.',
+    keywords:
+      'affordable summer programs Dublin CA, academic summer camp Dublin Pleasanton, summer academic programs Tri-Valley, summer tutoring Dublin CA, affordable summer academic programs, summer camp value Dublin, Tri-Valley summer programs',
+    path: '/resources/affordable-summer-academic-programs-dublin-ca',
     type: 'article',
   },
 

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -49,6 +49,7 @@ const corePages: SitemapEntry[] = [
   { path: '/contact', priority: 0.8, changefreq: 'monthly' },
   { path: '/dublin-ca', priority: 0.9, changefreq: 'monthly' },
   { path: '/from-nextdoor', priority: 0.9, changefreq: 'monthly' },
+  { path: '/bulletin', priority: 0.85, changefreq: 'monthly' },
   { path: '/enroll', priority: 0.85, changefreq: 'monthly' },
   { path: '/enroll-academic', priority: 0.9, changefreq: 'monthly' },
   { path: '/book-assessment', priority: 0.9, changefreq: 'monthly' },


### PR DESCRIPTION
## Summary
- Adds `/bulletin` landing page with email signup (Brevo list), welcome email (Brevo + SMTP fallback), JSON-LD, sitemap/metadata, and mobile-validated layout.
- Cross-links bulletin ↔ resources hub (CTA on all resource articles, featured guides on bulletin, hub promo strip).
- Adds **Summer Learning** and **STEM** filters on `/resources`; retags existing summer and coding guides.
- Publishes Article 12: `/resources/affordable-summer-academic-programs-dublin-ca` with SEO/AEO copy, FAQ schema, breadcrumbs, and reciprocal internal links.

## Deploy notes
Set in Vercel (production):
```
BREVO_LIST_BULLETIN=25
```

## Test plan
- [ ] Visit `/bulletin` — hero, subscribe form, featured guides, Contact Anshika CTA → `/contact`
- [ ] Submit bulletin signup with valid email — success state; contact added to Brevo list 25; welcome email received
- [ ] Visit `/resources` — filter by **Summer Learning** (7 guides) and **STEM**
- [ ] Open `/resources/affordable-summer-academic-programs-dublin-ca` — meta, FAQs, JSON-LD (Article + FAQPage + BreadcrumbList)
- [ ] Open any resource article — bulletin CTA strip renders; links to `/bulletin`
- [ ] `npm test -- --testPathPattern="bulletin|affordable-summer|resources-hub-categories"`

Made with [Cursor](https://cursor.com)