### PR TITLE
fix(seo): allow locale redirect crawl + SEO implementation rules

### DIFF
--- a/.cursor/SEO.md
+++ b/.cursor/SEO.md
@@ -1,162 +1,685 @@
-# GrowWise School — SEO Checklist (Enforced)
+# GrowWise SEO Implementation Rules
 
-**Read this before adding routes, blogs, resources, metadata, sitemap entries, or conversion CTAs.**
+This file is the required SEO guardrail for all future GrowWise website changes.
 
-Full architecture hub: [`docs/SEO.md`](../docs/SEO.md)  
-Operational runbooks: [`docs/seo-post-deploy-checklist.md`](../docs/seo-post-deploy-checklist.md), [`docs/seo-jsonld-validation.md`](../docs/seo-jsonld-validation.md)
+Before changing routes, navigation, metadata, sitemap, robots.txt, redirects, page content, schema, internal links, or program pages, check this file first.
+
+**Supporting docs:** Architecture hub → [`docs/SEO.md`](../docs/SEO.md)  
+Post-deploy runbooks → [`docs/seo-post-deploy-checklist.md`](../docs/seo-post-deploy-checklist.md), [`docs/seo-jsonld-validation.md`](../docs/seo-jsonld-validation.md)
 
 Violations = incorrect solution. If a constraint cannot be met, STOP and explain.
 
 ---
 
-## 1. Business goals
+## 1. Current SEO Strategy
 
-| Priority | Path | Role |
-|----------|------|------|
-| **Primary** | `/book-assessment` | Free assessment booking — top conversion goal |
-| **Secondary** | `/enroll` | Enrollment form (marketing) or Phase3 payment when `?program=` is set |
-| **Program hubs** | `/academic`, `/steam/*`, `/camps/summer`, `/programs` | Intent-matched next step from content |
+GrowWise SEO priority is:
 
-Every **indexable** page must link to at least one conversion action (assessment, enroll, or a relevant program hub).
+1. Local academic intent
+   * Math tutoring
+   * English / reading / writing
+   * SAT / PSAT
+   * IM1 / IM2 readiness
+   * Dublin, Pleasanton, San Ramon, Tri-Valley
+
+2. Certification-based Future Skills
+   * Design & Creative Media
+   * Python Certification
+   * AI & Data / Artificial Intelligence
+   * AI Entrepreneur
+
+3. Search-driven parent content
+   * Readiness checklists
+   * Comparison articles
+   * Parent guides
+   * Grade/pathway preparation articles
+
+Do not prioritize Roblox, Scratch, Unity, or Game Development unless specifically requested. Keep existing Game Development pages live if already present, but do not promote them in main navigation or SEO priority work.
 
 ---
 
-## 2. New marketing page checklist
+## 2. Domain and Canonical Rules
 
-Use this for any new page under `src/app/[locale]/`:
+Canonical domain:
 
