### PR TITLE
fix: remove incomplete Course JSON-LD from section layouts

### DIFF
--- a/src/app/[locale]/academic/layout.tsx
+++ b/src/app/[locale]/academic/layout.tsx
@@ -36,16 +36,6 @@ export default function AcademicLayout({
       "url": baseUrl,
     },
     "areaServed": ["Dublin, CA", "Pleasanton, CA", "San Ramon, CA", "Tri-Valley, CA"],
-    "hasOfferCatalog": {
-      "@type": "OfferCatalog",
-      "name": "Academic Programs",
-      "itemListElement": [
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Math Tutoring Grades 1-12", "url": `${baseUrl}/academic/math` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "High School Math", "url": `${baseUrl}/academic/math/high-school` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "English Tutoring Grades 1-12", "url": `${baseUrl}/academic/english` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "SAT Prep", "url": `${baseUrl}/courses/sat-prep` } },
-      ],
-    },
   }
 
   return (

--- a/src/app/[locale]/future-skills/layout.tsx
+++ b/src/app/[locale]/future-skills/layout.tsx
@@ -50,6 +50,7 @@ export default async function FutureSkillsLayout({
           '@type': 'Course',
           name: pathway.title,
           description: pathway.summary,
+          provider: { '@type': 'Organization', name: 'GrowWise School' },
           url: absoluteSiteUrl(pathway.href, locale, baseUrl),
         },
       })),

--- a/src/app/[locale]/programs/layout.tsx
+++ b/src/app/[locale]/programs/layout.tsx
@@ -30,18 +30,6 @@ export default function ProgramsLayout({
       "url": baseUrl,
     },
     "areaServed": ["Dublin, CA", "Pleasanton, CA", "San Ramon, CA", "Tri-Valley, CA"],
-    "hasOfferCatalog": {
-      "@type": "OfferCatalog",
-      "name": "All Programs",
-      "itemListElement": [
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Math Tutoring", "url": `${baseUrl}/academic/math` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "English Tutoring", "url": `${baseUrl}/academic/english` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "SAT Prep", "url": `${baseUrl}/courses/sat-prep` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Future Skills Pathways", "url": `${baseUrl}/future-skills` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "ML/AI Coding", "url": `${baseUrl}/steam/ml-ai-coding` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Game Development", "url": `${baseUrl}/steam/game-development` } },
-      ],
-    },
   }
 
   return (

--- a/src/app/[locale]/steam/layout.tsx
+++ b/src/app/[locale]/steam/layout.tsx
@@ -28,17 +28,6 @@ export default function SteamLayout({
       "url": baseUrl,
     },
     "areaServed": ["Dublin, CA", "Pleasanton, CA", "San Ramon, CA", "Tri-Valley, CA"],
-    "hasOfferCatalog": {
-      "@type": "OfferCatalog",
-      "name": "STEAM Programs",
-      "itemListElement": [
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Future Skills Pathways", "url": `${baseUrl}/future-skills` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "ML/AI Coding", "url": `${baseUrl}/steam/ml-ai-coding` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Game Development", "url": `${baseUrl}/steam/game-development` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Coding Programs", "url": `${baseUrl}/coding` } },
-        { "@type": "Offer", "itemOffered": { "@type": "Course", "name": "Game Dev", "url": `${baseUrl}/game-dev` } },
-      ],
-    },
   }
 
   return (

--- a/src/lib/seo/__tests__/layout-offer-catalog.test.ts
+++ b/src/lib/seo/__tests__/layout-offer-catalog.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { buildEducationalOrganizationSchema } from '@/lib/seo/educationalOrganizationSchema'
+
+const APP_LOCALE = join(process.cwd(), 'src', 'app', '[locale]')
+
+/** Section layouts must not duplicate bare Course nodes — org schema covers sitewide catalog. */
+const LAYOUTS_WITHOUT_OFFER_CATALOG = [
+  'academic/layout.tsx',
+  'programs/layout.tsx',
+  'steam/layout.tsx',
+] as const
+
+describe('layout offer catalog — Rich Results regression', () => {
+  it.each(LAYOUTS_WITHOUT_OFFER_CATALOG)(
+    '%s does not emit hasOfferCatalog (avoids incomplete Course duplicates)',
+    (relativePath) => {
+      const source = readFileSync(join(APP_LOCALE, relativePath), 'utf8')
+      expect(source).not.toContain('hasOfferCatalog')
+    },
+  )
+
+  it('site-wide org catalog courses include description, provider, and url', () => {
+    const schema = buildEducationalOrganizationSchema() as Record<string, unknown>
+    const catalog = schema.hasOfferCatalog as Record<string, unknown>
+    const items = catalog.itemListElement as Array<Record<string, unknown>>
+
+    expect(items.length).toBeGreaterThanOrEqual(5)
+
+    for (const offer of items) {
+      const course = offer.itemOffered as Record<string, unknown>
+      expect(course['@type']).toBe('Course')
+      expect(typeof course.description).toBe('string')
+      expect((course.description as string).length).toBeGreaterThan(10)
+      expect(course.provider).toMatchObject({
+        '@type': 'Organization',
+        name: 'GrowWise School',
+      })
+      expect(typeof course.url).toBe('string')
+      expect(course.url).toMatch(/^https:\/\//)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes Google Rich Results "Missing field description" errors on `/academic/math`, `/academic/math/elementary`, `/programs`, and `/steam`
- Removes redundant `hasOfferCatalog` blocks from academic, programs, and steam section layouts that nested bare `Course` objects (name + url only)
- Site-wide `EducationalOrganization` schema already provides complete course catalog on every page
- Adds `provider` to Future Skills catalog courses
- Adds regression test in `layout-offer-catalog.test.ts`

## Test plan
- [ ] `npm test -- --testPathPatterns="layout-offer-catalog|educationalOrganizationSchema" --ci`
- [ ] Rich Results Test: `https://growwiseschool.org/academic/math` — no invalid Course items
- [ ] Rich Results Test: `https://growwiseschool.org/academic/math/elementary` — no invalid Course items
- [ ] Optional GSC URL Inspection → Request indexing on `/academic/math`


Made with [Cursor](https://cursor.com)