### PR TITLE
Add Why GrowWise page + grades resource + fix stale E2E

### DIFF
--- a/e2e/specs/seo-layout-headings.spec.ts
+++ b/e2e/specs/seo-layout-headings.spec.ts
@@ -35,7 +35,7 @@ test.describe('SEO — headings & landmarks (TC-01 / TC-04 / TC-08)', { tag: '@n
     await page.goto(localePath('/academic/math'));
     await expect(page.locator('main h1')).toHaveCount(1);
     await expect(page.locator('main h1')).toHaveText(
-      'K-12 Math Tutoring in Dublin, CA',
+      "Find the right math program for your child's grade and goal.",
     );
 
     await page.goto(localePath('/academic/english'));

--- a/public/api/mock/en/footer.json
+++ b/public/api/mock/en/footer.json
@@ -53,6 +53,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "About GrowWise", "href": "/about", "active": true },
+        { "label": "Why GrowWise", "href": "/why-growwise", "active": true },
         { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Trusted by Dublin Neighbors", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },

--- a/public/api/mock/es/footer.json
+++ b/public/api/mock/es/footer.json
@@ -43,6 +43,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "Acerca de GrowWise", "href": "/about", "active": true },
+        { "label": "Por Qué GrowWise", "href": "/why-growwise", "active": true },
         { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Recomendado en Nextdoor", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },

--- a/public/api/mock/hi/footer.json
+++ b/public/api/mock/hi/footer.json
@@ -43,6 +43,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "About GrowWise", "href": "/about", "active": true },
+        { "label": "GrowWise क्यों चुनें", "href": "/why-growwise", "active": true },
         { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Trusted by Dublin Neighbors", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },

--- a/public/api/mock/zh/footer.json
+++ b/public/api/mock/zh/footer.json
@@ -43,6 +43,7 @@
         { "label": "Book Free Assessment →", "href": "/book-assessment", "active": true, "highlight": true },
         { "label": "Free Diagnostic Tool →", "href": "/self-check", "active": true, "highlight": true },
         { "label": "关于 GrowWise", "href": "/about", "active": true },
+        { "label": "为什么选择 GrowWise", "href": "/why-growwise", "active": true },
         { "label": "GrowWise Bulletin", "href": "/bulletin", "active": true },
         { "label": "Dublin 邻里推荐", "href": "/from-nextdoor", "active": true },
         { "label": "Blog", "href": "/growwise-blogs", "active": true },

--- a/src/app/[locale]/resources/why-grades-hide-learning-gaps/layout.tsx
+++ b/src/app/[locale]/resources/why-grades-hide-learning-gaps/layout.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next'
+import {
+  WHY_GRADES_DESCRIPTION,
+  WHY_GRADES_META_TITLE,
+  WHY_GRADES_PATH,
+} from '@/data/resources/why-grades-hide-learning-gaps-copy'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+import { buildWhyGradesHideLearningGapsPageGraphSchema } from '@/lib/schema/why-grades-hide-learning-gaps-jsonld'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const metadata = generateMetadataFromPath(WHY_GRADES_PATH, locale)
+  return (
+    metadata ?? {
+      title: WHY_GRADES_META_TITLE,
+      description: WHY_GRADES_DESCRIPTION,
+    }
+  )
+}
+
+export default async function WhyGradesHideLearningGapsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+  const graphSchema = buildWhyGradesHideLearningGapsPageGraphSchema(baseUrl, locale)
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(graphSchema) }} />
+      {children}
+    </>
+  )
+}

--- a/src/app/[locale]/resources/why-grades-hide-learning-gaps/page.tsx
+++ b/src/app/[locale]/resources/why-grades-hide-learning-gaps/page.tsx
@@ -1,0 +1,5 @@
+import { WhyGradesHideLearningGapsPage } from '@/components/resources/WhyGradesHideLearningGapsPage'
+
+export default function WhyGradesHideLearningGapsResourcePage() {
+  return <WhyGradesHideLearningGapsPage />
+}

--- a/src/app/[locale]/why-growwise/layout.tsx
+++ b/src/app/[locale]/why-growwise/layout.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next'
+import {
+  WHY_GROWWISE_DESCRIPTION,
+  WHY_GROWWISE_META_TITLE,
+  WHY_GROWWISE_PATH,
+} from '@/data/resources/why-growwise-copy'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+import { buildWhyGrowWisePageGraphSchema } from '@/lib/schema/why-growwise-jsonld'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const metadata = generateMetadataFromPath(WHY_GROWWISE_PATH, locale)
+  return (
+    metadata ?? {
+      title: WHY_GROWWISE_META_TITLE,
+      description: WHY_GROWWISE_DESCRIPTION,
+    }
+  )
+}
+
+export default async function WhyGrowWiseLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
+  const graphSchema = buildWhyGrowWisePageGraphSchema(baseUrl, locale)
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(graphSchema) }} />
+      {children}
+    </>
+  )
+}

--- a/src/app/[locale]/why-growwise/page.tsx
+++ b/src/app/[locale]/why-growwise/page.tsx
@@ -1,0 +1,5 @@
+import { WhyGrowWisePage } from '@/components/resources/WhyGrowWisePage'
+
+export default function Page() {
+  return <WhyGrowWisePage />
+}

