### PR TITLE
Track door-hanger assessment traffic by community

### DIFF
--- a/src/app/[locale]/book-assessment/page.tsx
+++ b/src/app/[locale]/book-assessment/page.tsx
@@ -20,7 +20,7 @@ import {
 import { BookOpen, CheckCircle, Clock, Users, Award, TrendingUp, Brain, FileText, Sparkles, Eye, ChevronRight, Lightbulb, Trophy, Star, Shield, ArrowRight, Calendar, GraduationCap, User, Mail, Phone as PhoneIcon, Send, Calculator, X, AlertCircle } from 'lucide-react';
 import CountryCodeSelector from '@/components/CountryCodeSelector';
 import FormPrivacyConsent from '@/components/form/FormPrivacyConsent';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { PHONE_PLACEHOLDER, CONTACT_INFO } from '@/lib/constants';
 import { cn } from '@/lib/utils';
@@ -45,10 +45,54 @@ interface FormData {
   hearAboutUs: string;
 }
 
+const NEIGHBORHOODS: Record<string, { name: string; headline: string }> = {
+  'dublin-ranch': {
+    name: 'Dublin Ranch',
+    headline: 'Advanced Math & English Pathways for Dublin Ranch Families.',
+  },
+  'wallis-ranch': {
+    name: 'Wallis Ranch',
+    headline: 'Empowering Wallis Ranch Students to Lead in Advanced Tracks.',
+  },
+  'schaefer-ranch': {
+    name: 'Schaefer Ranch',
+    headline: 'Elite Acceleration & AP Prep for Schaefer Ranch Scholars.',
+  },
+  'tassajara-hills': {
+    name: 'Tassajara Hills',
+    headline: 'Exceeding Classroom Pacing for Tassajara Hills Families.',
+  },
+};
+
+const DEFAULT_ASSESSMENT_HEADLINE =
+  'Advanced After-School Math & English Enrichment (Grades 1-12).';
+
+const ASSESSMENT_CALENDLY_URL =
+  process.env.NEXT_PUBLIC_ASSESSMENT_CALENDLY_URL ||
+  'https://calendly.com/connect-thegrowwise/new-meeting';
+const CALENDLY_NEIGHBORHOOD_PARAM =
+  process.env.NEXT_PUBLIC_CALENDLY_NEIGHBORHOOD_PARAM || 'a1';
+
 export default function BookAssessmentPage() {
   const t = useTranslations();
   const locale = useLocale();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const communitySlug = searchParams.get('community') || '';
+  const neighborhood = NEIGHBORHOODS[communitySlug] || {
+    name: 'Dublin',
+    headline: DEFAULT_ASSESSMENT_HEADLINE,
+  };
+  const calendlyUrl = useMemo(() => {
+    const url = new URL(ASSESSMENT_CALENDLY_URL);
+    if (communitySlug) {
+      url.searchParams.set('utm_source', 'door-hanger');
+      url.searchParams.set('utm_medium', 'physical-drop');
+      url.searchParams.set('utm_campaign', communitySlug);
+      url.searchParams.set(CALENDLY_NEIGHBORHOOD_PARAM, neighborhood.name);
+    }
+    return url.toString();
+  }, [communitySlug, neighborhood.name]);
   const [scrollY, setScrollY] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -93,7 +137,7 @@ export default function BookAssessmentPage() {
   }, []);
 
   const grades = [
-    'Kindergarten', 'Grade 1', 'Grade 2', 'Grade 3', 'Grade 4', 'Grade 5',
+    'Grade 1', 'Grade 2', 'Grade 3', 'Grade 4', 'Grade 5',
     'Grade 6', 'Grade 7', 'Grade 8', 'Grade 9', 'Grade 10', 'Grade 11', 'Grade 12'
   ];
 
@@ -221,6 +265,15 @@ export default function BookAssessmentPage() {
 
       const scheduleCombined = 'Flexible - discuss during callback';
 
+      const storedUtmNotes = getStoredUtmNotesLine();
+      const notes = [
+        storedUtmNotes,
+        communitySlug && `Neighborhood: ${neighborhood.name}`,
+        communitySlug && `Community slug: ${communitySlug}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+
       const assessmentData = {
         parentName: formData.parentName,
         email: formData.email,
@@ -233,7 +286,7 @@ export default function BookAssessmentPage() {
         mode: formData.mode || 'Flexible',
         schedule: scheduleCombined,
         hearAboutUs: formData.hearAboutUs,
-        notes: getStoredUtmNotesLine(),
+        notes,
         agreeToCommunications,
         recaptchaToken: recaptchaToken || undefined,
       };
@@ -278,6 +331,8 @@ export default function BookAssessmentPage() {
     validateForm,
     router,
     locale,
+    neighborhood.name,
+    communitySlug,
   ]);
 
   const assessmentFeatures = [
@@ -394,14 +449,10 @@ export default function BookAssessmentPage() {
               id="book-assessment-hero-h1"
               className="text-3xl sm:text-4xl font-semibold tracking-tight text-balance text-gray-900 mb-4"
             >
-              Book Your{' '}
-              <span className="bg-gradient-to-r from-[#F16112] to-[#F1894F] bg-clip-text text-transparent">
-                Free Academic Assessment
-              </span>{' '}
-              Today
+              {neighborhood.headline}
             </h1>
             <p className="text-gray-600 max-w-2xl mx-auto text-lg">
-              Tell us the basics. We&apos;ll call or text within 24 hours to confirm the best assessment time.
+              Capped at 8 students per class | 4564 Dublin Blvd
             </p>
           </div>
           <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
@@ -501,7 +552,7 @@ export default function BookAssessmentPage() {
                           <Input id="studentName" type="text" value={formData.studentName} onChange={(e) => handleInputChange('studentName', e.target.value)} onFocus={() => setFocusedField('studentName')} onBlur={() => setFocusedField(null)} className={cn("bg-white border-2 rounded-lg md:rounded-xl transition-all h-12 md:h-14 text-sm sm:text-base", focusedField === 'studentName' ? 'border-[#F16112] shadow-md ring-2 ring-[#F16112]/10' : 'border-gray-300 hover:border-gray-400')} placeholder="Optional" />
                         </div>
                         <div className="space-y-2">
-                          <Label htmlFor="grade" className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2"><BookOpen className="w-4 h-4 text-[#1F396D]" />Grade / Level <span className="text-red-500">*</span></Label>
+                          <Label htmlFor="grade" className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2"><BookOpen className="w-4 h-4 text-[#1F396D]" />Child&apos;s Current Grade <span className="text-red-500">*</span></Label>
                           <Select
                             onValueChange={(value) => handleInputChange('grade', value)}
                             value={formData.grade || undefined}
@@ -663,6 +714,23 @@ export default function BookAssessmentPage() {
                 </div>
               );
             })}
+          </div>
+
+          <div className="mt-12 rounded-2xl border border-[#1F396D]/10 bg-white p-4 shadow-xl sm:p-6">
+            <div className="mb-4 text-center">
+              <h2 className="text-xl font-bold text-[#1F396D]">Prefer to choose a time now?</h2>
+              <p className="mt-1 text-sm text-slate-600">
+                Calendly receives the same neighborhood tracking automatically.
+              </p>
+            </div>
+            <div className="min-h-[700px] overflow-hidden rounded-xl border border-slate-200 bg-slate-50">
+              <iframe
+                title="Schedule a GrowWise academic assessment"
+                src={calendlyUrl}
+                className="h-[700px] w-full"
+                loading="lazy"
+              />
+            </div>
           </div>
         </div>
       </section>

--- a/src/components/analytics/PageTrackingWrapper.tsx
+++ b/src/components/analytics/PageTrackingWrapper.tsx
@@ -20,33 +20,64 @@ export function PageTrackingWrapper({ children }: PageTrackingWrapperProps) {
     if (typeof window === 'undefined') return;
     const w = window as any;
     const isDev = process.env.NODE_ENV !== 'production';
+    const search = window.location.search.replace(/^\?/, '');
+    const params = new URLSearchParams(search);
+    const community = params.get('community') || undefined;
+    const isDoorHangerAssessment = pathname.endsWith('/book-assessment') && Boolean(community);
+    const utmSource = params.get('utm_source') || (isDoorHangerAssessment ? 'door-hanger' : undefined);
+    const utmMedium = params.get('utm_medium') || (isDoorHangerAssessment ? 'physical-drop' : undefined);
+    const utmCampaign = params.get('utm_campaign') || community;
+    const pagePathWithQuery = search ? `${pathname}?${search}` : pathname;
 
     const gtmConfigured = Boolean(process.env.NEXT_PUBLIC_GTM_ID?.trim());
+    const pageViewParams: Record<string, any> = {
+      page_path: pagePathWithQuery,
+      page_title: document.title,
+      page_location: window.location.href,
+      ...(community ? { community } : {}),
+      ...(utmSource ? { utm_source: utmSource } : {}),
+      ...(utmMedium ? { utm_medium: utmMedium } : {}),
+      ...(utmCampaign ? { utm_campaign: utmCampaign } : {}),
+      ...(isDev ? { debug_mode: true } : {}),
+    };
+    const dataLayerPayload: Record<string, any> = {
+      event: 'virtual_page_view',
+      ...pageViewParams,
+    };
+    const doorHangerParams: Record<string, any> | null = isDoorHangerAssessment
+      ? {
+          page_path: pagePathWithQuery,
+          page_title: document.title,
+          page_location: window.location.href,
+          community,
+          utm_source: utmSource,
+          utm_medium: utmMedium,
+          utm_campaign: utmCampaign,
+          ...(isDev ? { debug_mode: true } : {}),
+        }
+      : null;
+    const doorHangerDataLayerPayload = doorHangerParams
+      ? {
+          event: 'door_hanger_assessment_page_view',
+          ...doorHangerParams,
+        }
+      : null;
 
     // If Google Tag Manager is configured, queue the event immediately. GTM will consume it
     // once the container loads, which avoids missing initial page views during script startup.
     if (gtmConfigured || Array.isArray(w.dataLayer)) {
       w.dataLayer = w.dataLayer || [];
-      const payload: Record<string, any> = {
-        event: 'virtual_page_view',
-        page_path: pathname,
-        page_title: document.title,
-        ...(isDev ? { debug_mode: true } : {}),
-      };
-      w.dataLayer.push(payload);
-      if (isDev) console.debug('[Analytics][dataLayer] pushed', payload);
+      w.dataLayer.push(dataLayerPayload);
+      if (doorHangerDataLayerPayload) w.dataLayer.push(doorHangerDataLayerPayload);
+      if (isDev) console.debug('[Analytics][dataLayer] pushed', dataLayerPayload);
       return;
     }
 
     // fallback to gtag if available (include debug_mode in dev)
     if (w.gtag) {
-      const payload = {
-        page_path: pathname,
-        page_title: document.title,
-        debug_mode: isDev,
-      };
-      w.gtag('event', 'page_view', payload);
-      if (isDev) console.debug('[Analytics][gtag] event', 'page_view', payload);
+      w.gtag('event', 'page_view', pageViewParams);
+      if (doorHangerParams) w.gtag('event', 'door_hanger_assessment_page_view', doorHangerParams);
+      if (isDev) console.debug('[Analytics][gtag] event', 'page_view', pageViewParams);
     }
   }, [pathname]);
 

--- a/src/components/analytics/__tests__/PageTrackingWrapper.test.tsx
+++ b/src/components/analytics/__tests__/PageTrackingWrapper.test.tsx
@@ -6,7 +6,9 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
 }))
 
-const { usePathname } = require('next/navigation') as { usePathname: jest.Mock }
+const { usePathname } = require('next/navigation') as {
+  usePathname: jest.Mock
+}
 
 describe('PageTrackingWrapper', () => {
   beforeEach(() => {
@@ -15,6 +17,7 @@ describe('PageTrackingWrapper', () => {
     ;(global as any).gtag = undefined
     document.title = 'Test Page'
     usePathname.mockReset()
+    window.history.pushState({}, '', '/')
   })
 
   it('pushes virtual_page_view to dataLayer on pathname changes', () => {
@@ -69,7 +72,46 @@ describe('PageTrackingWrapper', () => {
     expect(gtag).toHaveBeenCalledWith('event', 'page_view', {
       page_path: '/only',
       page_title: 'Test Page',
+      page_location: 'http://localhost/',
       debug_mode: true,
+    })
+  })
+
+  it('pushes door hanger community attribution for assessment URLs', () => {
+    const mockDL: any[] = []
+    ;(global as any).dataLayer = mockDL
+    window.history.pushState(
+      {},
+      '',
+      '/book-assessment?community=dublin-ranch',
+    )
+
+    usePathname.mockReturnValue('/book-assessment')
+
+    render(
+      <PageTrackingWrapper>
+        <div>child</div>
+      </PageTrackingWrapper>
+    )
+
+    expect(mockDL).toHaveLength(2)
+    expect(mockDL[0]).toMatchObject({
+      event: 'virtual_page_view',
+      page_path: '/book-assessment?community=dublin-ranch',
+      page_title: 'Test Page',
+      page_location: 'http://localhost/book-assessment?community=dublin-ranch',
+      community: 'dublin-ranch',
+      utm_source: 'door-hanger',
+      utm_medium: 'physical-drop',
+      utm_campaign: 'dublin-ranch',
+    })
+    expect(mockDL[1]).toMatchObject({
+      event: 'door_hanger_assessment_page_view',
+      page_path: '/book-assessment?community=dublin-ranch',
+      community: 'dublin-ranch',
+      utm_source: 'door-hanger',
+      utm_medium: 'physical-drop',
+      utm_campaign: 'dublin-ranch',
     })
   })
 })

--- a/src/lib/analytics/__tests__/utm.test.ts
+++ b/src/lib/analytics/__tests__/utm.test.ts
@@ -1,0 +1,34 @@
+import { captureUtmFromSearchParams, getStoredUtm } from '../utm'
+
+describe('utm attribution storage', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    window.history.pushState({}, '', '/')
+  })
+
+  it('infers door hanger attribution from book assessment community URLs', () => {
+    window.history.pushState({}, '', '/book-assessment?community=dublin-ranch')
+
+    captureUtmFromSearchParams('?community=dublin-ranch')
+
+    expect(getStoredUtm()).toEqual({
+      utm_source: 'door-hanger',
+      utm_medium: 'physical-drop',
+      utm_campaign: 'dublin-ranch',
+    })
+  })
+
+  it('preserves explicit UTM parameters when provided', () => {
+    window.history.pushState({}, '', '/book-assessment?community=dublin-ranch')
+
+    captureUtmFromSearchParams(
+      '?community=dublin-ranch&utm_source=qr&utm_medium=print&utm_campaign=test-drop',
+    )
+
+    expect(getStoredUtm()).toEqual({
+      utm_source: 'qr',
+      utm_medium: 'print',
+      utm_campaign: 'test-drop',
+    })
+  })
+})

--- a/src/lib/analytics/utm.ts
+++ b/src/lib/analytics/utm.ts
@@ -5,6 +5,11 @@ export const NEXTDOOR_UTM = {
   utm_campaign: 'dublin_community',
 } as const
 
+export const DOOR_HANGER_UTM = {
+  utm_source: 'door-hanger',
+  utm_medium: 'physical-drop',
+} as const
+
 const UTM_STORAGE_KEY = 'growwise_attribution_utms'
 
 export type StoredUtm = {
@@ -35,13 +40,20 @@ export function appendUtm(href: string, utm: StoredUtm = getStoredUtm() ?? NEXTD
 export function captureUtmFromSearchParams(search?: string): void {
   if (!isBrowser()) return
   const params = new URLSearchParams(search ?? window.location.search)
-  const source = params.get('utm_source')
+  const community = params.get('community')
+  const source =
+    params.get('utm_source') ||
+    (community && window.location.pathname.endsWith('/book-assessment')
+      ? DOOR_HANGER_UTM.utm_source
+      : null)
   if (!source) return
 
   const stored: StoredUtm = {
     utm_source: source,
-    utm_medium: params.get('utm_medium') ?? undefined,
-    utm_campaign: params.get('utm_campaign') ?? undefined,
+    utm_medium:
+      params.get('utm_medium') ??
+      (source === DOOR_HANGER_UTM.utm_source ? DOOR_HANGER_UTM.utm_medium : undefined),
+    utm_campaign: params.get('utm_campaign') ?? community ?? undefined,
   }
   try {
     sessionStorage.setItem(UTM_STORAGE_KEY, JSON.stringify(stored))


### PR DESCRIPTION
## Summary
- personalize the book assessment page for door-hanger community URLs
- add Calendly attribution for community variants while keeping the default assessment page clean
- send GA/GTM door_hanger_assessment_page_view events with community/source/medium/campaign metadata
- infer door-hanger attribution from /book-assessment?community=... for lead notes
- relabel the grade dropdown to Child's Current Grade and limit it to Grades 1-12

## Validation
- npm test -- --runTestsByPath src/components/analytics/__tests__/PageTrackingWrapper.test.tsx src/lib/analytics/__tests__/utm.test.ts
- npm run build

## SEO validation
| Check | Result | Evidence | Follow-up |
| ----- | ------ | -------- | --------- |
| /robots.txt | Pass | HTTP 200, content-type text/plain | None |
| /sitemap.xml | Pass | HTTP 200, application/xml, no community query URLs, no retired locale-prefixed URLs | None |
| /sitemap-pages.xml | Pass | HTTP 200, application/xml, no community query URLs, no retired locale-prefixed URLs | None |
| /sitemap-blogs.xml | Pass | HTTP 200, application/xml, no community query URLs, no retired locale-prefixed URLs | None |
| /og-image.jpg | Pass | HTTP 200, content-type image/webp | None |
| /random-test-url | Pass | HTTP 404 | None |
| /abc123 | Pass | HTTP 404 | None |
| /academic/not-real-page | Pass | HTTP 404 | None |
| /book-assessment metadata | Pass | title renders, robots index/follow, canonical path is /book-assessment | Local env host is localhost; production env should provide growwiseschool.org canonical host |
| /book-assessment?community=dublin-ranch metadata | Pass | rendered H1 is personalized; canonical path remains /book-assessment; no separate sitemap URL | None |

## Note
- PR targets dev as requested. dev has been fast-forwarded to latest main before this branch was rebased.