### PR TITLE
Fix duplicate summer DOM and lead conversion tracking

### DIFF
--- a/gtm/README.md
+++ b/gtm/README.md
@@ -6,9 +6,22 @@ This file is an **import package** for the GrowWise GTM container (`GTM-TNFBBQJM
 
 - **GA4 Configuration** tag (`send_page_view`: false)
 - **GA4 Event** tag for `virtual_page_view`
+- **GA4 Event** tag for `generate_lead`
 - Related triggers and data layer variables
 
 There is **no Meta (Facebook) Pixel tag** in this export. The live GTM workspace may still include a Pixel or other tags that were added directly in the Tag Manager UI and never exported here.
+
+## Consent policy
+
+The app now loads GTM / GA4 for all real users so `virtual_page_view` and `generate_lead`
+can be attributed even when a visitor does not click the cookie banner before converting.
+
+Consent-sensitive tags must be controlled inside GTM:
+
+- GA4 Configuration: fire for all users
+- `GA4 - virtual_page_view`: fire for all users
+- `GA4 - generate_lead`: fire for all users
+- Facebook / Meta Pixel: add an exception or consent trigger so it fires only after accepted consent
 
 ## Avoiding duplicate Meta Pixel loads
 
@@ -19,6 +32,36 @@ If the **same** pixel ID is fired from **both** the Next app ([`src/components/a
 See [`env.local.example`](../env.local.example) and [`src/lib/metaPixelEnv.ts`](../src/lib/metaPixelEnv.ts).
 
 **Manual check:** In Google Tag Manager → **Tags**, search for “Facebook”, “Meta”, or “Custom HTML” snippets that load `fbevents.js` or `connect.facebook.net`.
+
+If the app standalone Meta Pixel is used instead of a GTM Pixel tag, it remains consent-gated in
+[`AnalyticsAfterConsent.tsx`](../src/components/analytics/AnalyticsAfterConsent.tsx).
+
+## Lead conversion event
+
+The app pushes `generate_lead` after successful lead form/API submissions:
+
+| `lead_source` | When |
+|---------------|------|
+| `book_assessment` | `/book-assessment` form success |
+| `free_assessment_modal` | shared free assessment modal success |
+| `contact_form` | contact form success |
+| `enroll` | general enrollment form success |
+| `enroll_academic` | academic enrollment form success |
+| `summer_camp_guide` | summer camp guide lead success |
+| `math_finals_practice` | math finals practice lead success |
+
+The checked-in import now includes:
+
+- Custom Event trigger: `generate_lead`
+- GA4 Event tag: `GA4 - generate_lead`
+- Data layer variables: `lead_source`, `form_name`, `page_path`, `page_location`, `grade`, `camp_interest`, `program_type`
+
+After importing/publishing in GTM:
+
+1. Test in **GTM Preview** by submitting a real form and confirm `GA4 - generate_lead` fires.
+2. Confirm `generate_lead` appears in **GA4 Realtime / DebugView**.
+3. In GA4 Admin → Events, mark `generate_lead` as a **key event**.
+4. In Google Ads → Goals → Conversions → Import from GA4, import `generate_lead`.
 
 ## Nextdoor conversion events (configure in GTM UI)
 

--- a/gtm/virtual_page_view_import.json
+++ b/gtm/virtual_page_view_import.json
@@ -65,6 +65,57 @@
           }
         ],
         "firingTriggerId": ["2147483647"]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "tagId": "3",
+        "name": "GA4 - generate_lead",
+        "type": "ga4event",
+        "parameter": [
+          {
+            "key": "event_name",
+            "value": "generate_lead"
+          },
+          {
+            "key": "event_parameters",
+            "map": [
+              {
+                "key": "lead_source",
+                "value": "{{DL - lead_source}}"
+              },
+              {
+                "key": "form_name",
+                "value": "{{DL - form_name}}"
+              },
+              {
+                "key": "page_path",
+                "value": "{{DL - page_path}}"
+              },
+              {
+                "key": "page_location",
+                "value": "{{DL - page_location}}"
+              },
+              {
+                "key": "grade",
+                "value": "{{DL - grade}}"
+              },
+              {
+                "key": "camp_interest",
+                "value": "{{DL - camp_interest}}"
+              },
+              {
+                "key": "program_type",
+                "value": "{{DL - program_type}}"
+              }
+            ]
+          },
+          {
+            "key": "measurementId",
+            "value": "G-HP143C77W2"
+          }
+        ],
+        "firingTriggerId": ["2147483646"]
       }
     ],
     "trigger": [
@@ -86,6 +137,23 @@
                 "key": "arg0",
                 "type": "template",
                 "value": "virtual_page_view"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "triggerId": "2147483646",
+        "name": "generate_lead",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "equals",
+            "parameter": [
+              {
+                "key": "arg0",
+                "type": "template",
+                "value": "generate_lead"
               }
             ]
           }
