### PR TITLE
feat: add vendor partner trust strip

### DIFF
--- a/src/app/[locale]/book-assessment/BookAssessmentPageClient.tsx
+++ b/src/app/[locale]/book-assessment/BookAssessmentPageClient.tsx
@@ -30,6 +30,7 @@ import { publicPath } from '@/lib/publicPath';
 import { siteGoogleTrustReviewCards } from '@/lib/siteGoogleTrustReviews';
 import { trackAssessmentFormSubmitted, trackGenerateLead } from '@/lib/analytics/gtmEvents';
 import { captureUtmFromSearchParams, getStoredUtm, getStoredUtmNotesLine } from '@/lib/analytics/utm';
+import PartnerTrustStrip from '@/components/shared/PartnerTrustStrip';
 
 interface FormData {
   parentName: string;
@@ -785,6 +786,8 @@ export default function BookAssessmentPageClient() {
           </div>
         </div>
       </section>
+
+      <PartnerTrustStrip />
 
       <section className="py-24 bg-gradient-to-br from-gray-50 via-white to-gray-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/app/[locale]/enroll/EnrollPageClient.tsx
+++ b/src/app/[locale]/enroll/EnrollPageClient.tsx
@@ -17,6 +17,7 @@ import { TrackedForm } from '@/lib/analytics/components';
 import Phase3EnrollPage from '@/components/enroll/EnrollPhase3Page';
 import { useSearchParams } from 'next/navigation';
 import { getRecaptchaToken } from '@/lib/recaptcha';
+import PartnerTrustStrip from '@/components/shared/PartnerTrustStrip';
 
 function EnrollPageInner() {
   const router = useRouter();
@@ -348,6 +349,7 @@ function EnrollPageInner() {
           ))}
         </div>
       </div>
+      <PartnerTrustStrip />
     </div>
   );
 }

--- a/src/components/enroll/EnrollPhase3Page.tsx
+++ b/src/components/enroll/EnrollPhase3Page.tsx
@@ -10,6 +10,7 @@ import enMessages from '@/i18n/messages/en.json';
 import { ReviewStep } from '@/app/enroll/steps/ReviewStep';
 import { ChildStep } from '@/app/enroll/steps/ChildStep';
 import { PaymentStep } from '@/app/enroll/steps/PaymentStep';
+import PartnerTrustStrip from '@/components/shared/PartnerTrustStrip';
 
 function EnrollPhase3Inner() {
   const searchParams = useSearchParams();
@@ -118,6 +119,7 @@ function EnrollPhase3Inner() {
           </div>
         </div>
       </div>
+      <PartnerTrustStrip />
     </div>
   );
 }

--- a/src/components/layout/Footer/FooterFindUsOn.tsx
+++ b/src/components/layout/Footer/FooterFindUsOn.tsx
@@ -17,8 +17,18 @@ function shouldShowAllTrustBadges(pathname: string): boolean {
   return !isHomePath(pathname) || isCampSeoLandingPath(pathname);
 }
 
