### PR TITLE
Fix GSC legacy redirect canonical signals

### DIFF
--- a/docs/ahrefs-recrawl-tracking.md
+++ b/docs/ahrefs-recrawl-tracking.md
@@ -160,6 +160,6 @@ In Ahrefs after re-crawl:
 - Check sitemap route handler returns the URL in correct format
 
 **OG tags still flagged:**
-- Fetch the raw HTML: `curl -s https://www.growwiseschool.org/page | grep og:`
+- Fetch the raw HTML: `curl -s https://growwiseschool.org/page | grep og:`
 - Verify `og:image` URL is absolute (not relative)
 - Verify image dimensions ≥ 1200×630 (Ahrefs checks this)

--- a/docs/seo-30day-dashboard.md
+++ b/docs/seo-30day-dashboard.md
@@ -62,10 +62,10 @@
 # GSC → URL Inspection → paste URL → check "Last crawl" date
 
 Pages to inspect:
-- https://www.growwiseschool.org/camps/summer
-- https://www.growwiseschool.org/courses/math
-- https://www.growwiseschool.org/about
-- https://www.growwiseschool.org/steam/ml-ai-coding
+- https://growwiseschool.org/camps/summer
+- https://growwiseschool.org/academic/math
+- https://growwiseschool.org/about
+- https://growwiseschool.org/steam/ml-ai-coding
 ```
 
 ---

--- a/docs/seo-post-deploy-checklist.md
+++ b/docs/seo-post-deploy-checklist.md
@@ -99,7 +99,7 @@ INDEXNOW_KEY=your_key_here node scripts/indexnow-submit.mjs
 ## 4. Bing Webmaster Tools
 
 1. Verify site at https://www.bing.com/webmasters if not already done
-2. Submit sitemap: `https://www.growwiseschool.org/sitemap.xml`
+2. Submit sitemap: `https://growwiseschool.org/sitemap.xml`
 3. Check **SEO Reports** → Site Scan after 48h
 4. Fix any Bing-specific issues (often mirrors GSC issues)
 
@@ -129,7 +129,7 @@ Paste the full page URL and check for:
 Ahrefs flagged 1 redirect warning. Find and fix:
 
 1. GSC → Pages → Excluded → "Redirect"
-2. Or run: `curl -sI https://www.growwiseschool.org/<suspect-path> | grep -i location`
+2. Or run: `curl -sI https://growwiseschool.org/<suspect-path> | grep -i location`
 3. Common culprit: trailing slash redirects (`/camps/summer` → `/camps/summer/`)
 4. Fix by ensuring internal links match the canonical URL exactly (no trailing slash difference)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,13 @@ import { LEGACY_PATH_REDIRECTS } from './src/lib/seo/legacy-path-redirects';
 const withNextIntl = createNextIntlPlugin('./src/i18n/config.ts');
 
 const isProd = process.env.NODE_ENV === 'production';