@@ -141,6 +209,108 @@
           {
             "key": "name",
             "value": "debug_mode"
+          }
+        ]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "variableId": "4",
+        "name": "DL - lead_source",
+        "type": "vtdlvar",
+        "parameter": [
+          {
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "key": "name",
+            "value": "lead_source"
+          }
+        ]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "variableId": "5",
+        "name": "DL - form_name",
+        "type": "vtdlvar",
+        "parameter": [
+          {
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "key": "name",
+            "value": "form_name"
+          }
+        ]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "variableId": "6",
+        "name": "DL - page_location",
+        "type": "vtdlvar",
+        "parameter": [
+          {
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "key": "name",
+            "value": "page_location"
+          }
+        ]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "variableId": "7",
+        "name": "DL - grade",
+        "type": "vtdlvar",
+        "parameter": [
+          {
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "key": "name",
+            "value": "grade"
+          }
+        ]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "variableId": "8",
+        "name": "DL - camp_interest",
+        "type": "vtdlvar",
+        "parameter": [
+          {
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "key": "name",
+            "value": "camp_interest"
+          }
+        ]
+      },
+      {
+        "accountId": "",
+        "containerId": "GTM-TNFBBQJM",
+        "variableId": "9",
+        "name": "DL - program_type",
+        "type": "vtdlvar",
+        "parameter": [
+          {
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "key": "name",
+            "value": "program_type"
           }
         ]
       }