+export function hasDedicatedPartnerStrip(pathname: string): boolean {
+  if (isHomePath(pathname)) return true;
+
+  const normalized = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '') || '/';
+  return normalized === '/book-assessment' || normalized === '/enroll';
+}
+
 export default function FooterFindUsOn() {
   const pathname = usePathname();
+
+  if (hasDedicatedPartnerStrip(pathname)) return null;
+
   const badges = getFooterTrustBadges(!shouldShowAllTrustBadges(pathname));
 
   return (

--- a/src/components/layout/Footer/__tests__/partner-strip-routing.test.ts
+++ b/src/components/layout/Footer/__tests__/partner-strip-routing.test.ts
@@ -1,0 +1,28 @@
+import { hasDedicatedPartnerStrip } from '../FooterFindUsOn';
+
+describe('partner trust strip routing', () => {
+  it.each([
+    '/',
+    '/en',
+    '/en/',
+    '/book-assessment',
+    '/en/book-assessment',
+    '/enroll',
+    '/en/enroll',
+  ])('hides footer partner badges on %s', (pathname) => {
+    expect(hasDedicatedPartnerStrip(pathname)).toBe(true);
+  });
+
+  it.each([
+    '/about',
+    '/en/about',
+    '/academic',
+    '/en/academic/math',
+    '/camps/summer',
+    '/en/book-assessment/thank-you',
+    '/en/enroll/thank-you',
+    '/contact',
+  ])('keeps footer partner badges on %s', (pathname) => {
+    expect(hasDedicatedPartnerStrip(pathname)).toBe(false);
+  });
+});

--- a/src/components/pages/HomeClient.tsx
+++ b/src/components/pages/HomeClient.tsx
@@ -13,6 +13,7 @@ import { HomeDiagnosticSection } from '../sections/home/HomeDiagnosticSection';
 import { HomeFaqSection } from '../sections/home/HomeFaqSection';
 import { HomeSteamSection } from '../sections/home/HomeSteamSection';
 import { HomeFinalAssessmentCta } from '../sections/home/HomeFinalAssessmentCta';
+import PartnerTrustStrip from '@/components/shared/PartnerTrustStrip';
 import type { HomeContentData } from '@/store/slices/homeSlice';
 
 interface HomeClientProps {
@@ -36,6 +37,7 @@ function HomeFunnelSections() {
       <HomeSocialProofSection />
       <HomeSteamSection />
       <HomeDiagnosticSection />
+      <PartnerTrustStrip />
       <HomeFaqSection />
       <HomeFinalAssessmentCta />
     </>

--- a/src/components/shared/PartnerTrustStrip.tsx
+++ b/src/components/shared/PartnerTrustStrip.tsx
@@ -1,0 +1,77 @@
+import Image from 'next/image';
+
+const partnerCardClass =
+  'group flex min-h-[92px] items-center justify-center rounded-2xl border border-[#1F396D]/10 bg-white px-5 py-4 shadow-[0_10px_35px_rgba(31,57,109,0.09)] ring-1 ring-white transition duration-300 hover:-translate-y-1 hover:border-[#F16112]/30 hover:shadow-[0_16px_42px_rgba(31,57,109,0.14)]';
+
+export default function PartnerTrustStrip() {
+  return (
+    <section
+      data-testid="partner-trust-strip"
+      className="relative overflow-hidden border-y border-[#1F396D]/8 bg-gradient-to-br from-[#F8FAFF] via-white to-[#FFF8F3] px-4 py-12 sm:py-14"
+      aria-labelledby="partner-trust-heading"
+    >
+      <div className="pointer-events-none absolute -left-20 top-0 h-52 w-52 rounded-full bg-[#1F396D]/5 blur-3xl" aria-hidden />
+      <div className="pointer-events-none absolute -right-16 bottom-0 h-52 w-52 rounded-full bg-[#F16112]/8 blur-3xl" aria-hidden />
+
+      <div className="relative mx-auto max-w-5xl">
+        <div className="text-center">
+          <p className="mb-2 text-xs font-bold uppercase tracking-[0.24em] text-[#F16112]">
+            Trusted platforms
+          </p>
+          <h2
+            id="partner-trust-heading"
+            className="text-2xl font-bold tracking-tight text-[#1F396D] sm:text-3xl"
+          >
+            Proudly Partnered With
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-slate-600 sm:text-base">
+            GrowWise is an approved vendor partner on platforms families trust to discover quality programs.
+          </p>
+        </div>
+
+        <div className="mx-auto mt-8 grid max-w-3xl grid-cols-1 gap-4 sm:grid-cols-3">
+          <a
+            href="https://www.6crickets.com/providerDirectory/US/CA/Dublin/GrowWise-03fcd68e5673f08b?refer&provider=6121&utm_medium=provider&utm_source=providers"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+            className={partnerCardClass}
+            aria-label="Visit GrowWise on 6crickets (opens in new tab)"
+          >
+            <span className="flex items-center gap-3">
+              <Image
+                src="https://www.6crickets.com/_assets/images/fav.png"
+                alt=""
+                width={44}
+                height={44}
+                className="h-11 w-11 object-contain"
+              />
+              <span className="text-xl font-extrabold tracking-tight text-[#263B70]">6crickets</span>
+            </span>
+          </a>
+
+          <a
+            href="https://www.activityhero.com/biz/169146-growwise-dublin-ca"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+            className={partnerCardClass}
+            aria-label="Visit GrowWise on ActivityHero (opens in new tab)"
+          >
+            <span className="text-center text-xl font-extrabold tracking-tight">
+              <span className="text-[#2767B2]">Activity</span>
+              <span className="text-[#F16112]">Hero</span>
+            </span>
+          </a>
+
+          <div className={partnerCardClass} role="img" aria-label="Velp vendor partner">
+            <span className="relative inline-flex min-w-32 items-center justify-center rounded-xl bg-[#21104F] px-7 py-3 text-2xl font-extrabold lowercase tracking-tight text-white shadow-md">
+              velp
+              <span className="absolute right-3 top-2 h-2 w-2 rounded-full bg-[#F16112]" aria-hidden />
+              <span className="absolute right-2 top-4 h-1.5 w-1.5 rounded-full bg-[#35B6A5]" aria-hidden />
+              <span className="absolute right-5 top-1.5 h-1.5 w-1.5 rounded-full bg-[#F4C542]" aria-hidden />
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/shared/__tests__/PartnerTrustStrip.test.tsx
+++ b/src/components/shared/__tests__/PartnerTrustStrip.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import PartnerTrustStrip from '../PartnerTrustStrip';
+
+describe('PartnerTrustStrip', () => {
+  it('renders the partnership message and all three vendor partners', () => {
+    render(<PartnerTrustStrip />);
+
+    expect(screen.getByTestId('partner-trust-strip')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Proudly Partnered With' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Visit GrowWise on 6crickets/)).toHaveAttribute(
+      'href',
+      expect.stringContaining('6crickets.com'),
+    );
+    expect(screen.getByLabelText(/Visit GrowWise on ActivityHero/)).toHaveAttribute(
+      'href',
+      expect.stringContaining('activityhero.com'),
+    );
+    expect(screen.getByLabelText('Velp vendor partner')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a polished Proudly Partnered With strip for 6crickets, ActivityHero, and Velp
- place it on the homepage, assessment, and both enrollment flows
- suppress footer partner badges only on those routes to prevent duplication
- add component and route-level coverage

## Validation
- structural placement checks passed
- 15 target and non-target route cases passed
- git diff --check passed

## Note
- live screenshots and Jest were blocked locally because the installed Node 24.10.0 runtime is incompatible with the current Next.js dependencies