+const retiredLocale = 'hi|zh|es';
+
+const LEGACY_ACADEMIC_REDIRECTS = [
+  { from: '/courses/math', to: '/academic/math' },
+  { from: '/courses/english', to: '/academic/english' },
+  { from: '/courses/high-school-math', to: '/academic/math/high-school' },
+] as const;
 
 const nextConfig: NextConfig = {
   /* config options here */
@@ -214,12 +221,28 @@ const nextConfig: NextConfig = {
   // Legacy `/camp/*` SEO landings → `/camps/*` (canonical namespace aligns with /camps/summer, /camps/winter).
   // `/en/camp/*` listed before `/en/:path*` so one redirect hop to `/camps/*`.
   async redirects() {
+    const legacyAcademicRedirects = LEGACY_ACADEMIC_REDIRECTS.flatMap(({ from, to }) => [
+      { source: from, destination: to, permanent: true as const },
+      { source: `${from}/`, destination: to, permanent: true as const },
+      { source: `/en${from}`, destination: to, permanent: true as const },
+      { source: `/en${from}/`, destination: to, permanent: true as const },
+      {
+        source: `/:locale(${retiredLocale})${from}`,
+        destination: to,
+        permanent: true as const,
+      },
+      {
+        source: `/:locale(${retiredLocale})${from}/`,
+        destination: to,
+        permanent: true as const,
+      },
+    ]);
+
     const legacyMarketingRedirects = LEGACY_PATH_REDIRECTS.flatMap(({ from, to }) => [
       { source: from, destination: to, permanent: true as const },
       { source: `${from}/`, destination: to, permanent: true as const },
     ]);
 
-    const retiredLocale = 'hi|zh|es';
     const localePrefixedLegacyRedirects = LEGACY_PATH_REDIRECTS.flatMap(({ from, to }) => [
       {
         source: `/:locale(${retiredLocale})${from}`,
@@ -234,6 +257,7 @@ const nextConfig: NextConfig = {
     ]);
 
     return [
+      ...legacyAcademicRedirects,
       ...localePrefixedLegacyRedirects,
       ...legacyMarketingRedirects,
       { source: '/camp', destination: '/camps/summer', permanent: true },

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -5,19 +5,19 @@ const BODY = `# GrowWise School
 > K-12 tutoring and STEAM enrichment in Dublin, CA. Math, English, coding, AI, robotics, SAT prep, and summer camps for Grades 1–12 in the Tri-Valley.
 
 ## Programs
-- [Academic (Math & English)](https://www.growwiseschool.org/academic)
-- [STEAM (Coding, AI, Game Dev)](https://www.growwiseschool.org/steam)
-- [Summer Camps](https://www.growwiseschool.org/camps/summer)
-- [Academic Summer Programs](https://www.growwiseschool.org/camps/academic-summer-programs-dublin-ca)
-- [SAT Prep](https://www.growwiseschool.org/courses/sat-prep)
-- [Workshops](https://www.growwiseschool.org/workshop-calendar)
+- [Academic (Math & English)](https://growwiseschool.org/academic)
+- [STEAM (Coding, AI, Game Dev)](https://growwiseschool.org/steam)
+- [Summer Camps](https://growwiseschool.org/camps/summer)
+- [Academic Summer Programs](https://growwiseschool.org/camps/academic-summer-programs-dublin-ca)
+- [SAT Prep](https://growwiseschool.org/courses/sat-prep)
+- [Workshops](https://growwiseschool.org/workshop-calendar)
 
 ## Info
-- [K-12 Tutoring in Dublin, CA](https://www.growwiseschool.org/dublin-ca)
-- [About](https://www.growwiseschool.org/about)
-- [Contact](https://www.growwiseschool.org/contact)
-- [Blog](https://www.growwiseschool.org/growwise-blogs)
-- [Parent Guides & Resources](https://www.growwiseschool.org/resources)
+- [K-12 Tutoring in Dublin, CA](https://growwiseschool.org/dublin-ca)
+- [About](https://growwiseschool.org/about)
+- [Contact](https://growwiseschool.org/contact)
+- [Blog](https://growwiseschool.org/growwise-blogs)
+- [Parent Guides & Resources](https://growwiseschool.org/resources)
 
 Location: 4564 Dublin Blvd, Dublin, CA 94568
 Phone: (925) 456-4606

--- a/src/lib/twilioSms.ts
+++ b/src/lib/twilioSms.ts
@@ -1,10 +1,10 @@
 const SMS_TEMPLATES = {
   contact: (name: string) =>
-    `GrowWise School: Got your inquiry ${name}! We'll reach out within 1 business day. Call: (925) 456-4606 or visit https://www.growwiseschool.org. Reply STOP to opt out.`,
+    `GrowWise School: Got your inquiry ${name}! We'll reach out within 1 business day. Call: (925) 456-4606 or visit https://growwiseschool.org. Reply STOP to opt out.`,
   assessment: (name: string) =>
     `GrowWise School: Hi ${name}, your free assessment request is confirmed! We'll contact you within 24 hrs to schedule. Call (925) 456-4606. Reply STOP to opt out.`,
   enrollment: (name: string) =>
-    `GrowWise School: Hi ${name}, your enrollment inquiry is received! Our team will reach out within 1 business day. Visit: https://www.growwiseschool.org. Reply STOP to opt out.`,
+    `GrowWise School: Hi ${name}, your enrollment inquiry is received! Our team will reach out within 1 business day. Visit: https://growwiseschool.org. Reply STOP to opt out.`,
   workshop: (name: string, eventTitle?: string) =>
     `GrowWise School: Hi ${name}, your spot for ${eventTitle || 'our upcoming event'} is confirmed! Check your email for details. Reply STOP to opt out.`,
 };


### PR DESCRIPTION
## Summary
- add permanent redirects for retired academic course URLs and locale-prefixed variants
- switch bot-facing and outbound links from www to the canonical non-www host
- update SEO docs/checklists to inspect canonical URLs instead of retired redirect targets

## Verification
- npm test -- --runTestsByPath src/lib/seo/__tests__/sitemapData.test.ts src/lib/seo/__tests__/seo-jsonld-route-audit.test.ts
- npx playwright test e2e/specs/legacy-locale-redirects.spec.ts --project=chromium