--- a/src/components/resources/WhyGradesHideLearningGapsPage.tsx
+++ b/src/components/resources/WhyGradesHideLearningGapsPage.tsx
@@ -1,0 +1,330 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft, GraduationCap } from 'lucide-react'
+import { useLocale } from 'next-intl'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { Button } from '@/components/ui/button'
+import { ResourceBulletinCta } from '@/components/resources/ResourceBulletinCta'
+import {
+  WHY_GRADES_CTA,
+  WHY_GRADES_FAQS,
+  WHY_GRADES_HERO,
+  WHY_GRADES_RELATED,
+} from '@/data/resources/why-grades-hide-learning-gaps-copy'
+import { RESOURCES_PATH } from '@/data/resources-hub'
+import { getDefaultOpenFaqValues } from '@/lib/faq-accordion'
+import { publicPath } from '@/lib/publicPath'
+import { cn } from '@/lib/utils'
+
+const sectionClass = 'mx-auto max-w-3xl px-4 sm:px-6'
+const h2Class = 'font-heading text-2xl font-bold text-[#1F396D] sm:text-3xl'
+const bodyClass = 'text-base leading-relaxed text-slate-700 sm:text-lg'
+
+export function WhyGradesHideLearningGapsPage() {
+  const locale = useLocale()
+  const resourcesHref = publicPath(RESOURCES_PATH, locale)
+  const selfCheckHref = publicPath('/self-check', locale)
+  const bookAssessmentHref = publicPath('/book-assessment', locale)
+  const mathCoursesHref = publicPath('/academic/math', locale)
+  const defaultOpenFaqs = getDefaultOpenFaqValues(WHY_GRADES_FAQS.length, (idx) => `why-grades-faq-${idx}`)
+
+  return (
+    <main data-why-grades-hide-learning-gaps className="min-h-screen bg-background font-sans">
+      <section
+        className="border-b border-slate-200/80 bg-slate-50 py-10 sm:py-14"
+        aria-labelledby="why-grades-hero-title"
+      >
+        <div className={cn(sectionClass, 'max-w-4xl')}>
+          <Link
+            href={resourcesHref}
+            className="inline-flex items-center text-sm font-medium text-slate-600 transition-colors hover:text-[#1F396D]"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+            Back to Parent Guides
+          </Link>
+          <span className="mt-6 inline-flex rounded-full bg-[#1F396D]/10 px-3 py-1 text-[11px] font-bold uppercase tracking-wide text-[#1F396D] ring-1 ring-[#1F396D]/15">
+            {WHY_GRADES_HERO.categoryLabel}
+          </span>
+          <h1
+            id="why-grades-hero-title"
+            className="font-heading mt-4 text-3xl font-bold leading-tight text-[#1F396D] sm:text-4xl md:text-[2.5rem]"
+          >
+            {WHY_GRADES_HERO.h1}
+          </h1>
+          <p className="mt-4 text-sm font-medium text-slate-500">{WHY_GRADES_HERO.meta}</p>
+        </div>
+      </section>
+
+      <article className="py-10 sm:py-14">
+        <div className={sectionClass}>
+
+          {/* Opening */}
+          <div className="space-y-6">
+            <p className={cn(bodyClass, 'text-lg font-medium text-slate-800')}>
+              Your child brought home an A.
+            </p>
+            <p className={bodyClass}>
+              You felt relieved. The teacher moved on. The unit ended.
+            </p>
+            <p className={bodyClass}>The gap is still there.</p>
+          </div>
+
+          {/* Section 1 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>What does a school grade actually measure?</h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>
+              A grade measures performance on a specific set of questions, on a specific day, under specific conditions.
+              It is not a measurement of understanding — and the difference between those two things grows more
+              significant every year your child moves through school.
+            </p>
+            <p className={bodyClass}>
+              A student can score an A on a fractions test in May and still be unable to apply fraction logic to a ratio
+              problem in September. The procedure was memorized correctly. The understanding was not built. The grade
+              reported mastery. The grade was wrong.
+            </p>
+          </div>
+
+          {/* Section 2 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>Can a student get good grades but still have learning gaps?</h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>
+              Yes — and it is more common than most parents expect. At GrowWise, we see this pattern consistently: a
+              student who scores well on assessments arrives at the next unit or the next grade year unable to connect
+              the prior material to new concepts. The grade said they were ready. The diagnostic tells a different story.
+            </p>
+            <p className={bodyClass}>
+              This is not a failure of the student or the teacher. Grades are designed to report performance at a moment
+              in time. They are not designed to measure whether understanding will hold when the curriculum moves forward
+              and the context changes.
+            </p>
+          </div>
+
+          {/* Section 3 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>Why do grades fail to show real understanding?</h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>There are three structural reasons grades misreport mastery.</p>
+            <div className="space-y-6">
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+                <h3 className="font-heading text-xl font-bold text-[#1F396D]">Most tests reward procedure</h3>
+                <p className="mt-3 text-slate-700">
+                  A student who has memorized a method can execute it correctly without understanding why it works. That
+                  execution earns full marks — and leaves the conceptual gap completely invisible.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+                <h3 className="font-heading text-xl font-bold text-[#1F396D]">Classroom conditions are consistent</h3>
+                <p className="mt-3 text-slate-700">
+                  A student takes every test in the same environment, with the same teacher, after studying the same
+                  material. That consistency suppresses errors that appear when the context shifts — which is exactly
+                  what happens when the next unit begins.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+                <h3 className="font-heading text-xl font-bold text-[#1F396D]">Grades are single data points</h3>
+                <p className="mt-3 text-slate-700">
+                  One test on one day. A student who was slightly unwell, slightly distracted, or slightly lucky
+                  produces a grade that does not represent their actual skill level. Most academic decisions — program
+                  placement, promotion, enrichment — are made on the basis of these single data points.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Section 4 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>What are the signs a grade is hiding a learning gap?</h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>Three signs that a grade is reporting performance rather than understanding:</p>
+            <ul className="list-disc space-y-4 pl-6 text-slate-700">
+              <li className={bodyClass}>
+                <strong>The child cannot explain it.</strong> Ask your child to teach you the concept they just tested
+                on. A student who truly understands a concept can explain it simply. A student who memorized a procedure
+                will describe steps — but cannot tell you why those steps work or what happens if the problem looks
+                slightly different.
+              </li>
+              <li className={bodyClass}>
+                <strong>The next unit feels disconnected.</strong> Math and science are cumulative. Genuine mastery of
+                Unit 3 makes Unit 4 manageable. Performed mastery — where the procedure was memorized but not
+                understood — makes Unit 4 confusing in ways the student cannot locate or explain.
+              </li>
+              <li className={bodyClass}>
+                <strong>The same concept fails in a different context.</strong> Give your child the same mathematical
+                concept framed differently than how it appeared on the test. True understanding transfers to new
+                contexts. A memorized procedure does not.
+              </li>
+            </ul>
+          </div>
+
+          {/* Section 5 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>Why does this matter more in middle school and high school?</h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>
+              In Grades 1 through 5, the curriculum repeats and reinforces core concepts frequently. A fragile
+              understanding of fractions in Grade 4 is likely to be retaught in Grade 5. The gap can hide.
+            </p>
+            <p className={bodyClass}>
+              From Grade 6 onward, the curriculum assumes mastery and builds on it. Integrated Math 1 assumes
+              proportional reasoning is solid. AP Calculus assumes algebraic manipulation is automatic. Each course adds
+              a layer. A fragile foundation in an earlier layer does not disappear — it becomes load-bearing.
+            </p>
+            <p className={bodyClass}>
+              At GrowWise, the students who arrive most behind are rarely students who failed. They are students who
+              passed — but whose passing grades masked gaps that compounded quietly across two or three grade years
+              before they became impossible to ignore.
+            </p>
+          </div>
+
+          {/* Section 6 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>
+            What does GrowWise look for that grades do not show?
+          </h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>
+              The GrowWise diagnostic assessment is designed to find exactly the gap that grades miss. Rather than asking
+              whether a student can produce a correct answer, the assessment examines where in the problem the
+              student&apos;s understanding actually holds and where it breaks down.
+            </p>
+            <p className={bodyClass}>
+              The assessment identifies four specific points of failure that grades do not capture:
+            </p>
+            <ul className="list-disc space-y-2 pl-6 text-slate-700">
+              <li>Whether the student can set up a problem correctly from a word description</li>
+              <li>Whether they understand <em>why</em> a procedure works or only <em>that</em> it works</li>
+              <li>Whether the correct answer transfers to a variation of the same concept</li>
+              <li>Whether the student can check their own work using a different method</li>
+            </ul>
+            <p className={bodyClass}>
+              A student who can do all four has genuine mastery. A student who can only produce a correct answer through
+              memorized procedure has a gap — regardless of what their report card says. Our{' '}
+              <Link
+                href={mathCoursesHref}
+                className="font-semibold text-[#1F396D] underline-offset-2 hover:underline"
+              >
+                math tutoring programs
+              </Link>{' '}
+              are built around this diagnostic-first model.
+            </p>
+          </div>
+
+          {/* Section 7 */}
+          <h2 className={cn(h2Class, 'mt-12 mb-4')}>How do I know if my child&apos;s grades are hiding a gap?</h2>
+          <div className="space-y-4">
+            <p className={bodyClass}>
+              The most direct way is the explanation test: ask your child to explain the last concept they were graded
+              on, in plain language, to someone who does not already know it. This test cannot be passed through
+              memorization. It requires actual understanding.
+            </p>
+            <p className={bodyClass}>
+              If the explanation breaks down — if they can describe steps but not reasons, if they can do it but cannot
+              say why — that is the gap. The grade reported something different. The gap is real.
+            </p>
+            <p className={bodyClass}>
+              A structured diagnostic, like the free assessment GrowWise offers, maps this precisely across an entire
+              subject area — showing not just where the gap exists but how far back it starts and how it connects to
+              current material.
+            </p>
+          </div>
+
+          {/* Inline CTA */}
+          <section
+            className="mt-12 rounded-2xl border border-[#1F396D]/15 bg-[#1F396D]/5 p-6 sm:p-8"
+            aria-labelledby="why-grades-cta"
+          >
+            <h2 id="why-grades-cta" className={cn(h2Class, 'text-2xl')}>
+              {WHY_GRADES_CTA.heading}
+            </h2>
+            <p className="mt-4 text-slate-700">{WHY_GRADES_CTA.subtext}</p>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <Button
+                asChild
+                className="min-h-[48px] rounded-lg bg-[#F16112] px-6 font-semibold text-white hover:bg-[#d54f0a]"
+              >
+                <Link href={selfCheckHref}>{WHY_GRADES_CTA.selfCheckLabel}</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="min-h-[48px] rounded-lg border-[#1F396D] px-6 font-semibold text-[#1F396D] hover:bg-[#1F396D]/5"
+              >
+                <Link href={bookAssessmentHref}>{WHY_GRADES_CTA.assessmentLabel}</Link>
+              </Button>
+            </div>
+          </section>
+
+          {/* FAQ */}
+          <section
+            className="mt-12 rounded-2xl border border-slate-200 bg-white px-4 py-10 shadow-sm sm:px-6"
+            aria-labelledby="why-grades-faq-heading"
+          >
+            <div className="mb-8 text-center">
+              <h2 id="why-grades-faq-heading" className={cn(h2Class, 'text-2xl')}>
+                Frequently Asked Questions
+              </h2>
+              <p className="mt-2 text-slate-600">Common questions about grades and learning gaps</p>
+            </div>
+            <Accordion type="multiple" className="space-y-4" defaultValue={defaultOpenFaqs}>
+              {WHY_GRADES_FAQS.map((faq, i) => (
+                <AccordionItem
+                  key={faq.question}
+                  value={`why-grades-faq-${i}`}
+                  className="rounded-lg border border-slate-200 bg-white shadow-sm transition-shadow hover:shadow-md"
+                >
+                  <AccordionTrigger className="px-4 py-4 text-left text-base hover:no-underline sm:px-6 sm:text-lg">
+                    <div className="flex items-center gap-3 pr-2">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#F16112]/10">
+                        <GraduationCap className="h-4 w-4 text-[#F16112]" aria-hidden />
+                      </div>
+                      <span className="font-semibold text-slate-900">{faq.question}</span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="px-4 pb-4 text-slate-600 sm:px-6 sm:text-base">
+                    {faq.answer}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </section>
+
+          <ResourceBulletinCta className="mt-12" />
+
+          {/* Related */}
+          <section className="mt-12 border-t border-slate-200 pt-10" aria-labelledby="why-grades-related">
+            <h2 id="why-grades-related" className="font-heading text-lg font-bold text-[#1F396D]">
+              Related guides &amp; programs
+            </h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {WHY_GRADES_RELATED.map((related) => {
+                const relatedHref = publicPath(related.href, locale)
+                return (
+                  <article
+                    key={related.href}
+                    className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
+                  >
+                    <h3 className="font-heading text-lg font-bold text-[#1F396D]">
+                      <Link href={relatedHref} className="hover:text-[#F16112] hover:underline">
+                        {related.title}
+                      </Link>
+                    </h3>
+                    <p className="mt-2 text-sm text-slate-600">{related.description}</p>
+                    <Link
+                      href={relatedHref}
+                      className="mt-3 inline-flex text-sm font-semibold text-[#F16112] hover:text-[#C45A1A] hover:underline"
+                    >
+                      Read more →
+                    </Link>
+                  </article>
+                )
+              })}
+            </div>
+          </section>
+
+        </div>
+      </article>
+    </main>
+  )
+}

--- a/src/components/resources/WhyGrowWisePage.tsx
+++ b/src/components/resources/WhyGrowWisePage.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import Link from 'next/link'
+import { useLocale } from 'next-intl'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { BookAssessmentLink } from '@/components/marketing/BookAssessmentLink'
+import { ResourceBulletinCta } from '@/components/resources/ResourceBulletinCta'
+import {
+  WHY_GROWWISE_CTA,
+  WHY_GROWWISE_COMPARISON_ROWS,
+  WHY_GROWWISE_FAQS,
+  WHY_GROWWISE_HERO,
+  WHY_GROWWISE_SECTIONS,
+} from '@/data/resources/why-growwise-copy'
+import { getDefaultOpenFaqValues } from '@/lib/faq-accordion'
+import { publicPath } from '@/lib/publicPath'
+import { cn } from '@/lib/utils'
+
+const bodyClass = 'text-base leading-relaxed text-slate-700 sm:text-lg'
+
+export function WhyGrowWisePage() {
+  const locale = useLocale()
+  const selfCheckHref = publicPath('/self-check', locale)
+  const defaultOpenFaqs = getDefaultOpenFaqValues(WHY_GROWWISE_FAQS.length, (idx) => `why-growwise-faq-${idx}`)
+
+  return (
+    <main data-why-growwise className="min-h-screen bg-white font-sans">
+      {/* Hero Section */}
+      <section className="border-b border-slate-200 bg-slate-50 py-14 md:py-20" aria-labelledby="why-growwise-hero-title">
+        <div className="mx-auto max-w-[1100px] px-5 md:px-12">
+          <h1
+            id="why-growwise-hero-title"
+            className="font-heading text-3xl font-bold leading-tight text-[#1F396D] sm:text-4xl md:text-[2.5rem]"
+          >
+            {WHY_GROWWISE_HERO.h1}
+          </h1>
+          <p className={cn(bodyClass, 'mt-6 text-lg font-medium text-slate-800')}>
+            {WHY_GROWWISE_HERO.opening}
+          </p>
+        </div>
+      </section>
+
+      {/* Main Content */}
+      <article className="border-b border-slate-200 py-14 md:py-20">
+        <div className="mx-auto max-w-[1100px] px-5 md:px-12">
+          {/* Sections */}
+          {WHY_GROWWISE_SECTIONS.map((section, idx) => (
+            <div key={idx} className={idx > 0 ? 'mt-12' : ''}>
+              <h2 className="font-heading text-2xl font-bold tracking-tight text-[#1F396D] md:text-3xl mb-4">
+                {section.h2}
+              </h2>
+              <div className="space-y-4">
+                {Array.isArray(section.body) ? (
+                  section.body.map((paragraph, pIdx) => (
+                    <p
+                      key={pIdx}
+                      className={bodyClass}
+                      dangerouslySetInnerHTML={{
+                        __html: paragraph
+                          .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+                          .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                          .replace(/^- /gm, ''),
+                      }}
+                    />
+                  ))
+                ) : (
+                  <p className={bodyClass}>{section.body}</p>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {/* Comparison Table */}
+          <div className="mt-12">
+            <h2 className="font-heading text-2xl font-bold tracking-tight text-[#1F396D] md:text-3xl mb-6">
+              The difference parents notice first
+            </h2>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="border-b-2 border-slate-300">
+                    <th className="bg-slate-100 px-4 py-3 text-left text-sm font-bold text-slate-900">
+                      &nbsp;
+                    </th>
+                    <th className="bg-slate-100 px-4 py-3 text-left text-sm font-bold text-slate-900">
+                      Worksheet-Based Programs
+                    </th>
+                    <th className="bg-slate-100 px-4 py-3 text-left text-sm font-bold text-slate-900">
+                      Drop-In Tutoring Centers
+                    </th>
+                    <th className="bg-[#1D9E75]/10 px-4 py-3 text-left text-sm font-bold text-[#1D9E75]">
+                      GrowWise
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {WHY_GROWWISE_COMPARISON_ROWS.map((row, idx) => (
+                    <tr
+                      key={idx}
+                      className={idx % 2 === 0 ? 'bg-white' : 'bg-slate-50'}
+                    >
+                      <td className="border-b border-slate-200 px-4 py-4 text-sm font-semibold text-slate-900">
+                        {row.label}
+                      </td>
+                      <td className="border-b border-slate-200 px-4 py-4 text-sm text-slate-700">
+                        {row.worksheetPrograms}
+                      </td>
+                      <td className="border-b border-slate-200 px-4 py-4 text-sm text-slate-700">
+                        {row.dropInCenters}
+                      </td>
+                      <td className="border-b border-slate-200 px-4 py-4 text-sm font-semibold text-[#1D9E75]">
+                        {row.growwise}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* FAQ Section */}
+          <div className="mt-12">
+            <h2 className="font-heading text-2xl font-bold tracking-tight text-[#1F396D] md:text-3xl mb-6">
+              Common questions about GrowWise programs
+            </h2>
+            <Accordion type="single" collapsible className="space-y-2">
+              {WHY_GROWWISE_FAQS.map((faq, idx) => (
+                <AccordionItem
+                  key={idx}
+                  value={`why-growwise-faq-${idx}`}
+                  className="border border-slate-200 bg-white"
+                  defaultOpen={defaultOpenFaqs.includes(`why-growwise-faq-${idx}`)}
+                >
+                  <AccordionTrigger className="px-4 py-4 hover:no-underline">
+                    <span className="text-left font-semibold text-slate-900 text-lg">
+                      {faq.question}
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent className="border-t border-slate-200 px-4 py-4 text-slate-700">
+                    {faq.answer}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </div>
+      </article>
+
+      {/* CTA Block */}
+      <section className="bg-[#1F396D] py-16 md:py-20" aria-labelledby="why-growwise-cta-heading">
+        <div className="mx-auto max-w-[800px] px-5 text-center md:px-12">
+          <h2
+            id="why-growwise-cta-heading"
+            className="font-heading text-2xl font-bold text-white md:text-3xl"
+          >
+            {WHY_GROWWISE_CTA.h2}
+          </h2>
+          <p className="mt-4 text-sm leading-relaxed text-zinc-200 sm:text-base">{WHY_GROWWISE_CTA.body}</p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap">
+            <Link
+              href={selfCheckHref}
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#F16112] px-6 py-3 text-sm font-semibold text-white hover:bg-[#d54f0a]"
+            >
+              {WHY_GROWWISE_CTA.buttonLabel1}
+            </Link>
+            <BookAssessmentLink
+              location="why-growwise-cta"
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full border-2 border-white/80 px-6 py-3 text-sm font-semibold text-white hover:bg-white/10"
+            >
+              {WHY_GROWWISE_CTA.buttonLabel2}
+            </BookAssessmentLink>
+          </div>
+        </div>
+      </section>
+
+      {/* Newsletter CTA */}
+      <ResourceBulletinCta />
+    </main>
+  )
+}

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -289,7 +289,15 @@ export default function About() {
               Explore K-12 tutoring &amp; coding classes at our Dublin center →
             </Link>
           </p>
-          
+          <p className="mb-8">
+            <Link
+              href={publicPath('/why-growwise', locale)}
+              className="text-base font-semibold text-[#F1894F] underline-offset-4 hover:text-[#ffb380] hover:underline sm:text-lg"
+            >
+              Why families choose GrowWise over traditional tutoring programs →
+            </Link>
+          </p>
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12">
             <div className="flex items-center justify-center gap-3">
               <MapPin className="w-6 h-6 text-[#F1894F]" />

--- a/src/data/resources-hub.ts
+++ b/src/data/resources-hub.ts
@@ -51,6 +51,16 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
     href: '/resources/reading-fluency-vs-comprehension',
   },
   {
+    id: 'why-grades-hide-learning-gaps',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: "Why Your Child's A Grade May Be Hiding a Learning Gap",
+    description:
+      "A grade measures performance on one day — not understanding. Three signs your child's grade is hiding a gap, and what to do about it.",
+    readTime: '5 min read',
+    href: '/resources/why-grades-hide-learning-gaps',
+  },
+  {
     id: 'careless-math-mistakes',
     category: 'academic',
     categoryLabel: 'ACADEMIC',

--- a/src/data/resources/index.ts
+++ b/src/data/resources/index.ts
@@ -1,5 +1,6 @@
 import { AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH } from '@/data/resources/affordable-summer-academic-programs-dublin-ca'
 import { CARELESS_MATH_MISTAKES_PATH } from '@/data/resources/careless-math-mistakes-copy'
+import { WHY_GRADES_PATH } from '@/data/resources/why-grades-hide-learning-gaps-copy'
 import { HOMEWORK_INDEPENDENCE_PATH } from '@/data/resources/homework-independence-copy'
 import { IM1_SUMMER_PREP_DUBLIN_CA_PATH } from '@/data/resources/im1-summer-prep-dublin-ca'
 import { KHAN_ACADEMY_SUMMER_DOESNT_WORK_PATH } from '@/data/resources/khan-academy-summer-doesnt-work'
@@ -29,6 +30,7 @@ export const RESOURCE_ARTICLE_PATHS = [
   AFFORDABLE_SUMMER_ACADEMIC_PROGRAMS_DUBLIN_CA_PATH,
   SUMMER_WRITING_PROGRAM_DUBLIN_CA_PATH,
   TUTORING_DUBLIN_CA_PATH,
+  WHY_GRADES_PATH,
 ] as const
 
 export type ResourceArticlePath = (typeof RESOURCE_ARTICLE_PATHS)[number]

--- a/src/data/resources/why-grades-hide-learning-gaps-copy.ts
+++ b/src/data/resources/why-grades-hide-learning-gaps-copy.ts
@@ -1,0 +1,78 @@
+export const WHY_GRADES_PATH = '/resources/why-grades-hide-learning-gaps' as const
+
+export const WHY_GRADES_TITLE =
+  "Why Your Child's A Grade May Be Hiding a Learning Gap"
+
+export const WHY_GRADES_META_TITLE =
+  "Why Your Child's A Grade May Be Hiding a Learning Gap | GrowWise"
+
+export const WHY_GRADES_DESCRIPTION =
+  "A grade measures performance on one day — not understanding. Here are three signs your child's grade is hiding a gap, and what to do about it."
+
+export const WHY_GRADES_KEYWORDS =
+  "learning gap grades, does good grade mean ready for next grade, child good grades but struggling, grades hide learning gaps, academic gap assessment, diagnostic vs grade"
+
+export const WHY_GRADES_HERO = {
+  categoryLabel: 'ACADEMIC',
+  h1: WHY_GRADES_TITLE,
+  meta: '5 min read · By Anshika, Academic Director, GrowWise School',
+} as const
+
+export const WHY_GRADES_FAQS = [
+  {
+    question: 'Does a good grade mean my child is ready for the next grade?',
+    answer:
+      'Not necessarily. Grade promotion is based on performance, not mastery. A student can pass Grade 5 math and still have fragile number sense that makes Grade 6 material significantly harder than it should be. Readiness requires that the understanding holds when the context changes — not just that the test was passed.',
+  },
+  {
+    question: 'My child does well on homework but not on tests. What does that mean?',
+    answer:
+      'Homework is completed with access to notes, examples, and often a parent nearby. Tests remove all of those supports. A consistent gap between homework performance and test performance usually means the skill has not transferred to independent recall — the understanding is dependent on scaffolding that will not be there in the exam.',
+  },
+  {
+    question: 'How do I find out if my child truly understands what they are being graded on?',
+    answer:
+      'Ask them to teach it to you. Not to show you how they solved it — to explain the concept itself, in their own words, as if you had never seen it. A student who can do this has genuine understanding. A student who can only describe steps has procedural memory. The two feel very similar until you ask this question.',
+  },
+  {
+    question: 'Is a learning gap the same as a learning disability?',
+    answer:
+      'No. A learning gap is a specific area where understanding did not form completely — usually because a concept was introduced too quickly, practiced without enough variation, or built on a prior concept that was also fragile. Learning gaps are correctable with targeted instruction. They are not indicators of a broader learning disability.',
+  },
+  {
+    question: 'What is the difference between a diagnostic assessment and a placement test?',
+    answer:
+      'A placement test finds where a student is relative to a grade-level benchmark. A diagnostic assessment finds where understanding breaks down — which specific concept, which type of problem, which step in the process. Placement tells you the level. Diagnostic tells you the gap. GrowWise uses a diagnostic, not a placement test, because the gap is what determines the instruction.',
+  },
+] as const
+
+export const WHY_GRADES_RELATED = [
+  {
+    title: 'Why Kids Make Careless Math Mistakes on Tests',
+    description: 'Careless mistakes follow specific patterns — and each has a fix. How to identify the real blocker.',
+    href: '/resources/careless-math-mistakes',
+  },
+  {
+    title: 'How to Build Homework Independence',
+    description: 'The system that builds independence in 6–8 weeks — without the fights.',
+    href: '/resources/homework-independence',
+  },
+  {
+    title: 'Math Tutoring Programs — Grades 1–12',
+    description: 'Diagnostic-first small-group math programs for every grade level.',
+    href: '/academic/math',
+  },
+  {
+    title: '5 Things to Evaluate in Summer Academic Programs',
+    description: 'Questions most programs cannot answer — and why that matters.',
+    href: '/resources/summer-academic-program-checklist',
+  },
+] as const
+
+export const WHY_GRADES_CTA = {
+  heading: 'Not sure what the grade is actually reporting?',
+  subtext:
+    "The GrowWise free academic assessment takes 45 minutes and identifies exactly where your child's understanding holds and where it breaks down — mapped against their current school curriculum. No charge. No enrollment commitment.",
+  selfCheckLabel: 'Take the Free 10-Minute Self-Check →',
+  assessmentLabel: 'Book a Free Assessment →',
+} as const

--- a/src/data/resources/why-growwise-copy.ts
+++ b/src/data/resources/why-growwise-copy.ts
@@ -1,0 +1,158 @@
+export const WHY_GROWWISE_PATH = '/why-growwise' as const
+
+export const WHY_GROWWISE_TITLE =
+  'Why Families Choose GrowWise Over Traditional Tutoring Programs'
+
+export const WHY_GROWWISE_META_TITLE =
+  'Why GrowWise | Structured, School-Aligned Programs for Grades 1–12'
+
+export const WHY_GROWWISE_DESCRIPTION =
+  'GrowWise uses a diagnostic-first, 3-level progression model with monthly progress reports and school-aligned curriculum. See how it compares to traditional tutoring programs.'
+
+export const WHY_GROWWISE_KEYWORDS =
+  'tutoring programs, structured tutoring, diagnostic assessment, school-aligned curriculum, diagnostic-first learning, small group tutoring, monthly progress reports, diagnostic learning model'
+
+export const WHY_GROWWISE_HERO = {
+  h1: WHY_GROWWISE_TITLE,
+  opening: `Most tutoring programs start teaching on day one. GrowWise starts with a diagnostic — a structured assessment that identifies exactly where your child's understanding breaks down before a single session is planned. Every program, every level, and every instruction style is built from that starting point.`,
+} as const
+
+export type WhyGrowWiseSection = {
+  h2: string
+  body: string | readonly string[]
+}
+
+export const WHY_GROWWISE_SECTIONS: readonly WhyGrowWiseSection[] = [
+  {
+    h2: 'What most programs get wrong',
+    body: [
+      'Worksheet-based programs move students through fixed packets at a set pace. Drop-in tutoring centers assign work and check answers. Neither approach identifies *why* a student is struggling — only *that* they are.',
+      'The result: parents end up sitting at the kitchen table at 9pm trying to explain concepts the program didn\'t close. The child completes the homework. The gap stays open.',
+      'GrowWise is built around a different principle: a student who understands the material should be able to do their work independently. If they can\'t, the gap hasn\'t been closed — regardless of how many sessions they\'ve attended.',
+    ],
+  },
+  {
+    h2: 'Three levels. Clear milestones. Earned progression.',
+    body: [
+      'For Grades 1–5, every student enters one of three structured levels: **Beginner → Champ → Pro**',
+      'Advancement is earned, not assumed. A student moves to the next level only after reaching 90% or above on a structured 3-month assessment. Students who reach that threshold receive a certificate and a milestone reward — a recognition system that builds genuine confidence, not participation trophies.',
+      'Every level is also personalized to your child\'s learning style. Two students at the Champ level in the same class will receive instruction adapted to how they individually process and retain information.',
+      '**What this means for parents:** You receive a monthly progress report showing exactly which skills were covered, which patterns were corrected, and what the next 30 days will focus on. No guessing. No waiting for the next report card.',
+    ],
+  },
+  {
+    h2: '95% aligned to your child\'s actual school curriculum',
+    body: [
+      'From Grade 6 upward, GrowWise programs are built around what your child\'s school is actually teaching — not a generic national curriculum.',
+      'For DUSD and PUSD students, this means:',
+      '- Math programs aligned 95% to the Integrated Math sequence (IM1, IM2, IM3) your child\'s school follows',
+      '- English programs that shift focus to writing — analytical writing, structured essays, and the skills middle and high school teachers actually grade on',
+      '- Instruction that maps directly to the pacing guide your child\'s teacher is following right now',
+      '**Why this matters:** A student preparing for an IM1 unit test needs support on *that unit*, not a generic algebra review. School alignment means every session has immediate, visible impact on the class your child is actually in.',
+    ],
+  },
+]
+
+export type ComparisonRow = {
+  label: string
+  worksheetPrograms: string
+  dropInCenters: string
+  growwise: string
+}
+
+export const WHY_GROWWISE_COMPARISON_ROWS: readonly ComparisonRow[] = [
+  {
+    label: 'Starting point',
+    worksheetPrograms: 'Fixed curriculum entry',
+    dropInCenters: 'Whatever homework is due',
+    growwise: 'Diagnostic assessment',
+  },
+  {
+    label: 'Class size',
+    worksheetPrograms: '15–20+ students',
+    dropInCenters: 'Open floor',
+    growwise: '6–10 students',
+  },
+  {
+    label: 'Progression',
+    worksheetPrograms: 'Timed packet completion',
+    dropInCenters: 'No defined levels',
+    growwise: '90% mastery required',
+  },
+  {
+    label: 'Milestones',
+    worksheetPrograms: 'None',
+    dropInCenters: 'None',
+    growwise: 'Certificate + reward every level',
+  },
+  {
+    label: 'Curriculum alignment',
+    worksheetPrograms: 'Generic national track',
+    dropInCenters: 'None',
+    growwise: '95% school-aligned (Gr 6+)',
+  },
+  {
+    label: 'Progress visibility',
+    worksheetPrograms: 'None',
+    dropInCenters: 'None',
+    growwise: 'Monthly written report',
+  },
+  {
+    label: 'Student independence',
+    worksheetPrograms: 'Parents often fill the gap',
+    dropInCenters: 'Homework sent home unresolved',
+    growwise: 'Students work independently',
+  },
+]
+
+export type WhyGrowWiseFaq = {
+  question: string
+  answer: string
+}
+
+export const WHY_GROWWISE_FAQS: readonly WhyGrowWiseFaq[] = [
+  {
+    question: 'How is GrowWise different from worksheet-based tutoring programs?',
+    answer:
+      'GrowWise does not use fixed packet progressions or timed worksheets. Every student starts with a diagnostic assessment, is placed in one of three structured levels (Beginner, Champ, or Pro), and advances only after reaching 90% mastery on a 3-month assessment. Instruction is personalized to each student\'s learning style within each level.',
+  },
+  {
+    question: 'How many students are in a GrowWise class?',
+    answer:
+      'GrowWise classes have 6 to 10 students. This size allows instructors to give close individual attention during every session while maintaining the collaborative energy of a group learning environment.',
+  },
+  {
+    question: 'Does GrowWise provide progress reports?',
+    answer:
+      'Yes. Parents receive a written monthly progress report detailing which skills were covered, which mistake patterns were corrected, and what the next 30 days will focus on. Progress is tracked continuously, not only at quarterly assessments.',
+  },
+  {
+    question: 'How does GrowWise align to my child\'s school curriculum?',
+    answer:
+      'For Grade 6 and above, GrowWise math programs are 95% aligned to the Integrated Math sequence used by DUSD and PUSD schools. English programs at this level focus on analytical writing and essay structure — the skills graded at the middle and high school level.',
+  },
+  {
+    question: 'What happens when my child reaches 90% in their GrowWise level?',
+    answer:
+      'Students who reach 90% or above on their 3-month assessment advance to the next program level and receive a certificate and milestone reward. Advancement is earned through demonstrated mastery, not time spent in the program.',
+  },
+  {
+    question: 'How does GrowWise personalize instruction?',
+    answer:
+      'Personalization at GrowWise operates at two levels. First, every student\'s program starts from their diagnostic results — not a generic starting point. Second, within each level, instructors adapt how concepts are taught based on each student\'s learning style. Two students at the same level receive instruction framed differently based on how they individually process information.',
+  },
+  {
+    question: 'Will my child need my help with homework after GrowWise sessions?',
+    answer:
+      'The goal of every GrowWise session is genuine understanding — not completion. If a student consistently needs parent help with work covered in their program, that signals a gap the program hasn\'t closed yet. GrowWise instructors track this and adjust before it becomes a pattern.',
+  },
+]
+
+export const WHY_GROWWISE_CTA = {
+  h2: 'Not sure where your child is right now?',
+  body: 'The free 10-minute Self-Check identifies your child\'s current mistake patterns — the same diagnostic lens GrowWise uses before placing any student.',
+  buttonLabel1: 'Take the Free Self-Check',
+  buttonHref1: '/self-check',
+  buttonLabel2: 'Book a Free 45-Minute Assessment',
+  buttonHref2: '/book-assessment',
+} as const

--- a/src/lib/schema/why-grades-hide-learning-gaps-jsonld.ts
+++ b/src/lib/schema/why-grades-hide-learning-gaps-jsonld.ts
@@ -1,0 +1,38 @@
+import {
+  WHY_GRADES_DESCRIPTION,
+  WHY_GRADES_FAQS,
+  WHY_GRADES_PATH,
+  WHY_GRADES_TITLE,
+} from '@/data/resources/why-grades-hide-learning-gaps-copy'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { generateBreadcrumbSchema, generateFAQPageSchema } from '@/lib/seo/structuredData'
+
+export function buildWhyGradesHideLearningGapsPageGraphSchema(baseUrl: string, locale: string) {
+  const pageUrl = absoluteSiteUrl(WHY_GRADES_PATH, locale, baseUrl)
+
+  const webPage = {
+    '@type': 'WebPage',
+    '@id': `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: WHY_GRADES_TITLE,
+    description: WHY_GRADES_DESCRIPTION,
+    isPartOf: { '@type': 'WebSite', url: baseUrl, name: 'GrowWise School' },
+  }
+
+  const faqPage = {
+    ...generateFAQPageSchema([...WHY_GRADES_FAQS]),
+    '@id': `${pageUrl}#faq`,
+  }
+
+  const breadcrumbPage = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: 'Parent Guides', url: absoluteSiteUrl('/resources', locale, baseUrl) },
+    { name: WHY_GRADES_TITLE, url: pageUrl },
+  ])
+  const breadcrumbList = { ...breadcrumbPage, '@id': `${pageUrl}#breadcrumb` }
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [webPage, faqPage, breadcrumbList],
+  }
+}

--- a/src/lib/schema/why-growwise-jsonld.ts
+++ b/src/lib/schema/why-growwise-jsonld.ts
@@ -1,0 +1,37 @@
+import {
+  WHY_GROWWISE_DESCRIPTION,
+  WHY_GROWWISE_FAQS,
+  WHY_GROWWISE_PATH,
+  WHY_GROWWISE_TITLE,
+} from '@/data/resources/why-growwise-copy'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { generateBreadcrumbSchema, generateFAQPageSchema } from '@/lib/seo/structuredData'
+
+export function buildWhyGrowWisePageGraphSchema(baseUrl: string, locale: string) {
+  const pageUrl = absoluteSiteUrl(WHY_GROWWISE_PATH, locale, baseUrl)
+
+  const webPage = {
+    '@type': 'WebPage',
+    '@id': `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: WHY_GROWWISE_TITLE,
+    description: WHY_GROWWISE_DESCRIPTION,
+    isPartOf: { '@type': 'WebSite', url: baseUrl, name: 'GrowWise School' },
+  }
+
+  const faqPage = {
+    ...generateFAQPageSchema([...WHY_GROWWISE_FAQS]),
+    '@id': `${pageUrl}#faq`,
+  }
+
+  const breadcrumbPage = generateBreadcrumbSchema([
+    { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
+    { name: WHY_GROWWISE_TITLE, url: pageUrl },
+  ])
+  const breadcrumbList = { ...breadcrumbPage, '@id': `${pageUrl}#breadcrumb` }
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [webPage, faqPage, breadcrumbList],
+  }
+}

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -538,6 +538,25 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
     type: 'article',
   },
 
+  '/why-growwise': {
+    title: 'Why GrowWise | Structured, School-Aligned Programs for Grades 1–12',
+    description:
+      'GrowWise uses a diagnostic-first, 3-level progression model with monthly progress reports and school-aligned curriculum. See how it compares to traditional tutoring programs.',
+    keywords:
+      'tutoring programs, structured tutoring, diagnostic assessment, school-aligned curriculum, diagnostic-first learning, small group tutoring, monthly progress reports, diagnostic learning model',
+    path: '/why-growwise',
+  },
+
+  '/resources/why-grades-hide-learning-gaps': {
+    title: "Why Your Child's A Grade May Be Hiding a Learning Gap | GrowWise",
+    description:
+      "A grade measures performance on one day — not understanding. Here are three signs your child's grade is hiding a gap, and what to do about it.",
+    keywords:
+      'learning gap grades, does good grade mean ready for next grade, child good grades but struggling, grades hide learning gaps, academic gap assessment, diagnostic vs grade',
+    path: '/resources/why-grades-hide-learning-gaps',
+    type: 'article',
+  },
+
   '/resources/careless-math-mistakes': {
     title: 'Why Kids Make Careless Math Mistakes on Tests | GrowWise',
     description:

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -45,6 +45,7 @@ export interface SitemapUrl {
 const corePages: SitemapEntry[] = [
   { path: '/', priority: 1.0, changefreq: 'weekly' },
   { path: '/about', priority: 0.9, changefreq: 'monthly' },
+  { path: '/why-growwise', priority: 0.85, changefreq: 'monthly' },
   { path: '/academic', priority: 0.9, changefreq: 'monthly' },
   { path: '/contact', priority: 0.8, changefreq: 'monthly' },
   { path: '/dublin-ca', priority: 0.9, changefreq: 'monthly' },


### PR DESCRIPTION
## Summary

- **New page `/why-growwise`** — marketing comparison page with 3-section body, 7-row comparison table, 7-question FAQ accordion, FAQPage JSON-LD, metadata, sitemap entry, dark navy CTA block
- **New resource `/resources/why-grades-hide-learning-gaps`** — parent guide article with 5 FAQs, JSON-LD, breadcrumbs, related links; added to `RESOURCE_ARTICLE_PATHS` (auto-sitemap) and `RESOURCE_GUIDES` (resources hub)
- **Footer** — "Why GrowWise" link added to Company section across all 4 locale files (en/es/zh/hi)
- **About page** — internal backlink to `/why-growwise` added in Location section
- **Sitemap** — `/why-growwise` added to `corePages` (priority 0.85)
- **Fix E2E TC-04** — `seo-layout-headings.spec.ts` stale H1 assertion for `/academic/math` was causing the nightly CI failure on `dev`

## Test plan

- [ ] `npm run build` passes ✅
- [ ] `npm run lint` 0 new errors ✅
- [ ] 49 SEO/sitemap/hub Jest tests pass ✅
- [ ] Both routes pre-rendered: `/en/why-growwise`, `/en/resources/why-grades-hide-learning-gaps` ✅
- [ ] Footer Company section shows "Why GrowWise" link
- [ ] E2E TC-04 passes with updated math H1 assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)