### PR TITLE
Fix production IndexNow verification routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,9 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Trigger Vercel production deployment
-        run: |
-          curl --fail --silent --show-error -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_PROD }}"
-          echo "Vercel production deployment triggered."
-
       - name: Wait for production and verify discovery endpoints
         run: |
+          # Vercel's Git integration deploys pushes to main automatically.
           KEY="$(tr -d '\r\n' < public/9bdcae9db63f4f39996f3ad38cc52d32.txt)"
           sleep 120
           for attempt in {1..30}; do
@@ -64,5 +60,5 @@ jobs:
           curl -s -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             --data '{
-              "text": "❌ *Production deploy failed* — Vercel deploy hook did not respond\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+              "text": "❌ *Production discovery verification failed* — check Vercel deployment, sitemap, robots, and IndexNow logs\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }'

--- a/next.config.ts
+++ b/next.config.ts
@@ -213,6 +213,9 @@ const nextConfig: NextConfig = {
 
   async rewrites() {
     return [
+      // Next.js reserves `/sitemap.xml`; keep the index on a non-reserved
+      // internal route and expose the standard public URL through a rewrite.
+      { source: '/sitemap.xml', destination: '/sitemap-index.xml' },
       // Legacy camp guide POST path → canonical API route.
       { source: '/api/summer-camp-lottery', destination: '/api/summer-camp-summercamp' },
     ];

--- a/src/app/sitemap-index.xml/route.ts
+++ b/src/app/sitemap-index.xml/route.ts
@@ -1,7 +1,7 @@
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
 import { getChildSitemaps, renderSitemapIndex } from '@/lib/seo/sitemapData'
 
-/** Sitemap index. Child sitemap routes emit urlsets. */
+/** Internal sitemap index route. `/sitemap.xml` rewrites here on Vercel. */
 export async function GET(): Promise<Response> {
   const baseUrl = getCanonicalSiteUrl()
   const xml = renderSitemapIndex(getChildSitemaps(baseUrl))

--- a/src/lib/seo/__tests__/indexnow-production-routing.test.ts
+++ b/src/lib/seo/__tests__/indexnow-production-routing.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const INDEXNOW_KEY_PATH = '/9bdcae9db63f4f39996f3ad38cc52d32.txt'
+
+describe('IndexNow production routing', () => {
+  it('allows the public key through dotted-path middleware protection', () => {
+    const middleware = readFileSync(
+      path.join(ROOT, 'src/middleware.ts'),
+      'utf8',
+    )
+    expect(middleware).toContain(`'${INDEXNOW_KEY_PATH}'`)
+  })
+
+  it('keeps the sitemap index on the Vercel-safe internal route', () => {
+    expect(
+      existsSync(path.join(ROOT, 'src/app/sitemap-index.xml/route.ts')),
+    ).toBe(true)
+    expect(existsSync(path.join(ROOT, 'src/app/sitemap.xml/route.ts'))).toBe(
+      false,
+    )
+  })
+
+  it('rewrites the standard sitemap URL to the internal index route', () => {
+    const config = readFileSync(path.join(ROOT, 'next.config.ts'), 'utf8')
+    expect(config).toContain(
+      "{ source: '/sitemap.xml', destination: '/sitemap-index.xml' }",
+    )
+  })
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -95,6 +95,7 @@ const ROOT_PUBLIC_FILES = new Set([
   '/file.svg',
   '/globe.svg',
   '/icon.png',
+  '/9bdcae9db63f4f39996f3ad38cc52d32.txt',
   '/manifest.json',
   '/next.svg',
   '/og-image.jpg',


### PR DESCRIPTION
## Production hotfix

The IndexNow release deployed through Vercel's Git integration, but its verification workflow correctly blocked submission because:

- the key `.txt` file was caught by middleware's unknown dotted-path 404 protection
- `/sitemap.xml` used a Next.js-reserved route that does not match on Vercel
- the obsolete Vercel deploy hook now returns 404 and stopped the workflow before verification

## Fix

- allow the exact IndexNow key file through middleware
- restore the Vercel-safe `/sitemap.xml` rewrite to `/sitemap-index.xml`
- rely on Vercel's working Git integration instead of the stale deployment hook
- retain live key, robots, and sitemap verification before IndexNow submission
- add regression tests for the key allowlist, route location, and rewrite

## Validation

- 14 focused SEO/routing tests passed
- 10 IndexNow tests passed
- targeted ESLint passed
- full Next.js production build passed
- no manual IndexNow submission was made