-- [ ] **Route location:** Page lives under `src/app/[locale]/{path}/page.tsx` only. Never duplicate at root `app/{path}/page.tsx` — that shadows the locale route (see `/enroll` lesson).
-- [ ] **Metadata:** Add entry to `src/lib/seo/metadataConfig.ts` **or** page-level `generateMetadata` using `getCanonicalSiteUrl()` + `absoluteSiteUrl()` from `@/lib/publicPath`.
-- [ ] **Title / description:** Title ≤ 60 characters. Description ≤ 150 characters. No pricing in meta descriptions.
-- [ ] **Headings:** One `h1` matching page intent. Logical `h2` → `h3` hierarchy.
-- [ ] **Sitemap:** If indexable, add to `src/lib/seo/sitemapData.ts` (`corePages`, camp slugs via `getCampSlugs()`, or the appropriate array).
-- [ ] **JSON-LD:** Reuse helpers in `src/lib/seo/structuredData.ts` and components under `src/components/schema/`. FAQ visible text must match FAQPage JSON-LD exactly.
-- [ ] **Internal links:** Page is linked **from** at least one hub (nav, footer, programs, camps, academic, or a related parent page). No orphan indexable URLs.
-- [ ] **Conversion:** Primary CTA visible without excessive scroll on mobile. Use `publicPath(path, locale)` for locale-aware links — never hardcode `/en/...`.
-- [ ] **Images:** `next/image` with `alt`, `sizes`, and appropriate `priority`/`loading`.
-
----
-
-## 3. New blog post checklist (`/growwise-blogs/*`)
-
-- [ ] Create `src/app/[locale]/growwise-blogs/{slug}/page.tsx`
-- [ ] Add slug path to `blogPostPaths` in `src/lib/seo/sitemapData.ts`
-- [ ] `generateMetadata`: title, description, canonical, OG image
-- [ ] Article JSON-LD via `generateArticleSchema()` in `structuredData.ts`
-- [ ] Bottom CTA: use `BlogPostConversionSection` — **never** enroll-only bottom bands
-
-### Program mapping by article intent
-
-| Intent | `programHref` | `programLabel` |
-|--------|---------------|----------------|
-| Coding / Python / Java / AI / career | `/future-skills` | Explore Future Ready Skills Pathways |
-| Game dev / Roblox | `/steam/game-development` | Explore Game Development |
-| Summer camps | `/camps/summer` | View Summer Camp Programs |
-| Academic / learning gaps / focus | `/academic` | Explore Academic Programs |
-| Assessment-led | `/book-assessment` | Book Free Assessment |
-| Math self-check | `/self-check` | Take the Math Self-Check |
-
-Example:
-
-```tsx
-import { BlogPostConversionSection } from '@/components/blogs/BlogPostConversionSection';
-
-<BlogPostConversionSection
-  locale={locale}
-  programHref="/future-skills"
-  programLabel="Explore Future Ready Skills Pathways"
-/>
+```txt
+https://growwiseschool.org
 ```
 
-Every blog conversion band includes: **program CTA** + **Book Free Assessment** + **Or enroll now** (tertiary link).
+Rules:
 
----
+* Use non-www canonical URLs.
+* Do not create canonical URLs with `www`.
+* Do not create duplicate URLs for the same page.
+* Keep canonical tags consistent with sitemap URLs.
+* Do not change Vercel/DNS settings from code.
+* Do not treat old audit data as current truth unless reproduced live.
 
-## 4. New resource article checklist (`/resources/*`)
+Expected behavior:
 
-- [ ] Add path to `RESOURCE_ARTICLE_PATHS` in `src/data/resources/index.ts` — sitemap picks it up automatically
-- [ ] Follow existing resource page pattern (structured sections, FAQ, related links)
-- [ ] Link from `/resources` hub and footer when published
-- [ ] Metadata + Article/FAQ JSON-LD matching visible content
-
----
-
-## 5. New camp SEO page checklist (`/camps/{slug}`)
-
-- [ ] Camp data in `src/lib/camps/` (see `get-camp-page.ts`, `CAMP_LANDING_PAGES`)
-- [ ] Slug included via `getCampSlugs()` in sitemap
-- [ ] Linked from `/camps/summer` (`FeaturedCampGuidesSection`) and/or `/camps` hub
-- [ ] Camp-specific metadata via `src/lib/seo/camp-metadata.ts` where applicable
-
----
-
-## 6. Route & indexing rules
-
-| Rule | Detail |
-|------|--------|
-| **Robots** | Single source: `src/app/robots.ts`. Do **not** add `public/robots.txt`. |
-| **Sitemap** | Index at `/sitemap.xml` → `sitemap-pages.xml` + `sitemap-blogs.xml`. Logic in `sitemapData.ts`. |
-| **Locale URLs** | `localePrefix: 'never'` — canonical URLs have no `/en/` prefix. Legacy `/en/*` 301 to prefix-free paths via `middleware.ts`. |
-| **Canonical domain** | Use `getCanonicalSiteUrl()` in `src/lib/seo/siteUrl.ts`. Never hand-build `www.` vs non-www inconsistently. |
-| **Protected routes** | Never rename/move/delete routes in `rules.md` §4 (checkout/success, camps/summer, coding, courses/math, steam pages, ad landings). |
-| **URL policy** | No deletions, 301 redirects, noindex, or content removals without GSC/analytics validation. Cross-link duplicate surfaces instead. |
-
-### `/enroll` routing (do not regress)
-
-- `/enroll` → marketing enrollment form (locale layout with header/footer)
-- `/enroll?program=...` → Phase3 payment stepper (`EnrollPhase3Page`)
-- Phase3 steps live under `src/app/enroll/steps/`; page component at `src/components/enroll/EnrollPhase3Page.tsx`
-
----
-
-## 7. Two content systems (do not conflate)
-
-| System | Path | Standards |
-|--------|------|-----------|
-| **Resources** | `/resources/*` | Modern hub-and-spoke; structured metadata; footer/nav links |
-| **Legacy blogs** | `/growwise-blogs/*` | Must still meet metadata, sitemap, and `BlogPostConversionSection` standards |
-
-Parallel program URLs (`/coding`, `/game-dev` vs `/steam/*`) both remain indexable — cross-link between them; do not delete without GSC gate.
-
----
-
-## 8. Required tests
-
-Run after SEO-affecting changes:
-
-```bash
-cd growwise_newui
-npm test -- --testPathPatterns=robots.seo|sitemapData|metadata-length
-npm run build
+```txt
+https://www.growwiseschool.org → https://growwiseschool.org
 ```
 
-When touching camps:
-
-```bash
-npm run test:camps
-```
-
-When touching enrollment routes:
-
-```bash
-npm run test:e2e -- e2e/specs/enroll-phase3-stepper.spec.ts --project=chromium
-```
-
-Defer full mobile-404 / bulk SEO E2E to CI unless the user requests locally.
+If live redirect works, old "www 403" findings are stale/false positives.
 
 ---
 
-## 9. SEO self-review (add to `rules.md` §15)
+## 3. Legacy Locale URL Rules
 
-Before finishing any SEO-related change, verify:
+The site is currently English-only.
 
-- [ ] Sitemap entry added if page is indexable
-- [ ] `metadataConfig` or `generateMetadata` with canonical URL
-- [ ] Conversion path includes `/book-assessment` where appropriate
-- [ ] No root-level `app/{route}/page.tsx` shadowing `[locale]/{route}`
-- [ ] Blog bottom CTA uses `BlogPostConversionSection` (not enroll-only)
-- [ ] Internal link from at least one hub page or nav/footer
-- [ ] Robots/sitemap logic unchanged unless explicitly approved
-- [ ] Founding year remains 2024 in any org/schema copy
+Retired locale prefixes:
 
-State **PASS** or **FAIL** for SEO items alongside the main self-review in `rules.md` §15.
+```txt
+/en
+/hi
+/zh
+/es
+```
+
+Expected behavior:
+
+* Legacy locale URLs should not return live duplicate English content under the prefixed URL.
+* Valid old locale paths may redirect to prefix-free English URLs.
+* Dead old locale paths may redirect to a dead English path and then return hard 404.
+* Do not add locale-prefixed URLs to sitemap.
+* Do not internally link to locale-prefixed URLs.
+* Do not create new `/en`, `/hi`, `/zh`, or `/es` pages unless multilingual strategy is intentionally reopened.
+
+Correct examples:
+
+```txt
+/zh/programs → /programs
+/hi/courses/math → /academic/math
+/hi/dead-old-page → /dead-old-page → 404
+```
+
+Do not force all legacy locale URLs to direct 404 if redirect strategy already exists.
+
+Implementation: [`src/middleware.ts`](../src/middleware.ts) (`redirectLegacyLocalePrefix`), [`src/lib/seo/legacy-path-redirects.ts`](../src/lib/seo/legacy-path-redirects.ts).
+
+---
+
+## 4. Sitemap Rules
+
+Sitemap must be clean, valid, and canonical.
+
+Rules:
+
+* `/sitemap.xml` must use valid XML.
+* If it is a sitemap index, use `<sitemapindex>`.
+* If it is a URL sitemap, use `<urlset>`.
+* Do not duplicate `/resources`.
+* Do not include retired locale-prefixed URLs.
+* Do not include non-canonical duplicate URLs.
+* Do not include URLs that redirect unless intentionally required.
+* Do not include 404 URLs.
+* Use canonical non-www absolute URLs.
+* Include important program, resource, blog, and certification pages.
+
+Required validation after sitemap changes:
+
+```txt
+/sitemap.xml
+/sitemap-pages.xml, if applicable
+/sitemap-blogs.xml, if applicable
+```
+
+Check:
+
+* correct XML format
+* no duplicates
+* no retired locale prefixes
+* no dead URLs
+* canonical non-www URLs only
+
+Implementation: [`src/lib/seo/sitemapData.ts`](../src/lib/seo/sitemapData.ts), [`src/app/sitemap-index.xml/route.ts`](../src/app/sitemap-index.xml/route.ts).
+
+---
+
+## 5. Robots.txt Rules
+
+Robots.txt must protect crawlability.
+
+Rules:
+
+* Do not block important program pages.
+* Do not block important resources or blogs.
+* Do not block sitemap access.
+* Do not block optimized images if Google needs them.
+* Do not block AI crawlers unless business direction changes.
+* Do not use robots.txt as a removal tool.
+* Do not block URLs that Google needs to crawl in order to see redirects.
+
+Important:
+
+If old URLs are intentionally redirected, Google may need to crawl the old URL to process the redirect. Do not block legacy redirect paths without verifying the SEO impact.
+
+Retired locale prefixes (`/en/`, `/hi/`, `/zh/`, `/es/`) are **not** disallowed in [`src/app/robots.ts`](../src/app/robots.ts). Middleware redirects them to prefix-free English URLs (§3); blocking them in robots.txt would prevent Googlebot from discovering those redirects during normal crawl.
+
+Required validation:
+
+```txt
+/robots.txt
+```
+
+Check:
+
+* sitemap URL is present
+* important pages are crawlable
+* image URLs are crawlable if used in metadata/content
+* blog pagination/discovery is not unintentionally blocked
+
+Single source: `src/app/robots.ts`. Do **not** add `public/robots.txt`.
+
+---
+
+## 6. 404 and Soft 404 Rules
+
+Missing pages must return real 404.
+
+Rules:
+
+* Unknown URLs must not return homepage content.
+* Unknown URLs must not return status 200.
+* Unknown URLs must show a real not-found page.
+* Add `noindex,follow` to the not-found page if supported.
+* Do not mask broken links with homepage fallback.
+* Do not redirect random unknown URLs to homepage.
+
+Required test URLs:
+
+```txt
+/random-test-url
+/abc123
+/academic/not-real-page
+```
+
+Expected:
+
+```txt
+HTTP 404
+Not homepage content
+Clear not-found page
+```
+
+Implementation: [`src/middleware.ts`](../src/middleware.ts) (`hard404UnknownPublicPath`, `notFoundResponse`).
+
+---
+
+## 7. Redirect Rules
+
+Redirects must be intentional and minimal.
+
+Allowed redirects:
+
+* `www` to non-www
+* legacy locale prefix to prefix-free English path
+* old known page to closest relevant current page
+* duplicate resource URL to canonical resource URL
+* renamed route to new route
+
+Avoid:
+
+* redirecting unrelated old pages to homepage
+* long redirect chains
+* redirect loops
+* redirecting all 404s automatically
+* redirecting low-value dead slugs without a relevant destination
+
+Important duplicate to verify:
+
+```txt
+/readinesschecklist
+/resources/readiness-checklist
+```
+
+There must be one canonical version. **Current state:** canonical is `/readinesschecklist` ([`metadataConfig.ts`](../src/lib/seo/metadataConfig.ts)); `/resources/readiness-checklist` still exists — resolve with redirect or consolidation in a separate approved PR.
+
+---
+
+## 8. Metadata Rules
+
+Metadata must be verified from rendered output, not only source code.
+
+For changed pages, check:
+
+* title
+* meta description
+* canonical URL
+* OG title
+* OG description
+* OG image
+* robots meta
+
+Guidelines:
+
+* Title should be clear, search-intent aligned, and not unnecessarily long.
+* Meta description should be accurate and parent-search friendly.
+* Do not keyword-stuff.
+* Do not create duplicate metadata across pages.
+* Use local terms naturally only where relevant.
+* Canonical must be non-www.
+* OG image must return real image content, not HTML.
+
+Required OG image check:
+
+```txt
+/og-image.jpg
+```
+
+Route: [`src/app/og-image.jpg`](../src/app/og-image.jpg). Default in [`metadataConfig.ts`](../src/lib/seo/metadataConfig.ts) and [`metadata.ts`](../src/lib/seo/metadata.ts).
+
+Expected:
+
+```txt
+HTTP 200
+Content-Type: image/jpeg, image/png, or image/webp
+Actual image response, not HTML
+```
+
+---
+
+## 9. Internal Linking Rules
+
+Internal links should support priority pages.
+
+Rules:
+
+* Do not link to retired locale-prefixed URLs.
+* Do not link to removed routes.
+* Do not link to duplicate URLs.
+* Do not link to redirecting URLs when the final canonical URL is known.
+* Use contextual links from blogs/resources to program pages.
+* Use hub pages to support money pages.
+* Keep footer useful but do not rely only on footer links.
+* Avoid footer link bloat as the main SEO structure.
+
+Priority internal link destinations:
+
+```txt
+/
+/academic/math
+/academic/english
+/courses/sat-prep
+/future-skills
+/future-skills/design-creative-media
+/future-skills/python-certification
+/future-skills/ai-machine-learning
+/future-skills/ai-entrepreneurship
+/readinesschecklist
+/book-assessment
+```
+
+Every search-driven article should link to:
+
+1. one main program page
+2. one related article/resource
+3. one assessment or CTA page
+4. one local/service page if relevant
+
+Use `publicPath(path, locale)` from [`src/lib/publicPath.ts`](../src/lib/publicPath.ts) — never hardcode `/en/...`.
+
+---
+
+## 10. Navigation Rules
+
+Current navigation direction:
+
+Replace generic STEAM positioning with certification-forward positioning.
+
+Preferred menu label:
+
+```txt
+Coding & Certifications
+```
+
+Short fallback:
+
+```txt
+Certifications
+```
+
+Primary dropdown should prioritize:
+
+1. Design & Creative Media
+2. Python Certification
+3. AI & Data / Artificial Intelligence
+4. AI Entrepreneur
+
+Do not show these as priority dropdown items unless requested:
+
+* Game Development
+* Roblox
+* Scratch
+* Unity
+* generic STEAM Programs wording
+
+Do not delete old Game Development pages automatically. Keep them live unless a separate removal/redirect plan is approved.
+
+---
+
+## 11. Certification Wording Rules
+
+Current certification status:
+
+* GrowWise is approved for Certiport.
+* GrowWise is in process for PCEP/OpenEDG.
+* Do not claim PCEP/OpenEDG approval yet.
+
+Allowed wording:
+
+```txt
+GrowWise is approved for Certiport.
+Certiport certification pathways.
+Certiport-aligned certification programs.
+Adobe certification pathway.
+Python certification pathway.
+Artificial intelligence certification pathway.
+Entrepreneurship certification pathway.
+Certification readiness.
+Exam preparation.
+```
+
+For PCEP/OpenEDG, allowed wording only:
+
+```txt
+PCEP/OpenEDG pathway in progress.
+Python certification pathway expanding toward PCEP.
+OpenEDG/PCEP approval in process.
+```
+
+Do not say:
+
+```txt
+GrowWise is approved for PCEP.
+OpenEDG approved academy.
+Official PCEP testing center.
+PCEP testing center.
+```
+
+unless later explicitly verified.
+
+---
+
+## 12. Future Skills Page Rules
+
+Priority Future Skills pages:
+
+```txt
+/future-skills
+/future-skills/design-creative-media
+/future-skills/python-certification
+/future-skills/ai-machine-learning
+/future-skills/ai-entrepreneurship
+```
+
+If route names change, preserve SEO intent and add proper redirects.
+
+Future Skills page content should emphasize:
+
+* certification pathways
+* project-based learning
+* portfolio readiness
+* middle and high school suitability
+* responsible AI use
+* parent-friendly outcomes
+* clear CTA
+
+Preferred CTAs:
+
+```txt
+Explore Certification Pathways
+Book a Free Assessment
+Start Certification Readiness
+```
+
+---
+
+## 13. Content and Article SEO Rules
+
+All new articles must be search-driven.
+
+Do not publish generic blogs.
+
+Each article must have:
+
+* clear primary search intent
+* clear parent/student audience
+* one main target query
+* one supporting query cluster
+* internal links to relevant money pages
+* useful headings
+* direct-answer sections
+* FAQ if appropriate
+* no filler content
+
+Priority article clusters:
+
+1. Python certification for students
+2. Certiport vs PCEP / Python pathway
+3. Adobe certification for students
+4. AI certification for students
+5. AI classes for middle/high school
+6. Math tutoring Dublin CA
+7. IM1 readiness
+8. IM2 readiness
+9. SAT/PSAT preparation timeline
+10. Middle school word problem struggles
+11. Writing improvement for middle school
+12. Reading comprehension support
+13. Dublin / Pleasanton / San Ramon academic pathways
+
+Do not create thin duplicate city pages. Local pages must have unique, useful local content.
+
+---
+
+## 14. Schema Rules
+
+Schema must remain valid.
+
+Current useful schema types:
+
+* EducationalOrganization
+* LocalBusiness
+* WebSite
+* BlogPosting
+* FAQPage
+* BreadcrumbList
+* Event, when there is a real event/workshop
+
+Rules:
+
+* Do not add fake schema.
+* Do not add FAQ schema unless FAQs are visible on the page.
+* Do not add Event schema unless event details are real and visible.
+* Do not break existing JSON-LD.
+* Validate schema after global changes.
+* Use BreadcrumbList on camps/resources/program pages where appropriate.
+
+Helpers: [`src/lib/seo/structuredData.ts`](../src/lib/seo/structuredData.ts), [`src/components/schema/`](../src/components/schema/).
+
+---
+
+## 15. Rendered Content Rules
+
+Important pages must have meaningful rendered content.
+
+Do not rely on nearly empty initial HTML for priority SEO pages.
+
+Pages to watch:
+
+```txt
+/enroll
+/camps/academic-summer-programs-dublin-ca
+/camps/winter/calendar
+/game-dev
+```
+
+If a page is priority, it should have:
+
+* rendered H1
+* meaningful crawlable content
+* clear metadata
+* internal links
+* CTA
+* no empty shell behavior
+
+If a page is not priority, mark it for later instead of making random changes.
+
+---
+
+## 16. AEO / AI Visibility Rules
+
+AEO priority:
+
+* clear answers
+* FAQs
+* comparison content
+* parent guides
+* llms.txt
+* strong internal links to key resources
+
+Rules:
+
+* Keep `/llms.txt` updated.
+* Include priority program/resource links.
+* Do not feature deprecated Game Development pages as primary AI visibility links.
+* Keep AI bots allowed unless business direction changes.
+* Write clear, direct answers in resource content.
+* Surface comparison articles because AI engines often use them.
+
+Important llms.txt links should include:
+
+```txt
+/future-skills
+/future-skills/python-certification
+/future-skills/design-creative-media
+/future-skills/ai-machine-learning
+/future-skills/ai-entrepreneurship
+/academic/math
+/academic/english
+/readinesschecklist
+```
+
+Route: [`src/app/llms.txt`](../src/app/llms.txt).
+
+---
+
+## 17. PR Validation Rules
+
+Every SEO-related PR must include validation evidence.
+
+Required validation table:
+
+| Check | Result | Evidence | Follow-up |
+| ----- | ------ | -------- | --------- |
+
+Minimum checks:
+
+```txt
+/robots.txt
+/sitemap.xml
+/llms.txt
+/random-test-url
+/abc123
+/academic/not-real-page
+/og-image.jpg
+```
+
+For changed pages, also check:
+
+* rendered title
+* rendered description
+* canonical URL
+* OG tags
+* status code
+* content-type
+* H1
+* internal links
+* schema if touched
+
+Screenshots are useful, but screenshots alone are not enough.
+
+SEO proof requires:
+
+* HTTP status code
+* response content-type
+* rendered HTML check
+* canonical URL
+* metadata output
+* link checker result where relevant
+
+---
+
+## 18. Do Not Do These
+
+Do not:
+
+* change Vercel/DNS from code
+* fix stale audit findings without live/repo validation
+* create duplicate city pages
+* keyword-stuff Dublin/Pleasanton/San Ramon
+* add locale-prefixed pages
+* add pages to sitemap that redirect or 404
+* redirect unrelated old pages to homepage
+* remove existing pages without redirect plan
+* claim PCEP/OpenEDG approval
+* promote Game Development in main nav
+* use generic STEAM positioning as the primary strategy
+* publish generic non-search-driven articles
+* rely only on source code instead of rendered output
+* merge SEO changes without validation evidence
+
+---
+
+## 19. Merge Gate
+
+Do not merge SEO-related PRs unless:
+
+* sitemap is valid
+* robots.txt is correct
+* unknown routes return real 404
+* canonicals are non-www
+* no retired locale URLs are added to sitemap
+* no broken internal links are introduced
+* metadata is verified from rendered output
+* OG image path returns a real image
+* changed schema parses correctly
+* priority pages remain crawlable
+* validation table is included (§17)
+
+---
+
+## 20. Current GSC Targets
+
+Current baseline from June 2026:
+
+```txt
+~66 clicks / 7 days
+~2.01K impressions / 7 days
+~3.3% CTR
+~10.9 average position
+```
+
+30-day target after Batch 1 + Batch 2 + search-driven articles:
+
+```txt
+500–650 clicks/month
+15K–20K impressions/month
+CTR above 4%
+Average position under 10
+```
+
+Track weekly:
+
+* clicks
+* impressions
+* CTR
+* average position
+* indexed pages
+* queries ranking positions 5–20
+* pages with high impressions and low CTR
+
+Do not judge SEO from one-day movement. Use 7-day and 28-day comparisons.

--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -100,7 +100,7 @@ Act as: Principal Engineer + Senior QA Engineer + Senior UX Designer.
 
 ## 7. SEO & CONTENT INTEGRITY
 
-**Full checklist → [`.cursor/SEO.md`](SEO.md)** (read before any new route, blog, resource, or metadata change).  
+**Implementation rules → [`.cursor/SEO.md`](SEO.md)** (read before any new route, blog, resource, or metadata change).  
 Architecture hub → [`docs/SEO.md`](../docs/SEO.md).
 
 1. Never remove or weaken SEO metadata — page titles, descriptions, keywords, JSON-LD structured data, and canonical URLs are intentional. Changes require approval.
@@ -198,7 +198,7 @@ Before final output, verify:
 - [ ] Primary CTA is visually dominant — no competing actions at equal weight
 - [ ] Only existing color palette, font scale, and component patterns used
 - [ ] Heading hierarchy is correct (`h1` → `h2` → `h3`, one `h1` per page)
-- [ ] SEO checklist (`.cursor/SEO.md` §9): sitemap, metadata, conversion path, no route shadowing, blog CTA pattern
+- [ ] SEO Implementation Rules (`.cursor/SEO.md` §17 validation table, §19 merge gate): sitemap, metadata, conversion path, no route shadowing, blog CTA pattern
 - [ ] Targeted E2E run when change touches conversion/enrollment/routes (see §17; not full suite unless requested)
 
 State **PASS** or **FAIL**. If FAIL: fix or refuse and explain.

--- a/.cursor/rules/growwise-school-enforced.mdc
+++ b/.cursor/rules/growwise-school-enforced.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 **Canonical sources (read before non-trivial work):**
 - [.cursorrules](../.cursorrules) — approval workflow, git safety, code quality
 - [.cursor/rules.md](../rules.md) — engineering, UX, Lighthouse, conversion, routes, SEO, testing
-- [.cursor/SEO.md](../SEO.md) — new routes, metadata, sitemap, blogs, conversion paths
+- [.cursor/SEO.md](../SEO.md) — SEO implementation rules (strategy, validation, merge gate)
 - [docs/SEO.md](../../docs/SEO.md) — SEO architecture hub + GSC runbooks
 
 Violations = incorrect solution. If a constraint cannot be met, STOP and explain — do not guess.
@@ -40,7 +40,7 @@ Act as **Principal Engineer + Senior QA + Senior UX Designer** for a parent-faci
 
 ## Self-review before finishing
 
-State **PASS** or **FAIL** against `rules.md` §15 checklist (git, build, lint, routes, tracking, mobile, CTA hierarchy, headings, SEO items in `.cursor/SEO.md` §9).
+State **PASS** or **FAIL** against `rules.md` §15 checklist (git, build, lint, routes, tracking, mobile, CTA hierarchy, headings, SEO items per `.cursor/SEO.md` §17 and §19).
 
 ## Timing copy (homepage PR context)
 

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -1,8 +1,8 @@
 # GrowWise School — SEO Architecture Hub
 
-This document maps how SEO works in `growwise_newui` and links to operational runbooks.
+This document maps how SEO is implemented in `growwise_newui` and links to operational runbooks.
 
-**Agent checklist (mandatory before route/content changes):** [`.cursor/SEO.md`](../.cursor/SEO.md)
+**Implementation rules (mandatory before route/content changes):** [`.cursor/SEO.md`](../.cursor/SEO.md) — strategy, validation gates, merge criteria, and do-not-do list.
 
 ---
 
@@ -38,8 +38,9 @@ flowchart LR
 | Page titles, descriptions, keywords | `src/lib/seo/metadataConfig.ts`, `src/lib/seo/metadata.ts` |
 | Canonical site URL | `src/lib/seo/siteUrl.ts` → `getCanonicalSiteUrl()` |
 | Sitemap entries + XML helpers | `src/lib/seo/sitemapData.ts` |
-| Sitemap route handlers | `src/app/sitemap.ts`, `sitemap-pages.xml/`, `sitemap-blogs.xml/` |
+| Sitemap route handlers | `src/app/sitemap-index.xml/route.ts`, `sitemap-pages.xml/`, `sitemap-blogs.xml/` (+ rewrite in `next.config.ts`) |
 | Crawl policy | `src/app/robots.ts` (no `public/robots.txt`) |
+| Legacy path redirects | `src/lib/seo/legacy-path-redirects.ts`, `next.config.ts` |
 | JSON-LD helpers | `src/lib/seo/structuredData.ts` |
 | Schema components | `src/components/schema/` |
 | Camp SEO landing pages | `src/lib/camps/get-camp-page.ts`, `src/lib/seo/camp-metadata.ts` |
@@ -48,6 +49,8 @@ flowchart LR
 | Resource article registry | `src/data/resources/index.ts` → `RESOURCE_ARTICLE_PATHS` |
 | Locale routing | `src/middleware.ts` (`localePrefix: 'never'`) |
 | Locale-aware paths | `src/lib/publicPath.ts` → `publicPath()`, `absoluteSiteUrl()` |
+| AEO hints | `src/app/llms.txt` |
+| OG image route | `src/app/og-image.jpg` |
 
 ---
 
@@ -55,8 +58,8 @@ flowchart LR
 
 | Sitemap | Contents |
 |---------|----------|
-| `/sitemap.xml` | Index pointing to child sitemaps |
-| `/sitemap-pages.xml` | Core pages, academic, courses, STEAM, camps, enroll, assessment |
+| `/sitemap.xml` | Index (`<sitemapindex>`) pointing to child sitemaps |
+| `/sitemap-pages.xml` | Core pages, academic, courses, Future Skills, camps, enroll, assessment |
 | `/sitemap-blogs.xml` | `/growwise-blogs/*` posts + `/resources/*` articles |
 
 **Adding a new indexable page:** edit `sitemapData.ts` (`corePages`, `blogPostPaths`, or rely on `RESOURCE_ARTICLE_PATHS` / `getCampSlugs()`).
@@ -65,16 +68,88 @@ flowchart LR
 
 ## Hub-and-spoke content map
 
-Cross-link these clusters; do not delete or redirect URLs without GSC validation.
+Cross-link these clusters; do not delete or redirect URLs without GSC validation (see `.cursor/SEO.md` §7, §18).
 
-| Hub | Spokes / related URLs |
-|-----|----------------------|
-| **Dublin local** | `/dublin-ca`, location mentions on academic/camp pages |
-| **Summer camps** | `/camps/summer`, `/camps/{slug}` (6 camp guides), summer resource articles |
-| **STEAM / coding** | `/steam`, `/steam/ml-ai-coding`, `/steam/game-development`, `/coding`, `/game-dev` |
-| **Academic / math** | `/academic`, `/academic/math`, `/courses/math`, `/math-finals-practice-session` |
-| **Assessment funnel** | `/book-assessment`, `/self-check`, `/enroll`, `/enroll-academic` |
-| **Blog → program** | Legacy blogs link to intent-matched program + assessment (see `.cursor/SEO.md` mapping) |
+| Priority | Hub | Spokes / related URLs |
+|----------|-----|----------------------|
+| **Primary** | **Academic** | `/academic`, `/academic/math`, `/academic/english`, `/courses/sat-prep`, `/math-finals-practice-session` |
+| **Primary** | **Future Skills / certifications** | `/future-skills`, `/future-skills/design-creative-media`, `/future-skills/python-certification`, `/future-skills/ai-machine-learning`, `/future-skills/ai-entrepreneurship` |
+| **Primary** | **Parent content** | `/readinesschecklist`, `/resources`, `/resources/*` articles |
+| **Secondary** | **Summer camps** | `/camps/summer`, `/camps/academic-summer-programs-dublin-ca`, `/camps/{slug}` camp guides |
+| **Secondary** | **Local** | `/dublin-ca`, location mentions on academic/camp pages |
+| **Secondary** | **Assessment funnel** | `/book-assessment`, `/self-check`, `/enroll`, `/enroll-academic` |
+| **Live, non-priority** | **Game dev / legacy STEAM** | `/steam/game-development`, `/game-dev`, `/coding` — keep indexable and cross-linked; do not promote in nav or new SEO work unless requested |
+
+---
+
+## Developer checklists
+
+Use these when implementing new pages. Strategy and merge gates: `.cursor/SEO.md`.
+
+### New marketing page (`src/app/[locale]/`)
+
+- [ ] Page lives under `src/app/[locale]/{path}/page.tsx` only. Never duplicate at root `app/{path}/page.tsx` — that shadows the locale route (see `/enroll` lesson).
+- [ ] **Metadata:** Add entry to `metadataConfig.ts` **or** page-level `generateMetadata` using `getCanonicalSiteUrl()` + `absoluteSiteUrl()` from `@/lib/publicPath`.
+- [ ] **Title / description:** Title ≤ 60 characters. Description ≤ 150 characters. No pricing in meta descriptions.
+- [ ] **Headings:** One `h1` matching page intent. Logical `h2` → `h3` hierarchy.
+- [ ] **Sitemap:** If indexable, add to `sitemapData.ts` (`corePages`, camp slugs via `getCampSlugs()`, or the appropriate array).
+- [ ] **JSON-LD:** Reuse helpers in `structuredData.ts` and `src/components/schema/`. FAQ visible text must match FAQPage JSON-LD exactly.
+- [ ] **Internal links:** Page is linked **from** at least one hub (nav, footer, programs, camps, academic, or a related parent page). No orphan indexable URLs.
+- [ ] **Conversion:** Primary CTA visible without excessive scroll on mobile. Use `publicPath(path, locale)` — never hardcode `/en/...`.
+- [ ] **Images:** `next/image` with `alt`, `sizes`, and appropriate `priority`/`loading`.
+
+### New blog post (`/growwise-blogs/*`)
+
+- [ ] Create `src/app/[locale]/growwise-blogs/{slug}/page.tsx`
+- [ ] Add slug path to `blogPostPaths` in `sitemapData.ts`
+- [ ] `generateMetadata`: title, description, canonical, OG image
+- [ ] Article JSON-LD via `generateArticleSchema()` in `structuredData.ts`
+- [ ] Bottom CTA: use `BlogPostConversionSection` — **never** enroll-only bottom bands
+
+#### Program mapping by article intent
+
+Prefer certification and academic hubs. Game dev mapping is secondary only.
+
+| Intent | `programHref` | `programLabel` |
+|--------|---------------|----------------|
+| Coding / Python / Java / AI / career / certification | `/future-skills` | Explore Certification Pathways |
+| Academic / learning gaps / focus / math / English | `/academic` | Explore Academic Programs |
+| Summer camps | `/camps/summer` | View Summer Camp Programs |
+| Assessment-led | `/book-assessment` | Book Free Assessment |
+| Math self-check | `/self-check` | Take the Math Self-Check |
+| Game dev / Roblox *(secondary — use only when article is explicitly about game dev)* | `/steam/game-development` | Explore Game Development |
+
+```tsx
+import { BlogPostConversionSection } from '@/components/blogs/BlogPostConversionSection';
+
+<BlogPostConversionSection
+  locale={locale}
+  programHref="/future-skills"
+  programLabel="Explore Certification Pathways"
+/>
+```
+
+Every blog conversion band includes: **program CTA** + **Book Free Assessment** + **Or enroll now** (tertiary link).
+
+### New resource article (`/resources/*`)
+
+- [ ] Add path to `RESOURCE_ARTICLE_PATHS` in `src/data/resources/index.ts` — sitemap picks it up automatically
+- [ ] Follow existing resource page pattern (structured sections, FAQ, related links)
+- [ ] Link from `/resources` hub and footer when published
+- [ ] Metadata + Article/FAQ JSON-LD matching visible content
+
+### New camp SEO page (`/camps/{slug}`)
+
+- [ ] Camp data in `src/lib/camps/` (see `get-camp-page.ts`, `CAMP_LANDING_PAGES`)
+- [ ] Slug included via `getCampSlugs()` in sitemap
+- [ ] Linked from `/camps/summer` (`FeaturedCampGuidesSection`) and/or camps hub
+- [ ] Camp-specific metadata via `src/lib/seo/camp-metadata.ts` where applicable
+
+### `/enroll` routing (do not regress)
+
+- `/enroll` → marketing enrollment form (locale layout with header/footer)
+- `/enroll?program=...` → Phase3 payment stepper (`EnrollPhase3Page`)
+- Phase3 steps live under `src/app/enroll/steps/`; page component at `src/components/enroll/EnrollPhase3Page.tsx`
 
 ---
 
@@ -85,12 +160,22 @@ Cross-link these clusters; do not delete or redirect URLs without GSC validation
 - Registry: `RESOURCE_ARTICLE_PATHS` in `src/data/resources/index.ts`
 - Modern structured pages with FAQ, related content, and hub links
 - Auto-included in blogs sitemap when path is in registry
+- Hub at `/resources` only — not duplicated in pages sitemap
 
 ### Legacy blogs (`/growwise-blogs/*`)
 
 - Individual `page.tsx` per slug under `src/app/[locale]/growwise-blogs/`
 - Slugs listed manually in `sitemapData.ts` → `blogPostPaths`
 - Bottom CTA standard: `BlogPostConversionSection` (program + assessment + enroll)
+
+### Two content systems (do not conflate)
+
+| System | Path | Standards |
+|--------|------|-----------|
+| **Resources** | `/resources/*` | Modern hub-and-spoke; structured metadata; footer/nav links |
+| **Legacy blogs** | `/growwise-blogs/*` | Must still meet metadata, sitemap, and `BlogPostConversionSection` standards |
+
+Parallel program URLs (`/coding`, `/game-dev` vs `/steam/*`) both remain indexable — cross-link between them; do not delete without GSC gate.
 
 ---
 
@@ -115,7 +200,7 @@ Component: `src/components/camps/FeaturedCampGuidesSection.tsx`
 ### Programs hub
 
 ```
-/programs → Book Free Assessment (primary) + Enroll Now + academic/STEAM cards
+/programs → Book Free Assessment (primary) + Enroll Now + academic / Future Skills cards
 ```
 
 ---
@@ -125,8 +210,11 @@ Component: `src/components/camps/FeaturedCampGuidesSection.tsx`
 | Issue | Resolution |
 |-------|------------|
 | `/enroll` route shadowing | Marketing form at `[locale]/enroll`; Phase3 only when `?program=` is set. No root `app/enroll/page.tsx`. |
-| Parallel STEAM URLs | `/coding` and `/game-dev` coexist with `/steam/*` — cross-link, don't consolidate without GSC data. |
+| Readiness URL duplicate | Canonical is `/readinesschecklist`. `/resources/readiness-checklist` still exists — resolve per `.cursor/SEO.md` §7. |
+| Locale robots + redirects | Do **not** `Disallow` `/en/`, `/hi/`, `/zh/`, `/es/` in `robots.ts` — Googlebot must crawl prefixed URLs to process middleware redirects (`.cursor/SEO.md` §5). |
 | `/en/` legacy URLs | Middleware 301s to prefix-free canonical. Do not make `/en/*` return 200. |
+| Sitemap index | `/sitemap.xml` is a rewrite to `/sitemap-index.xml` — do not add conflicting `app/sitemap.xml/route.ts`. |
+| Parallel STEAM URLs | `/coding` and `/game-dev` coexist with `/steam/*` — cross-link; non-priority for new SEO work. |
 | Robots conflict | Only `app/robots.ts`. Never reintroduce `public/robots.txt`. |
 | FAQ JSON-LD | Visible FAQ text must match `FAQPage` schema exactly (AEO + Rich Results). |
 | Email addresses | Frontend uses `contact@growwiseschool.org`; backend notification constants may differ — don't mix in user-facing copy without checking. |
@@ -143,11 +231,30 @@ Component: `src/components/camps/FeaturedCampGuidesSection.tsx`
 | `src/lib/seo/__tests__/seo-jsonld-route-audit.test.ts` | JSON-LD on key routes |
 | `src/lib/seo/__tests__/countJsonLdTypes.test.ts` | Duplicate schema types |
 | `src/lib/seo/__tests__/homeFaqSchemaDuplicate.test.ts` | Single FAQPage on home |
+| `src/lib/seo/__tests__/layout-offer-catalog.test.ts` | No incomplete Course catalogs in layouts |
 
 ```bash
 cd growwise_newui
-npm test -- --testPathPatterns=robots.seo|sitemapData|metadata-length|countJsonLd|homeFaq
+npm test -- --testPathPatterns=robots.seo|sitemapData|metadata-length|countJsonLd|homeFaq|layout-offer-catalog
 npm run build
+```
+
+When touching camps:
+
+```bash
+npm run test:camps
+```
+
+When touching enrollment routes:
+
+```bash
+npm run test:e2e -- e2e/specs/enroll-phase3-stepper.spec.ts --project=chromium
+```
+
+When touching locale redirects:
+
+```bash
+npm run test:e2e -- e2e/specs/legacy-locale-redirects.spec.ts --project=chromium
 ```
 
 ---
@@ -173,6 +280,7 @@ npm run build
 
 ## Related enforced rules
 
+- [`.cursor/SEO.md`](../.cursor/SEO.md) — implementation rules, PR validation (§17), merge gate (§19)
 - [`.cursor/rules.md`](../.cursor/rules.md) §7 — SEO & content integrity
 - [`.cursor/rules/growwise-school-enforced.mdc`](../.cursor/rules/growwise-school-enforced.mdc) — always-on agent rules
 - [`CLAUDE.md`](../../CLAUDE.md) — repo-level guidance

--- a/docs/seo-jsonld-validation.md
+++ b/docs/seo-jsonld-validation.md
@@ -18,7 +18,7 @@ This is **not** the same as “Page with redirect.” Google fetched the URL but
 
 | URL pattern | Why |
 |-------------|-----|
-| `/en/...`, `/hi/...`, `/zh/...`, `/es/...` | Retired locale prefixes **301** to prefix-free English URLs (`localePrefix: 'never'`). Google should not index prefixed URLs. |
+| `/en/...`, `/hi/...`, `/zh/...`, `/es/...` | Retired locale prefixes **301** to prefix-free English URLs (`localePrefix: 'never'`). Google should not index prefixed URLs. See [`.cursor/SEO.md`](../.cursor/SEO.md) §3 and §5. `robots.ts` must **not** disallow these paths — Googlebot needs to fetch them to process redirects. |
 | `sitemap.xml` | Sitemaps are for discovery, not search results. |
 | `api.growwiseschool.org` | API host should not rank. Block on the API service (`robots.txt` disallow or `noindex`). |
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -13,11 +13,9 @@ export default function robots(): MetadataRoute.Robots {
         '/_next/image?*',
         '/growwise-blogs?page=*',
       ],
+      // Do not disallow /en/, /hi/, /zh/, /es/ — middleware 301s those to prefix-free
+      // English URLs; Googlebot must fetch them to process redirects (.cursor/SEO.md §5).
       disallow: [
-        '/en/',
-        '/hi/',
-        '/zh/',
-        '/es/',
         '/*?*',
         '/favicon.ico',
         '/student-login',

--- a/src/lib/seo/__tests__/robots.seo.test.ts
+++ b/src/lib/seo/__tests__/robots.seo.test.ts
@@ -2,7 +2,7 @@ import robots from '@/app/robots'
 
 /** TC-07 — robots.txt policy (merged static + programmatic rules). */
 describe('robots() — GWA-192 / TC-07', () => {
-  it('allows all, keeps crawl exceptions, and disallows legacy/auth/cart paths', () => {
+  it('allows all, keeps crawl exceptions, and does not block locale redirect paths', () => {
     const r = robots()
     expect(r.sitemap).toMatch(/sitemap\.xml$/)
 
@@ -17,15 +17,19 @@ describe('robots() — GWA-192 / TC-07', () => {
       '/growwise-blogs?page=*',
     ])
     expect(rules.disallow).toEqual([
-      '/en/',
-      '/hi/',
-      '/zh/',
-      '/es/',
       '/*?*',
       '/favicon.ico',
       '/student-login',
       '/cart',
     ])
+  })
+
+  it('does not disallow retired locale prefixes so Googlebot can follow redirects', () => {
+    const serialized = JSON.stringify(robots())
+    expect(serialized).not.toContain('/en/')
+    expect(serialized).not.toContain('/hi/')
+    expect(serialized).not.toContain('/zh/')
+    expect(serialized).not.toContain('/es/')
   })
 
   it('does not disallow marketing program paths', () => {


### PR DESCRIPTION
## Summary
- Remove `Disallow` for `/en/`, `/hi/`, `/zh/`, `/es/` from `robots.ts` so Googlebot can crawl legacy locale-prefixed URLs and discover middleware 301/308 redirects to prefix-free English URLs.
- Replace `.cursor/SEO.md` with the 20-section **GrowWise SEO Implementation Rules** (strategy, validation gates, merge criteria).
- Refactor `docs/SEO.md` as architecture hub; sync `seo-jsonld-validation.md` and agent rule cross-references.

## Why
Blocking `/hi/`, `/zh/`, etc. in robots.txt prevented Googlebot from fetching old prefixed URLs during normal crawl, leaving stale GSC 404/blocked entries even though the server returns redirects. Redirects remain the primary control; sitemap still has no locale-prefixed URLs.

## Test plan
- [x] `npm test -- --testPathPatterns=robots.seo` (3/3 pass)
- [ ] After deploy: `curl -s https://growwiseschool.org/robots.txt` — no locale Disallow lines
- [ ] GSC URL Inspection: `https://growwiseschool.org/zh/programs` → redirect to `/programs`
- [ ] Confirm important paths still crawlable (`/academic/math`, `/sitemap.xml`)


Made with [Cursor](https://cursor.com)