--- a/src/app/[locale]/book-assessment/page.tsx
+++ b/src/app/[locale]/book-assessment/page.tsx
@@ -28,7 +28,7 @@ import { validatePhoneWithCountryCode, getPhonePlaceholder, getCallingCode, DIAL
 import { getRecaptchaToken } from '@/lib/recaptcha';
 import { publicPath } from '@/lib/publicPath';
 import { siteGoogleTrustReviewCards } from '@/lib/siteGoogleTrustReviews';
-import { trackAssessmentFormSubmitted } from '@/lib/analytics/gtmEvents';
+import { trackAssessmentFormSubmitted, trackGenerateLead } from '@/lib/analytics/gtmEvents';
 import { captureUtmFromSearchParams, getStoredUtm, getStoredUtmNotesLine } from '@/lib/analytics/utm';
 
 interface FormData {
@@ -256,6 +256,11 @@ export default function BookAssessmentPage() {
 
       if (result.success) {
         trackAssessmentFormSubmitted(window.location.pathname);
+        trackGenerateLead('book_assessment', {
+          form_name: 'book_assessment',
+          assessment_type: assessmentData.assessmentType,
+          grade: assessmentData.grade,
+        });
         router.replace(publicPath('/book-assessment/thank-you', locale));
         return;
       } else {

--- a/src/app/[locale]/camps/summer/layout.tsx
+++ b/src/app/[locale]/camps/summer/layout.tsx
@@ -46,10 +46,10 @@ export default async function SummerCampLayout({
   const { locale } = await params;
   const baseUrl = getCanonicalSiteUrl();
   const summerEventDescription =
-    'Standards-aligned summer STEAM camps in Dublin, CA for Grades K-12. Weekly sessions in Math, Coding, Robotics, and AI. June through August 2026.';
+    'Weekly 2026 summer camps in Dublin, CA for Grades 1-12: Math, Robotics, Coding, AI, game development, and writing. Online and in-person options available June through August.';
 
   const eventSchema = generateEventSchema({
-    name: 'Summer STEAM Camp 2026 — Dublin, CA',
+    name: 'Math, Robotics, Coding & AI Summer Camps 2026 — Dublin, CA',
     description: summerEventDescription,
     startDate: SUMMER_CAMP_EVENT_START_ISO,
     endDate: SUMMER_CAMP_EVENT_END_ISO,
@@ -91,7 +91,7 @@ export default async function SummerCampLayout({
 
   const pageUrl = absoluteSiteUrl('/camps/summer', locale, baseUrl);
   const webPageSchema = generateWebPageJsonLd({
-    name: 'Summer STEAM Camps 2026 in Dublin, CA | GrowWise',
+    name: 'Math, Robotics, Coding & AI Summer Camps Dublin CA | GrowWise',
     description: summerEventDescription,
     url: pageUrl,
   });

--- a/src/app/[locale]/camps/summer/page.tsx
+++ b/src/app/[locale]/camps/summer/page.tsx
@@ -35,6 +35,7 @@ import { SummerCampTrustBlock } from '@/components/camps/SummerCampTrustBlock';
 import { FeaturedCampGuidesSection } from '@/components/camps/FeaturedCampGuidesSection';
 import { SummerCampParentsKnowStrip } from '@/components/camps/SummerCampParentsKnowStrip';
 import { SummerCampEmptySlotsPanel } from '@/components/camps/SummerCampUI';
+import { trackGenerateLead } from '@/lib/analytics/gtmEvents';
 const SummerCampGuideLeadDialog = dynamic(
   () => import('./SummerCampGuideLeadDialog').then((m) => ({ default: m.SummerCampGuideLeadDialog })),
   { ssr: false },
@@ -347,6 +348,11 @@ export default function SummerCampPage() {
           ...(phoneTrim ? { ph: phoneTrim } : {}),
         })
       );
+      trackGenerateLead('summer_camp_guide', {
+        form_name: 'summer_camp_guide',
+        camp_interest: summerCampInterest,
+        grade: summerCampChildGrade,
+      });
       const qs = new URLSearchParams({
         interest: summerCampInterest,
         grade: summerCampChildGrade,

--- a/src/app/[locale]/enroll-academic/EnrollAcademicPageClient.tsx
+++ b/src/app/[locale]/enroll-academic/EnrollAcademicPageClient.tsx
@@ -16,6 +16,7 @@ import { PHONE_PLACEHOLDER } from '@/lib/constants';
 import { validatePhoneSimple } from '@/lib/phoneValidation';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 import { getRecaptchaToken } from '@/lib/recaptcha';
+import { trackGenerateLead } from '@/lib/analytics/gtmEvents';
 
 interface EnrollFormData {
   parentName: string;
@@ -146,6 +147,11 @@ export default function EnrollAcademicPageClient() {
       }
 
       if (result.success) {
+        trackGenerateLead('enroll_academic', {
+          form_name: 'enroll_academic',
+          subject: formData.subject,
+          grade: formData.grade,
+        });
         router.replace(publicPath("/enroll-academic/thank-you", locale));
         return;
       } else {

--- a/src/app/[locale]/enroll/EnrollPageClient.tsx
+++ b/src/app/[locale]/enroll/EnrollPageClient.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Loader2, AlertCircle, User, Mail, Phone as PhoneIcon, GraduationCap, MapPin, Target, BookOpen, Code } from 'lucide-react';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 import { useFormTracking, usePageTracking } from '@/lib/analytics/hooks';
+import { trackGenerateLead } from '@/lib/analytics/gtmEvents';
 import { TrackedForm } from '@/lib/analytics/components';
 import Phase3EnrollPage from '@/components/enroll/EnrollPhase3Page';
 import { useSearchParams } from 'next/navigation';
@@ -106,6 +107,12 @@ function EnrollPageInner() {
 
       if (result.success) {
         trackFormSubmit('enrollment_form', true);
+        trackGenerateLead('enroll', {
+          form_name: 'enrollment_form',
+          program_type: programType ?? 'unknown',
+          course: course ?? '',
+          bootcamp: bootcamp ?? '',
+        });
         router.replace(publicPath('/enroll/thank-you', locale));
         return;
       } else {
@@ -352,5 +359,4 @@ export default function EnrollPageClient() {
     </Suspense>
   );
 }
-
 

--- a/src/app/[locale]/steam/game-development/page.tsx
+++ b/src/app/[locale]/steam/game-development/page.tsx
@@ -149,6 +149,24 @@ const gameDevCourses: GameDevCourse[] = [
   }
 ];
 
+const FLOATING_GAME_SYMBOLS = [
+  { symbol: '🎮', left: '9.7%', top: '41.1%', duration: '11.7s', size: '20px' },
+  { symbol: '🎯', left: '18.2%', top: '14.5%', duration: '9.4s', size: '24px' },
+  { symbol: '🚀', left: '27.8%', top: '68.3%', duration: '10.8s', size: '29px' },
+  { symbol: '💎', left: '36.6%', top: '28.9%', duration: '8.9s', size: '21px' },
+  { symbol: '⭐', left: '44.9%', top: '52.7%', duration: '12s', size: '31px' },
+  { symbol: '🎨', left: '52.3%', top: '18.6%', duration: '10.2s', size: '25px' },
+  { symbol: '🎵', left: '61.8%', top: '33.8%', duration: '10.7s', size: '27px' },
+  { symbol: '🏆', left: '69.5%', top: '72.4%', duration: '9.8s', size: '22px' },
+  { symbol: '💡', left: '76.4%', top: '21.5%', duration: '11.3s', size: '30px' },
+  { symbol: '⚡', left: '84.1%', top: '57.2%', duration: '8.6s', size: '23px' },
+  { symbol: '🔧', left: '13.6%', top: '79.8%', duration: '12.1s', size: '26px' },
+  { symbol: '🎪', left: '31.4%', top: '8.7%', duration: '9.1s', size: '28px' },
+  { symbol: '🌟', left: '48.7%', top: '83.5%', duration: '10.5s', size: '24px' },
+  { symbol: '🎲', left: '73.9%', top: '9.6%', duration: '11.6s', size: '21px' },
+  { symbol: '🎊', left: '91.2%', top: '39.4%', duration: '9.7s', size: '29px' },
+] as const;
+
 // Component that handles search params - wrapped separately for Suspense
 function SearchParamsHandler({ 
   onLevelFound,
@@ -401,20 +419,20 @@ const GameDevelopmentPage: React.FC = () => {
         <div className="absolute inset-0 bg-gradient-to-br from-green-50 via-blue-50 via-purple-50 to-pink-50">
           {/* Floating game symbols */}
           <div className="absolute inset-0 overflow-hidden">
-            {[...Array(15)].map((_, i) => (
+            {FLOATING_GAME_SYMBOLS.map((item, i) => (
               <div
                 key={i}
                 className="absolute text-gray-500/60 animate-float-gentle font-semibold"
                 style={{
-                  left: `${Math.random() * 100}%`,
-                  top: `${Math.random() * 100}%`,
+                  left: item.left,
+                  top: item.top,
                   transform: `translateY(${scrollY * 0.05}px)`,
                   animationDelay: `${i * 1.2}s`,
-                  animationDuration: `${8 + Math.random() * 4}s`,
-                  fontSize: `${Math.random() * 15 + 18}px`
+                  animationDuration: item.duration,
+                  fontSize: item.size
                 }}
               >
-                {['🎮', '🎯', '🚀', '💎', '⭐', '🎨', '🎵', '🏆', '💡', '⚡', '🔧', '🎪', '🌟', '🎲', '🎊'][Math.floor(Math.random() * 15)]}
+                {item.symbol}
               </div>
             ))}
           </div>
@@ -963,4 +981,3 @@ const GameDevelopmentPage: React.FC = () => {
 };
 
 export default GameDevelopmentPage;
-

--- a/src/app/[locale]/steam/ml-ai-coding/page.tsx
+++ b/src/app/[locale]/steam/ml-ai-coding/page.tsx
@@ -120,6 +120,24 @@ const mlaiCourses: MLAICourse[] = [
   }
 ];
 
+const FLOATING_AI_SYMBOLS = [
+  { symbol: '🤖', left: '8.5%', top: '44.2%', duration: '11.4s', size: '22px' },
+  { symbol: '🧠', left: '16.9%', top: '17.8%', duration: '9.5s', size: '28px' },
+  { symbol: '💻', left: '24.7%', top: '69.6%', duration: '10.9s', size: '24px' },
+  { symbol: '⚡', left: '33.1%', top: '29.4%', duration: '8.7s', size: '30px' },
+  { symbol: '🔬', left: '41.5%', top: '55.3%', duration: '12.1s', size: '21px' },
+  { symbol: '📊', left: '50.2%', top: '13.6%', duration: '10.4s', size: '26px' },
+  { symbol: '🎯', left: '58.8%', top: '34.9%', duration: '11s', size: '23px' },
+  { symbol: '🚀', left: '67.4%', top: '75.1%', duration: '9.9s', size: '31px' },
+  { symbol: '💡', left: '75.6%', top: '22.4%', duration: '11.5s', size: '27px' },
+  { symbol: '⚙️', left: '83.3%', top: '59.8%', duration: '8.8s', size: '25px' },
+  { symbol: '🔍', left: '12.9%', top: '80.5%', duration: '12s', size: '24px' },
+  { symbol: '📈', left: '30.6%', top: '7.9%', duration: '9.2s', size: '29px' },
+  { symbol: '🌟', left: '47.8%', top: '84.1%', duration: '10.6s', size: '22px' },
+  { symbol: '🎨', left: '72.5%', top: '10.7%', duration: '11.8s', size: '26px' },
+  { symbol: '🔮', left: '90.4%', top: '38.6%', duration: '9.6s', size: '28px' },
+] as const;
+
 // Component that handles search params - wrapped separately for Suspense
 function SearchParamsHandler({ 
   onGradeFound,
@@ -374,20 +392,20 @@ const MLAICoursesPage: React.FC = () => {
         <div className="absolute inset-0 bg-gradient-to-br from-purple-50 via-blue-50 via-indigo-50 to-teal-50">
           {/* Floating AI/tech symbols */}
           <div className="absolute inset-0 overflow-hidden">
-            {[...Array(15)].map((_, i) => (
+            {FLOATING_AI_SYMBOLS.map((item, i) => (
               <div
                 key={i}
                 className="absolute text-gray-500/60 animate-float-gentle font-semibold"
                 style={{
-                  left: `${Math.random() * 100}%`,
-                  top: `${Math.random() * 100}%`,
+                  left: item.left,
+                  top: item.top,
                   transform: `translateY(${scrollY * 0.05}px)`,
                   animationDelay: `${i * 1.2}s`,
-                  animationDuration: `${8 + Math.random() * 4}s`,
-                  fontSize: `${Math.random() * 15 + 18}px`
+                  animationDuration: item.duration,
+                  fontSize: item.size
                 }}
               >
-                {['🤖', '🧠', '💻', '⚡', '🔬', '📊', '🎯', '🚀', '💡', '⚙️', '🔍', '📈', '🌟', '🎨', '🔮'][Math.floor(Math.random() * 15)]}
+                {item.symbol}
               </div>
             ))}
           </div>
@@ -935,4 +953,3 @@ const MLAICoursesPage: React.FC = () => {
 };
 
 export default MLAICoursesPage;
-

--- a/src/components/FreeAssessmentModal.tsx
+++ b/src/components/FreeAssessmentModal.tsx
@@ -18,6 +18,7 @@ import CountryCodeSelector from "./CountryCodeSelector";
 import { PHONE_PLACEHOLDER } from '@/lib/constants';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
 import { validatePhoneWithCountryCode } from '@/lib/phoneValidation';
+import { trackGenerateLead } from '@/lib/analytics/gtmEvents';
 
 /** Matches `assessmentTypes` value on `src/app/[locale]/book-assessment/page.tsx` for general Grades 1–12 intake. */
 const DEFAULT_ASSESSMENT_TYPE = 'Complete Academic Assessment' as const;
@@ -211,6 +212,11 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
       }
 
       if (result.success) {
+        trackGenerateLead('free_assessment_modal', {
+          form_name: 'free_assessment_modal',
+          assessment_type: payload.assessmentType,
+          grade: payload.grade,
+        });
         router.replace(publicPath('/book-assessment/thank-you', locale));
         resetAndClose();
         return;
@@ -558,4 +564,3 @@ const FreeAssessmentModal: React.FC<FreeAssessmentModalProps> = ({ isOpen, onClo
 };
 
 export default FreeAssessmentModal;
-

--- a/src/components/analytics/AnalyticsAfterConsent.tsx
+++ b/src/components/analytics/AnalyticsAfterConsent.tsx
@@ -82,32 +82,31 @@ export function AnalyticsAfterConsent() {
 
   return (
     <>
-      {/* Meta Pixel loads without a consent gate so Meta's Event Setup Tool can detect it.
-          Custom events (Lead, Purchase, etc.) are fired explicitly from user actions and are
-          unaffected by this change. Suppress during automated audits and when explicitly
-          disabled (e.g. pixel is already loaded via GTM). */}
-      {!isAudit && !isAppMetaPixelScriptDisabled() && env.pixelId ? (
+      {/* Standalone app Meta Pixel stays consent-gated. If Pixel is configured in GTM,
+          block that GTM tag with a consent trigger and set NEXT_PUBLIC_META_PIXEL_DISABLE_APP=true. */}
+      {consentAccepted && !isAudit && !isAppMetaPixelScriptDisabled() && env.pixelId ? (
         <MetaPixel pixelId={env.pixelId} />
       ) : null}
 
-      {/* GTM and GA remain behind the consent gate. */}
+      {/* GTM loads for all real users. Consent-sensitive tags must be blocked inside GTM. */}
+      {!isAudit && env.gtmId ? (
+        <>
+          <GTMHead gtmId={env.gtmId} strategy="afterInteractive" />
+          <GTMNoScript gtmId={env.gtmId} />
+        </>
+      ) : null}
+
+      {/* GA fallback only when GTM isn't configured; it follows the same all-users measurement policy. */}
+      {!isAudit && !env.gtmId && env.gaId ? (
+        <>
+          <Script src={`https://www.googletagmanager.com/gtag/js?id=${env.gaId}`} strategy="lazyOnload" />
+          <Script id="gtag-inline" strategy="lazyOnload" dangerouslySetInnerHTML={{ __html: buildGtagInline(env.gaId) }} />
+        </>
+      ) : null}
+
+      {/* Consent-sensitive non-GTM tools remain behind the cookie consent gate. */}
       {consentAccepted && !isAudit ? (
         <>
-          {env.gtmId ? (
-            <>
-              <GTMHead gtmId={env.gtmId} strategy="afterInteractive" />
-              <GTMNoScript gtmId={env.gtmId} />
-            </>
-          ) : null}
-
-          {/* GA fallback only when GTM isn't configured */}
-          {!env.gtmId && env.gaId ? (
-            <>
-              <Script src={`https://www.googletagmanager.com/gtag/js?id=${env.gaId}`} strategy="lazyOnload" />
-              <Script id="gtag-inline" strategy="lazyOnload" dangerouslySetInnerHTML={{ __html: buildGtagInline(env.gaId) }} />
-            </>
-          ) : null}
-
           {env.hubspotHubId ? <HubSpotSpaTracker hubId={env.hubspotHubId} /> : null}
           {env.clarityProjectId && !isClarityExcludedPath(pathname) ? (
             <MicrosoftClarity projectId={env.clarityProjectId} pathname={pathname} />

--- a/src/components/analytics/ConsentAndAnalytics.tsx
+++ b/src/components/analytics/ConsentAndAnalytics.tsx
@@ -4,8 +4,8 @@ import { AnalyticsAfterConsent } from '@/components/analytics/AnalyticsAfterCons
 import { CookieConsentBanner } from '@/components/analytics/CookieConsentBanner';
 
 /**
- * Loads GTM / GA / Meta Pixel only after analytics consent (localStorage).
- * Keeps third-party cookies off the critical path until the user accepts — improves Lighthouse Best Practices.
+ * Loads measurement scripts and consent-sensitive marketing tools.
+ * GTM / GA4 load for all users; ad pixels and session tools remain consent-gated here or in GTM.
  */
 export function ConsentAndAnalytics() {
   return (

--- a/src/components/analytics/PageTrackingWrapper.tsx
+++ b/src/components/analytics/PageTrackingWrapper.tsx
@@ -21,9 +21,12 @@ export function PageTrackingWrapper({ children }: PageTrackingWrapperProps) {
     const w = window as any;
     const isDev = process.env.NODE_ENV !== 'production';
 
-    // If Google Tag Manager is present, push a custom event to dataLayer to avoid duplicate automatic page_view sends.
-    // Configure your GTM workspace with a GA4 Event tag that listens for 'virtual_page_view' (or disable automatic page_view in the GA4 Configuration tag).
-    if (w.dataLayer) {
+    const gtmConfigured = Boolean(process.env.NEXT_PUBLIC_GTM_ID?.trim());
+
+    // If Google Tag Manager is configured, queue the event immediately. GTM will consume it
+    // once the container loads, which avoids missing initial page views during script startup.
+    if (gtmConfigured || Array.isArray(w.dataLayer)) {
+      w.dataLayer = w.dataLayer || [];
       const payload: Record<string, any> = {
         event: 'virtual_page_view',
         page_path: pathname,

--- a/src/components/camps/AcademicProgramList.tsx
+++ b/src/components/camps/AcademicProgramList.tsx
@@ -252,7 +252,6 @@ function renderProgramGrid(
   programs: Program[],
   selectedProgramId: string | null,
   onSelectProgram: (program: Program) => void,
-  layout: 'mobile' | 'desktop',
   locale: string,
 ) {
   return programs.map((program, idx) => {
@@ -261,26 +260,19 @@ function renderProgramGrid(
     const isGetReady = isAcademicGetReadyProgram(program.id);
     const isEnhancedCard = isSprint || isGetReady;
     const hasOddCount = programs.length % 2 !== 0;
-    const isLastAndAlone = layout === 'desktop' && hasOddCount && idx === programs.length - 1;
+    const isLastAndAlone = hasOddCount && idx === programs.length - 1;
     const seo = getAcademicProgramSeoLink(program.id);
     const seoLabel = seo ? academicSeoLinkLabel(seo.labelKey) : undefined;
 
-    const imageSizes =
-      layout === 'mobile'
-        ? '(max-width:768px) 96vw, 100vw'
-        : '(min-width: 1024px) 24vw, (min-width: 769px) 42vw, 100vw';
+    const imageSizes = '(max-width:768px) 96vw, (min-width: 1024px) 24vw, (min-width: 769px) 42vw, 100vw';
 
     const imageWrapperClassName = isEnhancedCard
-      ? layout === 'mobile'
-        ? 'aspect-[650/270]'
-        : isLastAndAlone
-          ? 'h-[120px]'
-          : 'aspect-[650/270]'
-      : layout === 'mobile'
-        ? 'aspect-[650/450]'
-        : isLastAndAlone
-          ? 'h-[200px]'
-          : 'aspect-[650/450]';
+      ? isLastAndAlone
+        ? 'aspect-[650/270] min-[769px]:aspect-auto min-[769px]:h-[120px]'
+        : 'aspect-[650/270]'
+      : isLastAndAlone
+        ? 'aspect-[650/450] min-[769px]:aspect-auto min-[769px]:h-[200px]'
+        : 'aspect-[650/450]';
 
     const CardComponent = isSprint
       ? AcademicSprintPickCard
@@ -294,7 +286,7 @@ function renderProgramGrid(
         id={`track-${program.id}`}
         className={`flex flex-col gap-2 scroll-mt-28 [content-visibility:auto] ${
           isEnhancedCard ? '[contain-intrinsic-size:auto_420px]' : '[contain-intrinsic-size:auto_300px]'
-        } ${isLastAndAlone ? 'col-span-2' : ''}`}
+        } ${isLastAndAlone ? 'min-[769px]:col-span-2' : ''}`}
       >
         <CardComponent
           program={program}
@@ -334,7 +326,7 @@ export const AcademicProgramList = memo(function AcademicProgramList({
 
   return (
     <div className="space-y-8" role="group" aria-label={COPY.ariaLabel}>
-      <div className="min-[769px]:hidden space-y-8">
+      <div className="space-y-8">
         {groups.map((groupEntry) => (
           <section key={groupEntry.group} className="space-y-3">
             <h3 className="font-heading text-base font-black uppercase tracking-tight text-slate-800">
@@ -342,43 +334,15 @@ export const AcademicProgramList = memo(function AcademicProgramList({
             </h3>
             <p className="text-xs text-slate-500">{COPY.groups[groupEntry.group].subtext}</p>
             <ul
-              className="m-0 grid list-none grid-cols-1 gap-3 p-0"
+              className="m-0 grid list-none grid-cols-1 gap-3 p-0 min-[769px]:grid-cols-2"
               aria-label={sectionHeading(groupEntry.group)}
             >
-              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, 'mobile', locale)}
+              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, locale)}
             </ul>
           </section>
         ))}
         {onInquire ? (
-          <p className="text-center">
-            <button
-              type="button"
-              onClick={onInquire}
-              className="text-[13px] font-medium text-[#065f46] underline-offset-2 hover:underline"
-            >
-              {COPY.inquireLink}
-            </button>
-          </p>
-        ) : null}
-      </div>
-
-      <div className="hidden min-[769px]:block space-y-8">
-        {groups.map((groupEntry) => (
-          <section key={`d-${groupEntry.group}`} className="space-y-3">
-            <h3 className="font-heading text-base font-black uppercase tracking-tight text-slate-800">
-              {sectionHeading(groupEntry.group)}
-            </h3>
-            <p className="text-xs text-slate-500">{COPY.groups[groupEntry.group].subtext}</p>
-            <ul
-              className="m-0 grid list-none grid-cols-2 gap-3 p-0"
-              aria-label={sectionHeading(groupEntry.group)}
-            >
-              {renderProgramGrid(groupEntry.programs, selectedProgramId, onSelectProgram, 'desktop', locale)}
-            </ul>
-          </section>
-        ))}
-        {onInquire ? (
-          <p className="text-center">
+          <p className="text-center min-[769px]:hidden">
             <button
               type="button"
               onClick={onInquire}

--- a/src/components/camps/SummerCampProgramList.tsx
+++ b/src/components/camps/SummerCampProgramList.tsx
@@ -176,31 +176,25 @@ export const ProgramList = memo(function ProgramList({
 
   const renderCardListItem = (
     program: Program,
-    layout: 'mobile' | 'desktop',
     idx: number,
     groupLength: number,
   ) => {
     const isSelected = selectedProgramId === program.id;
     const hasOddCount = groupLength % 2 !== 0;
-    const isLastAndAlone = layout === 'desktop' && hasOddCount && idx === groupLength - 1;
+    const isLastAndAlone = hasOddCount && idx === groupLength - 1;
     const seo = getSummerCampProgramSeoLink(program.id);
 
-    const imageSizes =
-      layout === 'mobile'
-        ? '(max-width:768px) 96vw, 100vw'
-        : '(min-width: 1024px) 24vw, (min-width: 769px) 42vw, 100vw';
+    const imageSizes = '(max-width:768px) 96vw, (min-width: 1024px) 24vw, (min-width: 769px) 42vw, 100vw';
 
     const imageWrapperClassName =
-      layout === 'mobile'
-        ? 'aspect-[650/270]'
-        : isLastAndAlone
-          ? 'h-[120px]'
-          : 'aspect-[650/270]';
+      isLastAndAlone
+        ? 'aspect-[650/270] min-[769px]:aspect-auto min-[769px]:h-[120px]'
+        : 'aspect-[650/270]';
 
     return (
       <li
         key={program.id}
-        className={`[content-visibility:auto] [contain-intrinsic-size:auto_420px] flex flex-col gap-2 ${isLastAndAlone ? 'col-span-2' : ''}`}
+        className={`[content-visibility:auto] [contain-intrinsic-size:auto_420px] flex flex-col gap-2 ${isLastAndAlone ? 'min-[769px]:col-span-2' : ''}`}
       >
         <SummerCampProgramPickCard
           program={program}
@@ -223,7 +217,7 @@ export const ProgramList = memo(function ProgramList({
 
   return (
     <div className="space-y-8" role="group" aria-label={t('page.title')}>
-      <div className="min-[769px]:hidden space-y-8">
+      <div className="space-y-8">
         {groups.map((group) => (
           <Fragment key={group.track}>
             <section className="space-y-3">
@@ -231,11 +225,11 @@ export const ProgramList = memo(function ProgramList({
                 {sectionHeading(group.track)}
               </h3>
               <ul
-                className="m-0 grid list-none grid-cols-1 gap-3 p-0"
+                className="m-0 grid list-none grid-cols-1 gap-3 p-0 min-[769px]:grid-cols-2"
                 aria-label={sectionHeading(group.track)}
               >
                 {group.programs.map((program, idx) =>
-                  renderCardListItem(program, 'mobile', idx, group.programs.length),
+                  renderCardListItem(program, idx, group.programs.length),
                 )}
               </ul>
             </section>
@@ -247,37 +241,11 @@ export const ProgramList = memo(function ProgramList({
             ) : null}
           </Fragment>
         ))}
-        <p className="text-center">
+        <p className="text-center min-[769px]:hidden">
           <a href="#lead-capture" className="text-[13px] font-medium text-[#065f46]">
             {t('mobile.summercampLink')}
           </a>
         </p>
-      </div>
-
-      <div className="hidden min-[769px]:block space-y-8">
-        {groups.map((group) => (
-          <Fragment key={`d-${group.track}`}>
-            <section className="space-y-3">
-              <h3 className="font-heading text-base font-black uppercase tracking-tight text-slate-800">
-                {sectionHeading(group.track)}
-              </h3>
-              <ul
-                className="m-0 grid list-none grid-cols-2 gap-3 p-0"
-                aria-label={sectionHeading(group.track)}
-              >
-                {group.programs.map((program, idx) =>
-                  renderCardListItem(program, 'desktop', idx, group.programs.length),
-                )}
-              </ul>
-            </section>
-            {group.track === 'aiGameDev' && showAcademicTeaser ? (
-              <>
-                <HighSchoolSummerIntensiveTeaserBand locale={locale} />
-                <AcademicSummerProgramsTeaserBand locale={locale} />
-              </>
-            ) : null}
-          </Fragment>
-        ))}
       </div>
 
       <div className="max-[768px]:hidden">

--- a/src/components/math-finals-practice/MathFinalsPracticeLanding.tsx
+++ b/src/components/math-finals-practice/MathFinalsPracticeLanding.tsx
@@ -26,6 +26,7 @@ import {
 import { PHONE_PLACEHOLDER } from '@/lib/constants'
 import { publicPath } from '@/lib/publicPath'
 import { cn } from '@/lib/utils'
+import { trackGenerateLead } from '@/lib/analytics/gtmEvents'
 import {
   BookOpen,
   Calculator,
@@ -154,6 +155,11 @@ export function MathFinalsPracticeLanding() {
         return
       }
       if (data.success) {
+        trackGenerateLead('math_finals_practice', {
+          form_name: 'math_finals_practice',
+          subject: form.subject,
+          grade: form.grade,
+        })
         setForm(initialForm)
         if (agendaInputRef.current) agendaInputRef.current.value = ''
         router.push(publicPath('/math-finals-practice-session/thank-you', locale))

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -43,6 +43,7 @@ import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { fetchContactRequested } from '@/store/slices/contactSlice';
 import { getIconComponent } from '@/lib/iconMap';
+import { trackGenerateLead } from '@/lib/analytics/gtmEvents';
 import { contactService } from '@/lib/contactService';
 import { CONTACT_INFO } from '@/lib/constants';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
@@ -126,6 +127,9 @@ export default function Contact() {
       });
 
       if (result.success) {
+        trackGenerateLead('contact_form', {
+          form_name: 'contact',
+        });
         router.replace(publicPath('/contact/thank-you', locale));
         return;
       } else {

--- a/src/i18n/messages/summer-camp-canonical-en.json
+++ b/src/i18n/messages/summer-camp-canonical-en.json
@@ -1,8 +1,8 @@
 {
   "hero": {
-    "h1": "Summer STEAM Camps 2026 in Dublin, CA",
-    "subhead": "This summer, your child builds something real. Coding, AI, Robotics & Math · Grades 1–12",
-    "subheadDetail": "Rated 4.9 ⭐ · 40+ Dublin families · Max 8 students · Weeks filling fast",
+    "h1": "Math, Robotics, Coding & AI Summer Camps in Dublin, CA",
+    "subhead": "Weekly 2026 camps for Grades 1–12: full-day Robotics, AI projects, coding/game dev, and high school math intensives",
+    "subheadDetail": "Dublin & Tri-Valley families · Max 8 students · Online + in-person options · Weeks filling fast",
     "primaryCta": "Reserve a Spot →",
     "secondaryCta": "Get Camp Guide →",
     "brochurePdf": "/assets/camps/SummerCampBrochure.pdf",

--- a/src/lib/analytics/gtmEvents.ts
+++ b/src/lib/analytics/gtmEvents.ts
@@ -1,5 +1,14 @@
 type DataLayerWindow = Window & { dataLayer?: Record<string, unknown>[] }
 
+type LeadSource =
+  | 'book_assessment'
+  | 'free_assessment_modal'
+  | 'contact_form'
+  | 'enroll'
+  | 'enroll_academic'
+  | 'summer_camp_guide'
+  | 'math_finals_practice'
+
 export function pushDataLayer(payload: Record<string, unknown>): void {
   if (typeof window === 'undefined') return
   const w = window as DataLayerWindow
@@ -27,5 +36,18 @@ export function trackAssessmentFormSubmitted(pagePath: string): void {
   pushDataLayer({
     event: 'assessment_form_submitted',
     page_path: pagePath,
+  })
+}
+
+export function trackGenerateLead(
+  leadSource: LeadSource,
+  params: Record<string, unknown> = {},
+): void {
+  pushDataLayer({
+    event: 'generate_lead',
+    lead_source: leadSource,
+    page_path: typeof window !== 'undefined' ? window.location.pathname : '',
+    page_location: typeof window !== 'undefined' ? window.location.href : '',
+    ...params,
   })
 }

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -341,9 +341,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/camps/summer': {
-    title: 'Summer STEAM Camps 2026 in Dublin, CA | GrowWise',
+    title: 'Math, Robotics, Coding & AI Summer Camps Dublin CA | GrowWise',
     description:
-      'Top-rated summer STEAM camps in Dublin, CA for Grades 3–12. Math, Coding, Robotics & AI. Weekly sessions June–August. Limited spots — enroll now.',
+      'Summer camps in Dublin, CA for Grades 1–12: Math, Robotics, Coding, AI, game development, and writing. Weekly June–August 2026. Reserve a spot.',
     keywords:
       'summer camp Dublin CA, summer camps Dublin CA 2026, STEAM summer camp Dublin, coding summer camp Dublin CA, math summer camp Dublin CA, summer camp Tri-Valley, summer programs for kids Dublin CA, summer coding camp Dublin CA, summer STEAM camp Dublin CA 2026, coding camp kids Tri-Valley, summer math camp Dublin CA, AI camp for kids Dublin CA, robotics camp kids Dublin CA, game development camp kids, young authors camp summer 2026, summer camp 2026 Dublin CA, STEM camp Pleasanton, STEM camp San Ramon',
     path: '/camps/summer',

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -341,7 +341,7 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/camps/summer': {
-    title: 'Math, Robotics, Coding & AI Summer Camps Dublin CA | GrowWise',
+    title: 'Math, Robotics, Coding & AI Camps Dublin CA | GrowWise',
     description:
       'Summer camps in Dublin, CA for Grades 1–12: Math, Robotics, Coding, AI, game development, and writing. Weekly June–August 2026. Reserve a spot.',
     keywords:


### PR DESCRIPTION
## Summary
- remove duplicate summer camp program DOM from the existing branch
- load GTM for real users outside the cookie consent gate while keeping Meta Pixel consent-gated
- push generate_lead dataLayer events before lead-form redirects and document/import the matching GTM GA4 event tag
- improve /camps/summer paid-ad message match for Math, Robotics, Coding, and AI traffic
- remove render-time randomness from STEAM hero pages to avoid hydration instability

## Validation
- npm run build
- npm run lint
- npm test -- --runTestsByPath src/components/analytics/__tests__/PageTrackingWrapper.test.tsx src/components/analytics/__tests__/MicrosoftClarity.test.tsx
- browser smoke: /camps/summer with fbclid and paid UTM, /steam/game-development, /steam/ml-ai-coding

## Manual follow-up after merge/deploy
- import and publish gtm/virtual_page_view_import.json in GTM
- confirm GA4 generate_lead fires in GTM Preview/GA4 DebugView
- mark generate_lead as a GA4 key event and import it into Google Ads
- consent-block only the Meta Pixel tag in GTM, not GA4 or generate_lead

## Notes
- Automated audit environments still suppress GTM script loading, so final GTM verification must be done with GTM Preview in a normal browser session.
- Production mobile Lighthouse should still be rerun after deploy before calling LCP fully optimized.