### PR TITLE
Fix internal links to use canonical paths (no /en/ or legacy /courses/*)

### DIFF
--- a/src/app/[locale]/camps/academic-summer-programs-dublin-ca/page.tsx
+++ b/src/app/[locale]/camps/academic-summer-programs-dublin-ca/page.tsx
@@ -11,9 +11,9 @@ export default function AcademicSummerProgramsRoutePage() {
           title="Academic Summer Programs in Dublin, CA"
           description="GrowWise academic summer programs help K-12 students strengthen math, reading, writing, and study skills before the next school year. Families can compare small-group tracks, readiness goals, and summer schedules for Dublin and Tri-Valley students."
           links={[
-            { href: '/en/camps/summer', label: 'Summer camps' },
-            { href: '/en/resources/summer-academic-program-checklist', label: 'Summer checklist' },
-            { href: '/en/book-assessment', label: 'Book a free assessment' },
+            { href: '/camps/summer', label: 'Summer camps' },
+            { href: '/resources/summer-academic-program-checklist', label: 'Summer checklist' },
+            { href: '/book-assessment', label: 'Book a free assessment' },
           ]}
         />
       }

--- a/src/app/[locale]/camps/winter/calendar/WinterCampCalendarClient.tsx
+++ b/src/app/[locale]/camps/winter/calendar/WinterCampCalendarClient.tsx
@@ -179,7 +179,7 @@ function WinterCampCalendarContent() {
               <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5" />
             </Button>
           </Link>
-          <h1 className="text-lg sm:text-xl md:text-2xl font-bold truncate ml-2 sm:ml-4">Calendar Week</h1>
+          <h1 className="text-lg sm:text-xl md:text-2xl font-bold truncate ml-2 sm:ml-4">Winter Camp Calendar</h1>
         </div>
       </div>
 

--- a/src/app/[locale]/camps/winter/calendar/page.tsx
+++ b/src/app/[locale]/camps/winter/calendar/page.tsx
@@ -4,19 +4,7 @@ import { WinterCampCalendarClient } from './WinterCampCalendarClient';
 
 export default function WinterCampCalendarPage() {
   return (
-    <>
-      <SeoPageFallback
-        eyebrow="Winter camps"
-        title="Winter Camp Calendar"
-        description="Review GrowWise winter camp dates, one-day camp options, and creative technology programs for students in Dublin, CA. Families can compare Roblox, Scratch, and Minecraft camp sessions before adding a date to the cart."
-        links={[
-          { href: '/camps/winter', label: 'Winter camps' },
-          { href: '/camps/summer', label: 'Summer camps' },
-          { href: '/contact', label: 'Contact GrowWise' },
-        ]}
-        className="sr-only"
-      />
-      <Suspense
+    <Suspense
         fallback={
           <SeoPageFallback
             eyebrow="Winter camps"
@@ -33,6 +21,5 @@ export default function WinterCampCalendarPage() {
       >
         <WinterCampCalendarClient />
       </Suspense>
-    </>
   );
 }

--- a/src/app/[locale]/camps/winter/calendar/page.tsx
+++ b/src/app/[locale]/camps/winter/calendar/page.tsx
@@ -10,9 +10,9 @@ export default function WinterCampCalendarPage() {
         title="Winter Camp Calendar"
         description="Review GrowWise winter camp dates, one-day camp options, and creative technology programs for students in Dublin, CA. Families can compare Roblox, Scratch, and Minecraft camp sessions before adding a date to the cart."
         links={[
-          { href: '/en/camps/winter', label: 'Winter camps' },
-          { href: '/en/camps/summer', label: 'Summer camps' },
-          { href: '/en/contact', label: 'Contact GrowWise' },
+          { href: '/camps/winter', label: 'Winter camps' },
+          { href: '/camps/summer', label: 'Summer camps' },
+          { href: '/contact', label: 'Contact GrowWise' },
         ]}
         className="sr-only"
       />
@@ -23,9 +23,9 @@ export default function WinterCampCalendarPage() {
             title="Winter Camp Calendar"
             description="Review GrowWise winter camp dates, one-day camp options, and creative technology programs for students in Dublin, CA. Families can compare Roblox, Scratch, and Minecraft camp sessions before adding a date to the cart."
             links={[
-              { href: '/en/camps/winter', label: 'Winter camps' },
-              { href: '/en/camps/summer', label: 'Summer camps' },
-              { href: '/en/contact', label: 'Contact GrowWise' },
+              { href: '/camps/winter', label: 'Winter camps' },
+              { href: '/camps/summer', label: 'Summer camps' },
+              { href: '/contact', label: 'Contact GrowWise' },
             ]}
             className="bg-[#ebebeb]"
           />

--- a/src/app/[locale]/courses/english/layout.tsx
+++ b/src/app/[locale]/courses/english/layout.tsx
@@ -4,12 +4,13 @@ import FAQSchema from '@/components/schema/FAQSchema'
 import { ENGLISH_COURSE_MERGED_FAQ_JSONLD } from '@/lib/schema/course-hub-jsonld-faqs'
 import { generateMetadataFromPath } from '@/lib/seo/metadata'
 import { generateCourseSchema } from '@/lib/seo/structuredData'
+import { MATH_COURSE_PATHS } from '@/lib/math-course-paths'
 import { absoluteSiteUrl } from '@/lib/publicPath'
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
-  const metadata = generateMetadataFromPath('/courses/english', locale)
+  const metadata = generateMetadataFromPath('/academic/english', locale)
   return metadata || { title: 'English Courses | GrowWise', description: 'Comprehensive English courses' }
 }
 
@@ -41,7 +42,7 @@ export default async function EnglishCoursesLayout({
       "Writing Skills"
     ],
     coursePrerequisites: "Placement assessment recommended to determine appropriate level",
-    url: absoluteSiteUrl('/courses/english', locale, baseUrl),
+    url: absoluteSiteUrl(MATH_COURSE_PATHS.english, locale, baseUrl),
     image: `${baseUrl}/assets/growwise-logo.png`,
     offers: {
       price: "35",
@@ -66,7 +67,7 @@ export default async function EnglishCoursesLayout({
           },
           {
             name: 'English Courses',
-            url: absoluteSiteUrl('/courses/english', locale, baseUrl),
+            url: absoluteSiteUrl(MATH_COURSE_PATHS.english, locale, baseUrl),
           },
         ]}
       />

--- a/src/app/[locale]/courses/high-school-math/layout.tsx
+++ b/src/app/[locale]/courses/high-school-math/layout.tsx
@@ -1,12 +1,13 @@
 import { Metadata } from 'next'
 import { generateMetadataFromPath } from '@/lib/seo/metadata'
 import { generateCourseSchema, generateBreadcrumbSchema } from '@/lib/seo/structuredData'
+import { MATH_COURSE_PATHS } from '@/lib/math-course-paths'
 import { absoluteSiteUrl } from '@/lib/publicPath'
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
-  const metadata = generateMetadataFromPath('/courses/high-school-math', locale)
+  const metadata = generateMetadataFromPath('/academic/math/high-school', locale)
   return metadata || { title: 'High School Math | GrowWise', description: 'High school math courses' }
 }
 
@@ -34,7 +35,7 @@ export default async function HighSchoolMathLayout({
       "Advanced Mathematics"
     ],
     coursePrerequisites: "High school level math foundation",
-    url: absoluteSiteUrl('/courses/high-school-math', locale, baseUrl),
+    url: absoluteSiteUrl(MATH_COURSE_PATHS.highSchool, locale, baseUrl),
     image: `${baseUrl}/assets/growwise-logo.png`,
     offers: {
       price: "35",
@@ -48,7 +49,7 @@ export default async function HighSchoolMathLayout({
     { name: 'Home', url: absoluteSiteUrl('/', locale, baseUrl) },
     { name: 'Programs', url: absoluteSiteUrl('/programs', locale, baseUrl) },
     { name: 'Academic', url: absoluteSiteUrl('/academic', locale, baseUrl) },
-    { name: 'High School Math', url: absoluteSiteUrl('/courses/high-school-math', locale, baseUrl) },
+    { name: 'High School Math', url: absoluteSiteUrl(MATH_COURSE_PATHS.highSchool, locale, baseUrl) },
   ])
 
   return (

--- a/src/app/[locale]/enroll/page.tsx
+++ b/src/app/[locale]/enroll/page.tsx
@@ -14,9 +14,9 @@ export default function EnrollPage() {
             title="Enroll at GrowWise"
             description="Start a GrowWise enrollment for tutoring, academic programs, coding, camps, and readiness support in Dublin, CA. Families can review the next steps, share student details, and choose the right program path."
             links={[
-              { href: '/en/programs', label: 'Explore programs' },
-              { href: '/en/book-assessment', label: 'Book a free assessment' },
-              { href: '/en/contact', label: 'Contact GrowWise' },
+              { href: '/programs', label: 'Explore programs' },
+              { href: '/book-assessment', label: 'Book a free assessment' },
+              { href: '/contact', label: 'Contact GrowWise' },
             ]}
           />
         }

--- a/src/app/[locale]/enroll/page.tsx
+++ b/src/app/[locale]/enroll/page.tsx
@@ -7,17 +7,6 @@ export default function EnrollPage() {
   return (
     <>
       <EnrollPageJsonLd />
-      <SeoPageFallback
-        eyebrow="Enrollment"
-        title="Enroll at GrowWise"
-        description="Start a GrowWise enrollment for tutoring, academic programs, coding, camps, and readiness support in Dublin, CA. Families can review the next steps, share student details, and choose the right program path."
-        links={[
-          { href: '/en/programs', label: 'Explore programs' },
-          { href: '/en/book-assessment', label: 'Book a free assessment' },
-          { href: '/en/contact', label: 'Contact GrowWise' },
-        ]}
-        className="sr-only"
-      />
       <Suspense
         fallback={
           <SeoPageFallback

--- a/src/app/[locale]/game-dev/page.tsx
+++ b/src/app/[locale]/game-dev/page.tsx
@@ -24,9 +24,9 @@ export default function GameDevPage() {
           title="Game Development for Kids in Dublin, CA"
           description="GrowWise game development classes help kids move from playing games to building them through Scratch, Roblox, Minecraft, and project-based coding. This page remains live for families looking for creative coding and game design programs."
           links={[
-            { href: '/en/future-skills', label: 'Future Skills pathways' },
-            { href: '/en/coding/python', label: 'Python coding' },
-            { href: '/en/book-assessment', label: 'Book a free assessment' },
+            { href: '/future-skills', label: 'Future Skills pathways' },
+            { href: '/coding/python', label: 'Python coding' },
+            { href: '/book-assessment', label: 'Book a free assessment' },
           ]}
           className="page-bg-gamedev"
         />

--- a/src/components/ElementaryEnglishPage.tsx
+++ b/src/components/ElementaryEnglishPage.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/lib/english-pricing-display'
 import { usePricingConfig } from '@/hooks/usePricingConfig'
 import { CONTACT_INFO } from '@/lib/constants'
+import { MATH_COURSE_PATHS } from '@/lib/math-course-paths'
 import { absoluteSiteUrl, publicPath } from '@/lib/publicPath'
 import { useLocale } from 'next-intl'
 
@@ -50,7 +51,7 @@ export default function ElementaryEnglishPage() {
         noSchema
         items={[
           { name: COPY.breadcrumb.academic, url: absoluteSiteUrl('/academic', locale) },
-          { name: COPY.breadcrumb.englishPrograms, url: absoluteSiteUrl('/courses/english', locale) },
+          { name: COPY.breadcrumb.englishPrograms, url: absoluteSiteUrl(MATH_COURSE_PATHS.english, locale) },
           { name: COPY.breadcrumb.elementary, url: absoluteSiteUrl('/academic/english/elementary', locale) },
         ]}
       />

--- a/src/components/seo/SeoPageFallback.tsx
+++ b/src/components/seo/SeoPageFallback.tsx
@@ -20,7 +20,7 @@ export function SeoPageFallback({
 }: SeoPageFallbackProps) {
   return (
     <section className={`min-h-[68vh] bg-white px-4 py-20 text-[#1F396D] ${className}`}>
-      <section className="mx-auto flex max-w-4xl flex-col gap-6">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
         <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#F16112]">{eyebrow}</p>
         <h1 className="text-4xl font-bold leading-tight md:text-5xl">{title}</h1>
         <p className="max-w-3xl text-lg leading-8 text-slate-700">{description}</p>
@@ -37,7 +37,7 @@ export function SeoPageFallback({
             ))}
           </nav>
         )}
-      </section>
+      </div>
     </section>
   );
 }

--- a/src/components/seo/SeoPageFallback.tsx
+++ b/src/components/seo/SeoPageFallback.tsx
@@ -19,7 +19,7 @@ export function SeoPageFallback({
   className = '',
 }: SeoPageFallbackProps) {
   return (
-    <main className={`min-h-[68vh] bg-white px-4 py-20 text-[#1F396D] ${className}`}>
+    <section className={`min-h-[68vh] bg-white px-4 py-20 text-[#1F396D] ${className}`}>
       <section className="mx-auto flex max-w-4xl flex-col gap-6">
         <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#F16112]">{eyebrow}</p>
         <h1 className="text-4xl font-bold leading-tight md:text-5xl">{title}</h1>
@@ -38,6 +38,6 @@ export function SeoPageFallback({
           </nav>
         )}
       </section>
-    </main>
+    </section>
   );
 }

--- a/src/i18n/messages/academic-summer-programs-hub-en.json
+++ b/src/i18n/messages/academic-summer-programs-hub-en.json
@@ -19,7 +19,7 @@
       "bestForLabel": "Best for:",
       "tracks": {
         "read-to-prove": {
-          "scheduleLine": "Daily · Mon–Fri · 10:00–11:30 AM · Starts June 15",
+          "scheduleLine": "Daily · Mon–Fri · 4:30–6:00 PM · Starts June 15",
           "bestFor": [
             "Struggles to find the main idea",
             "Guesses on comprehension questions",
@@ -27,7 +27,7 @@
           ]
         },
         "write-to-explain": {
-          "scheduleLine": "Daily · Mon–Fri · 10:30 AM–12:00 PM · Starts June 15",
+          "scheduleLine": "Daily · Mon–Fri · 4:30–6:00 PM · Starts June 15",
           "bestFor": [
             "Has ideas but can't put them on paper",
             "Writes incomplete sentences or short paragraphs",
@@ -35,7 +35,7 @@
           ]
         },
         "bridge-the-gap-math": {
-          "scheduleLine": "Daily · Mon–Fri · 9:00–10:30 AM · Starts June 15",
+          "scheduleLine": "Daily · Mon–Fri · 4:30–6:00 PM · Starts June 15",
           "bestFor": [
             "Has gaps in fractions or multi-step math",
             "Gets stuck on word problems",

--- a/src/i18n/messages/summer-math-foundations-dublin-ca-en.json
+++ b/src/i18n/messages/summer-math-foundations-dublin-ca-en.json
@@ -94,7 +94,7 @@
     },
     {
       "question": "My child is entering Grade 7. Should they take Bridge the Gap Math or IM1 Get Ready?",
-      "answer": "If your child has foundational gaps in fractions or multi-step math, start with Bridge the Gap Math (Grades 1–8, mornings). If they are specifically entering Grade 7 accelerated math (IM1), IM1 Get Ready is the right fit (evenings, DUSD aligned). Contact us if you are unsure."
+      "answer": "If your child has foundational gaps in fractions or multi-step math, start with Bridge the Gap Math (Grades 1–8, evenings). If they are specifically entering Grade 7 accelerated math (IM1), IM1 Get Ready is the right fit (evenings, DUSD aligned). Contact us if you are unsure."
     },
     {
       "question": "What grade levels does Bridge the Gap Math actually serve?",

--- a/src/i18n/messages/summer-reading-writing-dublin-ca-en.json
+++ b/src/i18n/messages/summer-reading-writing-dublin-ca-en.json
@@ -81,7 +81,7 @@
     "items": {
       "mathFoundations": {
         "label": "Summer Math Foundations",
-        "description": "Bridge the Gap Math · Grades 1–8 · mornings"
+        "description": "Bridge the Gap Math · Grades 1–8 · evenings"
       },
       "algebra": {
         "label": "Algebra 1 Get Ready",
@@ -96,7 +96,7 @@
   "faq": [
     {
       "question": "What is the difference between Read to Prove and Write to Explain?",
-      "answer": "Read to Prove focuses on reading comprehension — finding the main idea, making inferences, and using text evidence to support answers. Write to Explain focuses on writing — sentence structure, paragraph writing, essays, and revision. Both run at different morning times so students can enroll in one or both."
+      "answer": "Read to Prove focuses on reading comprehension — finding the main idea, making inferences, and using text evidence to support answers. Write to Explain focuses on writing — sentence structure, paragraph writing, essays, and revision. Both run at the same evening time, so students enroll in one or both across different cohorts."
     },
     {
       "question": "Are these programs DUSD aligned?",
@@ -108,7 +108,7 @@
     },
     {
       "question": "Can my child enroll in both Read to Prove and Write to Explain?",
-      "answer": "Yes. Both tracks run at different times — Read to Prove runs 10:00–11:30 AM and Write to Explain runs 10:30 AM–12:00 PM. The schedules overlap by 30 minutes so a student cannot attend both in the same session. However, a student can enroll in Read to Prove for Cohort 1 and Write to Explain for Cohort 2, or alternate based on which skill needs more support."
+      "answer": "Yes — but not in the same session. Read to Prove and Write to Explain both run 4:30–6:00 PM daily, so a student cannot attend both on the same day. However, a student can enroll in Read to Prove for Cohort 1 and Write to Explain for Cohort 2, or alternate based on which skill needs more support."
     },
     {
       "question": "What if my child is in a different grade than listed?",


### PR DESCRIPTION
## Summary
- Points internal links and JSON-LD at canonical `/academic/*` paths (no legacy `/courses/math|english` or `/en/` prefixes).
- Fixes enroll and winter calendar duplicate `h1` (§15 rendered content).
- Updates Academic Summer Sprint hub schedule copy to 4:30–6:00 PM evening slots.

## SEO validation (`.cursor/SEO.md` §17)

| Check | Result | Evidence | Follow-up |
| ----- | ------ | -------- | --------- |
| `/robots.txt` | PASS | HTTP 200, `text/plain` (prod) | None |
| `/sitemap.xml` | PASS | HTTP 200, `application/xml` (prod) | None |
| `/llms.txt` | PASS | HTTP 200, `text/plain` (prod) | None |
| `/og-image.jpg` | PASS | HTTP 200, `image/webp` (prod) | None |
| `/random-test-url` | PASS | HTTP 404 (prod) | None |
| `/abc123` | PASS | HTTP 404 (prod) | None |
| `/academic/not-real-page` | PASS | HTTP 404 (prod) | None |
| `www` → non-www | PASS | 301 → `https://growwiseschool.org/` | None |
| No `/en/` internal links | PASS | SeoPageFallback links use prefix-free paths | None |
| Legacy `/courses/*` internal links | PASS | Breadcrumbs/schema use `/academic/english`, `/academic/math/high-school` | `/courses/sat-prep` + `/courses/integrated-math-1-dublin-ca` remain canonical |
| Enroll single `main h1` | PASS | Removed duplicate sr-only fallback; client renders one h1 | E2E `legacy-locale-redirects` |
| Winter calendar single h1 | PASS | Removed sr-only fallback; visible h1 = "Winter Camp Calendar" | — |
| Jest SEO suite | PASS | `robots.seo`, `sitemapData`, `legacy-path-redirects` | CI PR Gate |

## Test plan
- [ ] `/enroll` — one `h1` in `main` after `/zh/enroll` redirect
- [ ] `/camps/winter/calendar` — one `h1`, title "Winter Camp Calendar"
- [ ] `/academic/english/elementary` breadcrumb links to `/academic/english`
- [ ] `/camps/academic-summer-programs-dublin-ca` — sprint cards show 4:30–6:00 PM