### PR TITLE
feat(nav): add Elementary School English submenu under Academic

### DIFF
--- a/public/api/mock/en/header.json
+++ b/public/api/mock/en/header.json
@@ -75,7 +75,20 @@
             "description": "Reading, writing, grammar, vocabulary, and comprehension.",
             "icon": "BookOpen",
             "href": "/academic/english",
-            "gradient": "from-[#F16112] to-[#F1894F]"
+            "gradient": "from-[#F16112] to-[#F1894F]",
+            "hasSubmenu": true,
+            "submenuHeaderTitle": "English",
+            "submenuHeaderSubtitle": "Grades 1–12 English programs",
+            "submenuItems": [
+              {
+                "key": "elementary-english",
+                "title": "Elementary School English",
+                "description": "Grades 1–5 reading fluency, vocabulary, grammar, and writing.",
+                "icon": "BookOpen",
+                "href": "/academic/english/elementary",
+                "gradient": "from-[#F16112] to-[#F1894F]"
+              }
+            ]
           },
           {
             "key": "satPrep",

--- a/src/components/layout/Header/__tests__/header-academic-math-nav.test.ts
+++ b/src/components/layout/Header/__tests__/header-academic-math-nav.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import {
   FALLBACK_MENU_ITEMS,
   MATH_GRADE_BAND_NAV_ITEMS,
+  ENGLISH_SUBMENU_NAV_ITEMS,
 } from '@/components/layout/Header/constants';
 import { MATH_COURSE_PATHS } from '@/lib/math-course-paths';
 
@@ -40,13 +41,17 @@ describe('header academic math nested menu', () => {
     ]);
   });
 
-  it('has English as a direct Academic link', () => {
+  it('has English with elementary link in flyout', () => {
     const english = academicItems.find((item) => item.key === 'english');
     expect(english).toMatchObject({
       title: 'English Courses',
       href: MATH_COURSE_PATHS.english,
+      hasSubmenu: true,
     });
-    expect(english?.hasSubmenu).toBeFalsy();
+    expect(english?.submenuItems).toEqual(ENGLISH_SUBMENU_NAV_ITEMS);
+    expect(english?.submenuItems?.map((item) => item.href)).toEqual([
+      MATH_COURSE_PATHS.englishElementary,
+    ]);
   });
 
   it('does not expose duplicate top-level High School Math flyout', () => {
@@ -81,6 +86,10 @@ describe('header academic math nested menu', () => {
       MATH_COURSE_PATHS.elementary,
       MATH_COURSE_PATHS.middleSchool,
       MATH_COURSE_PATHS.highSchool,
+    ]);
+    const apiEnglish = apiItems.find((item) => item.key === 'english');
+    expect(apiEnglish?.submenuItems?.map((item) => item.href)).toEqual([
+      MATH_COURSE_PATHS.englishElementary,
     ]);
   });
 });

--- a/src/components/layout/Header/constants.ts
+++ b/src/components/layout/Header/constants.ts
@@ -44,6 +44,18 @@ export const MATH_GRADE_BAND_NAV_ITEMS: SubmenuItem[] = [
   },
 ];
 
+/** Grade-band links under Academic → English (desktop flyout + mobile accordion). */
+export const ENGLISH_SUBMENU_NAV_ITEMS: SubmenuItem[] = [
+  {
+    key: 'elementary-english',
+    title: 'Elementary School English',
+    description: 'Grades 1–5 reading fluency, vocabulary, grammar, and writing.',
+    icon: 'BookOpen',
+    href: MATH_COURSE_PATHS.englishElementary,
+    gradient: 'from-[#F16112] to-[#F1894F]',
+  },
+];
+
 // Icon mapping for dynamic icon rendering
 export const ICON_MAP = {
   Calculator,
@@ -140,6 +152,10 @@ export const FALLBACK_MENU_ITEMS: MenuItem[] = [
           icon: 'BookOpen',
           href: MATH_COURSE_PATHS.english,
           gradient: 'from-[#F16112] to-[#F1894F]',
+          hasSubmenu: true,
+          submenuHeaderTitle: 'English',
+          submenuHeaderSubtitle: 'Grades 1–12 English programs',
+          submenuItems: ENGLISH_SUBMENU_NAV_ITEMS,
         },
         {
           key: 'satPrep',

--- a/src/components/layout/Header/utils.ts
+++ b/src/components/layout/Header/utils.ts
@@ -4,6 +4,7 @@ import {
   ROUTE_PATH_PATTERNS_HIDE_CART,
   FALLBACK_MENU_ITEMS,
   MATH_GRADE_BAND_NAV_ITEMS,
+  ENGLISH_SUBMENU_NAV_ITEMS,
 } from './constants';
 import { MATH_COURSE_PATHS } from '@/lib/math-course-paths';
 import { ENABLED_LOCALES } from '@/i18n/localeConfig';
@@ -101,19 +102,31 @@ export function normalizeAcademicMathNav(menuItems: MenuItem[]): MenuItem[] {
     }
 
     const items = item.dropdown.items.map((dropdownItem) => {
-      if (dropdownItem.key !== 'math') {
-        return dropdownItem;
+      if (dropdownItem.key === 'math') {
+        return {
+          ...dropdownItem,
+          href: dropdownItem.href?.trim() || MATH_COURSE_PATHS.hub,
+          hasSubmenu: true,
+          submenuItems:
+            dropdownItem.submenuItems?.length && dropdownItem.submenuItems.length > 0
+              ? dropdownItem.submenuItems
+              : MATH_GRADE_BAND_NAV_ITEMS,
+        };
       }
 
-      return {
-        ...dropdownItem,
-        href: dropdownItem.href?.trim() || MATH_COURSE_PATHS.hub,
-        hasSubmenu: true,
-        submenuItems:
-          dropdownItem.submenuItems?.length && dropdownItem.submenuItems.length > 0
-            ? dropdownItem.submenuItems
-            : MATH_GRADE_BAND_NAV_ITEMS,
-      };
+      if (dropdownItem.key === 'english') {
+        return {
+          ...dropdownItem,
+          href: dropdownItem.href?.trim() || MATH_COURSE_PATHS.english,
+          hasSubmenu: true,
+          submenuItems:
+            dropdownItem.submenuItems?.length && dropdownItem.submenuItems.length > 0
+              ? dropdownItem.submenuItems
+              : ENGLISH_SUBMENU_NAV_ITEMS,
+        };
+      }
+
+      return dropdownItem;
     });
 
     return {

--- a/src/lib/__tests__/math-nav-links.test.ts
+++ b/src/lib/__tests__/math-nav-links.test.ts
@@ -3,6 +3,7 @@ import { MATH_COURSE_PATHS } from '@/lib/math-course-paths';
 import {
   FALLBACK_MENU_ITEMS,
   MATH_GRADE_BAND_NAV_ITEMS,
+  ENGLISH_SUBMENU_NAV_ITEMS,
 } from '@/components/layout/Header/constants';
 import { normalizeAcademicMathNav } from '@/components/layout/Header/utils';
 
@@ -20,6 +21,14 @@ describe('math navigation links', () => {
     const math = academic?.dropdown?.items.find((item) => item.key === 'math');
     expect(math?.href).toBe(MATH_COURSE_PATHS.hub);
     expect(math?.hasSubmenu).toBe(true);
+  });
+
+  it('Academic English dropdown item links to hub with submenu', () => {
+    const academic = FALLBACK_MENU_ITEMS.find((item) => item.key === 'academic');
+    const english = academic?.dropdown?.items.find((item) => item.key === 'english');
+    expect(english?.href).toBe(MATH_COURSE_PATHS.english);
+    expect(english?.hasSubmenu).toBe(true);
+    expect(english?.submenuItems).toEqual(ENGLISH_SUBMENU_NAV_ITEMS);
   });
 
   it('legacy courses high-school band URL redirects to academic math high school', () => {

--- a/src/lib/math-course-paths.ts
+++ b/src/lib/math-course-paths.ts
@@ -9,6 +9,7 @@ export const MATH_COURSE_PATHS = {
   highSchool: '/academic/math/high-school',
   mathFinalsPrep: '/math-finals-practice-session',
   english: '/academic/english',
+  englishElementary: '/academic/english/elementary',
 } as const;
 
 export type MathCoursePathKey = keyof typeof MATH_COURSE_PATHS;


### PR DESCRIPTION
English Courses flyout now links to /academic/english/elementary, mirroring the Math grade-band pattern.