### PR TITLE
Add parent practice downloads page

### DIFF
--- a/src/app/[locale]/resources/downloads/layout.tsx
+++ b/src/app/[locale]/resources/downloads/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  return (
+    generateMetadataFromPath('/resources/downloads', locale) ?? {
+      title: 'Free Math & English Study Plans | GrowWise',
+      description:
+        'Download starter resources and create a free 4-week Math or English study plan for your child.',
+    }
+  )
+}
+
+export default function DownloadsLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/src/app/[locale]/resources/downloads/page.tsx
+++ b/src/app/[locale]/resources/downloads/page.tsx
@@ -1,0 +1,5 @@
+import { StudyPlansDownloadPage } from '@/components/resources/StudyPlansDownloadPage'
+
+export default function DownloadsPage() {
+  return <StudyPlansDownloadPage />
+}

--- a/src/components/resources/StudyPlansDownloadPage.tsx
+++ b/src/components/resources/StudyPlansDownloadPage.tsx
@@ -1,0 +1,554 @@
+'use client'
+
+import { useState, type FormEvent } from 'react'
+import Link from 'next/link'
+import { useLocale } from 'next-intl'
+import {
+  ArrowRight,
+  BookOpenCheck,
+  CalendarDays,
+  CheckCircle2,
+  ClipboardCheck,
+  Download,
+  Eye,
+  FileText,
+  Home,
+  ListChecks,
+  Mail,
+  PenLine,
+  Printer,
+  Sparkles,
+  Target,
+  UserRound,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { publicPath } from '@/lib/publicPath'
+import { cn } from '@/lib/utils'
+
+type Subject = 'math' | 'english'
+type Frequency = '3' | '5'
+
+type DownloadItem = {
+  id: string
+  subject: Subject
+  title: string
+  grade: string
+  description: string
+  status: 'live' | 'planned'
+  href?: string
+}
+
+type PlanDay = {
+  day: string
+  title: string
+  detail: string
+}
+
+type ParentJob = {
+  id: string
+  title: string
+  description: string
+  subject: Subject
+}
+
+const downloads: DownloadItem[] = [
+  {
+    id: 'thinking-gap-playbook',
+    subject: 'math',
+    title: 'Thinking Gap Playbook for Parents',
+    grade: 'Grades 3-8',
+    description:
+      'A parent guide for spotting hidden reasoning gaps before they turn into homework battles or test mistakes.',
+    status: 'live',
+    href: '/downloads/ThinkingGap_Playbook_for_parents.pdf',
+  },
+  {
+    id: 'math-weekly-plan',
+    subject: 'math',
+    title: 'Weekly Math Study Plan',
+    grade: 'Grades 3-8',
+    description: 'A printable weekly routine for skill review, mistake correction, and short practice blocks.',
+    status: 'planned',
+  },
+  {
+    id: 'fractions-word-problems',
+    subject: 'math',
+    title: 'Fractions and Word Problems Practice',
+    grade: 'Grades 4-7',
+    description: 'Mixed practice for fraction sense, setup accuracy, and multi-step word problem confidence.',
+    status: 'planned',
+  },
+  {
+    id: 'english-weekly-plan',
+    subject: 'english',
+    title: 'Weekly English Study Plan',
+    grade: 'Grades 2-8',
+    description: 'A reading and writing routine that balances comprehension, vocabulary, and written response.',
+    status: 'planned',
+  },
+  {
+    id: 'reading-comprehension',
+    subject: 'english',
+    title: 'Reading Comprehension Practice Sheet',
+    grade: 'Grades 3-8',
+    description: 'Short passage practice with main idea, inference, evidence, and summary prompts.',
+    status: 'planned',
+  },
+  {
+    id: 'paragraph-planner',
+    subject: 'english',
+    title: 'Paragraph Writing Planner',
+    grade: 'Grades 3-8',
+    description: 'A simple structure for topic sentences, evidence, explanation, and revision checks.',
+    status: 'planned',
+  },
+]
+
+const focusOptions: Record<Subject, string[]> = {
+  math: ['Math facts and accuracy', 'Fractions', 'Word problems', 'Algebra readiness'],
+  english: ['Reading comprehension', 'Vocabulary', 'Paragraph writing', 'Grammar and editing'],
+}
+
+const parentJobs: ParentJob[] = [
+  {
+    id: 'guessing',
+    title: "I don't know what to practice",
+    description: 'Pick a grade, subject, and focus skill. The page turns it into a simple weekly routine.',
+    subject: 'math',
+  },
+  {
+    id: 'battles',
+    title: 'Practice turns into a fight',
+    description: 'Use short named practice blocks so your child knows exactly when they are done.',
+    subject: 'english',
+  },
+  {
+    id: 'mistakes',
+    title: 'My child keeps making the same mistakes',
+    description: 'Add mistake correction days instead of only assigning more worksheets.',
+    subject: 'math',
+  },
+]
+
+const planTemplates: Record<Subject, Record<Frequency, PlanDay[]>> = {
+  math: {
+    '3': [
+      { day: 'Monday', title: 'Skill refresh', detail: 'Review one core concept and complete 12 focused problems.' },
+      { day: 'Wednesday', title: 'Mistake correction', detail: 'Redo missed problems and write the reason for each mistake.' },
+      { day: 'Friday', title: 'Mini quiz', detail: 'Take a 15-minute mixed practice check without help.' },
+    ],
+    '5': [
+      { day: 'Monday', title: 'Skill refresh', detail: 'Review one core concept and complete 10 focused problems.' },
+      { day: 'Tuesday', title: 'Accuracy sprint', detail: 'Practice short problems with a checking routine.' },
+      { day: 'Wednesday', title: 'Word problem day', detail: 'Solve 4 multi-step problems and label the operation choices.' },
+      { day: 'Thursday', title: 'Mistake correction', detail: 'Redo missed problems and explain the fix.' },
+      { day: 'Friday', title: 'Mini quiz', detail: 'Take a 15-minute mixed practice check without help.' },
+    ],
+  },
+  english: {
+    '3': [
+      { day: 'Monday', title: 'Read and notice', detail: 'Read one short passage and mark the main idea plus key evidence.' },
+      { day: 'Wednesday', title: 'Vocabulary and inference', detail: 'Practice 6 vocabulary words and answer 3 inference questions.' },
+      { day: 'Friday', title: 'Written response', detail: 'Write one paragraph using claim, evidence, and explanation.' },
+    ],
+    '5': [
+      { day: 'Monday', title: 'Fluency read', detail: 'Read one passage aloud, then write a one-sentence main idea.' },
+      { day: 'Tuesday', title: 'Vocabulary builder', detail: 'Practice 6 words using context clues and original sentences.' },
+      { day: 'Wednesday', title: 'Comprehension check', detail: 'Answer literal, inference, and evidence-based questions.' },
+      { day: 'Thursday', title: 'Paragraph planner', detail: 'Plan a response with topic sentence, evidence, and explanation.' },
+      { day: 'Friday', title: 'Revision day', detail: 'Revise for clarity, grammar, and stronger evidence.' },
+    ],
+  },
+}
+
+function subjectLabel(subject: Subject) {
+  return subject === 'math' ? 'Math' : 'English'
+}
+
+export function StudyPlansDownloadPage() {
+  const locale = useLocale()
+  const [subject, setSubject] = useState<Subject>('math')
+  const [grade, setGrade] = useState('Grade 5')
+  const [focus, setFocus] = useState(focusOptions.math[0])
+  const [frequency, setFrequency] = useState<Frequency>('3')
+  const [email, setEmail] = useState('')
+  const [showPlan, setShowPlan] = useState(false)
+
+  const planDays = planTemplates[subject][frequency]
+  const bookAssessmentHref = publicPath('/book-assessment', locale)
+
+  function selectSubject(nextSubject: Subject) {
+    setSubject(nextSubject)
+    setFocus(focusOptions[nextSubject][0])
+    setShowPlan(false)
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setShowPlan(true)
+  }
+
+  return (
+    <main className="min-h-screen bg-[#F7FAFC] font-sans text-slate-900">
+      <section className="border-b border-slate-200 bg-white py-12 sm:py-16" aria-labelledby="study-plans-title">
+        <div className="mx-auto grid max-w-6xl gap-10 px-4 sm:px-6 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+          <div>
+            <p className="inline-flex items-center gap-2 rounded-full bg-orange-50 px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#F16112] ring-1 ring-orange-100">
+              <Sparkles className="size-4" aria-hidden="true" />
+              Parent practice platform
+            </p>
+            <h1 id="study-plans-title" className="font-heading mt-5 text-3xl font-bold leading-tight text-[#1F396D] sm:text-5xl">
+              Know what your child should practice this week
+            </h1>
+            <p className="mt-5 max-w-2xl text-base leading-relaxed text-slate-700 sm:text-lg">
+              A free parent workspace for Math and English practice: choose the skill, get a weekly routine, and stop guessing which worksheet comes next.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button asChild className="min-h-[48px] rounded-lg bg-[#F16112] px-6 text-white hover:bg-[#d54f0a]">
+                <a href="#plan-builder">
+                  Build my child&apos;s plan
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </a>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="min-h-[48px] rounded-lg border-[#1F396D]/25 px-6 text-[#1F396D] hover:bg-slate-50"
+              >
+                <a href="#free-downloads">
+                  Browse downloads
+                  <Download className="size-4" aria-hidden="true" />
+                </a>
+              </Button>
+            </div>
+            <div className="mt-7 grid gap-3 text-sm text-slate-700 sm:grid-cols-3">
+              {[
+                ['No login first', 'Start with email only'],
+                ['Math + English', 'One place for both'],
+                ['Weekly rhythm', 'Clear parent routine'],
+              ].map(([title, detail]) => (
+                <div key={title} className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                  <p className="font-bold text-[#1F396D]">{title}</p>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600">{detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-[#F7FAFC] p-4 shadow-sm sm:p-5">
+            <div className="rounded-xl border border-slate-200 bg-white p-5">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-wide text-[#F16112]">My child&apos;s practice board</p>
+                  <h2 className="font-heading mt-2 text-xl font-bold text-[#1F396D]">This week&apos;s plan</h2>
+                </div>
+                <span className="flex size-12 items-center justify-center rounded-xl bg-[#1F396D] text-white">
+                  <UserRound className="size-6" aria-hidden="true" />
+                </span>
+              </div>
+              <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                <div className="rounded-lg bg-slate-50 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Student</p>
+                  <p className="mt-1 font-bold text-[#1F396D]">{grade}</p>
+                </div>
+                <div className="rounded-lg bg-slate-50 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Focus</p>
+                  <p className="mt-1 font-bold text-[#1F396D]">{focus}</p>
+                </div>
+                <div className="rounded-lg bg-slate-50 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Rhythm</p>
+                  <p className="mt-1 font-bold text-[#1F396D]">{frequency} days/week</p>
+                </div>
+              </div>
+              <div className="mt-5 grid gap-3">
+                {planDays.slice(0, 3).map((item) => (
+                  <div key={item.day} className="flex gap-3 rounded-lg border border-slate-200 bg-white p-3">
+                    <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-orange-50 text-[#F16112]">
+                      <ClipboardCheck className="size-4" aria-hidden="true" />
+                    </span>
+                    <div>
+                      <p className="text-sm font-bold text-[#1F396D]">{item.day}: {item.title}</p>
+                      <p className="mt-1 text-xs leading-relaxed text-slate-600">{item.detail}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              {[
+                [Eye, 'See the gap'],
+                [ListChecks, 'Know the next step'],
+                [Home, 'Run practice at home'],
+              ].map(([Icon, label]) => {
+                const IconComponent = Icon as typeof Eye
+                return (
+                  <div key={label as string} className="rounded-lg bg-white p-3 text-center text-sm font-semibold text-[#1F396D] ring-1 ring-slate-200">
+                    <IconComponent className="mx-auto mb-2 size-5 text-[#F16112]" aria-hidden="true" />
+                    {label as string}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-[#F7FAFC] py-10" aria-labelledby="parent-jobs-title">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">Choose what feels true</p>
+              <h2 id="parent-jobs-title" className="font-heading mt-2 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+                Built around the parent job
+              </h2>
+            </div>
+            <p className="max-w-xl text-sm leading-relaxed text-slate-600">
+              The page should feel less like school paperwork and more like a weekly operating system for helping your child.
+            </p>
+          </div>
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            {parentJobs.map((job) => (
+              <button
+                key={job.id}
+                type="button"
+                onClick={() => selectSubject(job.subject)}
+                className="rounded-xl border border-slate-200 bg-white p-5 text-left shadow-sm transition hover:border-[#F16112]/40 hover:shadow-md"
+              >
+                <Target className="size-6 text-[#F16112]" aria-hidden="true" />
+                <h3 className="mt-4 text-lg font-bold text-[#1F396D]">{job.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-600">{job.description}</p>
+                <span className="mt-4 inline-flex text-sm font-bold text-[#F16112]">
+                  Build {subjectLabel(job.subject)} plan
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="free-downloads" className="bg-white py-12 sm:py-16" aria-labelledby="downloads-title">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">Start here</p>
+              <h2 id="downloads-title" className="font-heading mt-2 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+                Your Math and English practice shelves
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-600">
+                Keep both subjects in one parent workspace. Download what is ready today, then use the plan builder to turn practice into a weekly routine.
+              </p>
+            </div>
+            <div className="flex rounded-xl bg-slate-100 p-1" aria-label="Choose plan subject">
+              {(['math', 'english'] as const).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  onClick={() => selectSubject(item)}
+                  className={cn(
+                    'rounded-lg px-4 py-2 text-sm font-semibold transition',
+                    subject === item ? 'bg-white text-[#1F396D] shadow-sm' : 'text-slate-600 hover:text-slate-900',
+                  )}
+                >
+                  {subjectLabel(item)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-8 grid gap-8 lg:grid-cols-2">
+            {(['math', 'english'] as const).map((group) => (
+              <section key={group} className="rounded-xl border border-slate-200 bg-slate-50 p-4 sm:p-5" aria-labelledby={`${group}-downloads-title`}>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <h3 id={`${group}-downloads-title`} className="font-heading text-xl font-bold text-[#1F396D]">
+                    {subjectLabel(group)} shelf
+                  </h3>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => selectSubject(group)}
+                    className="min-h-[40px] rounded-lg border-[#1F396D]/20 bg-white text-[#1F396D] hover:bg-white"
+                  >
+                    Build {subjectLabel(group)} plan
+                  </Button>
+                </div>
+                <ul className="mt-5 grid list-none gap-4 p-0" role="list">
+                  {downloads
+                    .filter((item) => item.subject === group)
+                    .map((item) => (
+                      <li key={item.id}>
+                        <article className="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+                          <div className="flex items-start justify-between gap-3">
+                            <span className="inline-flex rounded-full bg-[#1F396D]/10 px-3 py-1 text-xs font-bold text-[#1F396D]">
+                              {item.grade}
+                            </span>
+                            <FileText className="size-5 text-[#F16112]" aria-hidden="true" />
+                          </div>
+                          <h4 className="mt-4 text-lg font-bold leading-snug text-[#1F396D]">{item.title}</h4>
+                          <p className="mt-3 flex-1 text-sm leading-relaxed text-slate-600">{item.description}</p>
+                          {item.status === 'live' && item.href ? (
+                            <Button asChild className="mt-5 min-h-[44px] rounded-lg bg-[#F16112] text-white hover:bg-[#d54f0a]">
+                              <a href={item.href} download>
+                                Download PDF
+                                <Download className="size-4" aria-hidden="true" />
+                              </a>
+                            </Button>
+                          ) : (
+                            <div className="mt-5 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-600">
+                              Included in upcoming worksheet pack
+                            </div>
+                          )}
+                        </article>
+                      </li>
+                    ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="plan-builder" className="border-y border-slate-200 bg-slate-50 py-12 sm:py-16" aria-labelledby="builder-title">
+        <div className="mx-auto grid max-w-6xl gap-8 px-4 sm:px-6 lg:grid-cols-[0.9fr_1.1fr]">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">My child&apos;s weekly routine</p>
+            <h2 id="builder-title" className="font-heading mt-2 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+              Build a 4-week {subjectLabel(subject).toLowerCase()} plan you can actually follow
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-slate-700 sm:text-base">
+              Choose the grade, focus skill, and practice rhythm. The preview becomes a parent-friendly plan: what to do, when to do it, and how to know the week is complete.
+            </p>
+
+            <form onSubmit={handleSubmit} className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="grid gap-4">
+                <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                  Parent email
+                  <span className="relative">
+                    <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                    <input
+                      type="email"
+                      value={email}
+                      onChange={(event) => setEmail(event.target.value)}
+                      placeholder="parent@example.com"
+                      required
+                      className="min-h-[46px] w-full rounded-lg border border-slate-300 bg-white pl-10 pr-3 text-sm outline-none transition focus:border-[#F16112] focus:ring-2 focus:ring-[#F16112]/20"
+                    />
+                  </span>
+                </label>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                    Grade
+                    <select
+                      value={grade}
+                      onChange={(event) => setGrade(event.target.value)}
+                      className="min-h-[46px] rounded-lg border border-slate-300 bg-white px-3 text-sm outline-none transition focus:border-[#F16112] focus:ring-2 focus:ring-[#F16112]/20"
+                    >
+                      {['Grade 1', 'Grade 2', 'Grade 3', 'Grade 4', 'Grade 5', 'Grade 6', 'Grade 7', 'Grade 8', 'High School'].map((item) => (
+                        <option key={item}>{item}</option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                    Practice rhythm
+                    <select
+                      value={frequency}
+                      onChange={(event) => setFrequency(event.target.value as Frequency)}
+                      className="min-h-[46px] rounded-lg border border-slate-300 bg-white px-3 text-sm outline-none transition focus:border-[#F16112] focus:ring-2 focus:ring-[#F16112]/20"
+                    >
+                      <option value="3">3 days per week</option>
+                      <option value="5">5 days per week</option>
+                    </select>
+                  </label>
+                </div>
+
+                <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                  Focus skill
+                  <select
+                    value={focus}
+                    onChange={(event) => setFocus(event.target.value)}
+                    className="min-h-[46px] rounded-lg border border-slate-300 bg-white px-3 text-sm outline-none transition focus:border-[#F16112] focus:ring-2 focus:ring-[#F16112]/20"
+                  >
+                    {focusOptions[subject].map((item) => (
+                      <option key={item}>{item}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <Button type="submit" className="min-h-[48px] rounded-lg bg-[#1F396D] text-white hover:bg-[#17305d]">
+                  Create my free plan
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </Button>
+              </div>
+            </form>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">Parent view</p>
+                <h3 className="font-heading mt-2 text-xl font-bold text-[#1F396D]">
+                  {showPlan ? `${grade} ${subjectLabel(subject)}: ${focus}` : 'Your child&apos;s weekly plan will appear here'}
+                </h3>
+              </div>
+              <span className="flex size-11 shrink-0 items-center justify-center rounded-lg bg-orange-50 text-[#F16112]">
+                <CalendarDays className="size-5" aria-hidden="true" />
+              </span>
+            </div>
+
+            <div className="mt-6 grid gap-3">
+              {planDays.map((item) => (
+                <div key={item.day} className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="font-bold text-[#1F396D]">{item.day}</p>
+                    <p className="text-sm font-semibold text-[#F16112]">{item.title}</p>
+                  </div>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{item.detail}</p>
+                </div>
+              ))}
+            </div>
+
+            {showPlan ? (
+              <div className="mt-6 rounded-lg bg-[#1F396D] p-4 text-white">
+                <p className="font-semibold">Plan created for {email}</p>
+                <p className="mt-1 text-sm leading-relaxed text-white/85">
+                  Use this weekly rhythm to guide short, focused practice. You can print or save it now.
+                </p>
+                <Button
+                  type="button"
+                  onClick={() => window.print()}
+                  className="mt-4 min-h-[44px] rounded-lg bg-white text-[#1F396D] hover:bg-slate-100"
+                >
+                  Print or save plan
+                  <Printer className="size-4" aria-hidden="true" />
+                </Button>
+              </div>
+            ) : (
+              <div className="mt-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm leading-relaxed text-slate-600">
+                Fill out the form to turn this into a weekly plan for your child&apos;s grade, subject, focus skill, and practice rhythm.
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white py-12 sm:py-16" aria-labelledby="next-step-title">
+        <div className="mx-auto max-w-4xl px-4 text-center sm:px-6">
+          <PenLine className="mx-auto size-9 text-[#F16112]" aria-hidden="true" />
+          <h2 id="next-step-title" className="font-heading mt-4 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+            Want GrowWise to tell you exactly where to start?
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-slate-700 sm:text-base">
+            Use this page as your parent workspace. When you want a teacher to identify the exact gap, book a free GrowWise assessment.
+          </p>
+          <Button asChild className="mt-7 min-h-[48px] rounded-lg bg-[#F16112] px-6 text-white hover:bg-[#d54f0a]">
+            <Link href={bookAssessmentHref}>
+              Book a free assessment
+              <ArrowRight className="size-4" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/data/resources-hub.ts
+++ b/src/data/resources-hub.ts
@@ -45,6 +45,16 @@ export function resourceCategoryTagClass(category: ResourceCategory): string {
 
 export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   {
+    id: 'study-plans-downloads',
+    category: 'parent-resources',
+    categoryLabel: 'PARENT RESOURCES',
+    title: 'Free Math & English Study Plans',
+    description:
+      'Download starter resources and create a simple 4-week practice plan for Math or English without a login.',
+    readTime: 'Interactive',
+    href: '/resources/downloads',
+  },
+  {
     id: 'math-reading-readiness-checklist',
     category: 'parent-resources',
     categoryLabel: 'PARENT RESOURCES',
@@ -63,6 +73,46 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
       'Interactive assessment to help your child discover their learning style and identify knowledge gaps quickly.',
     readTime: 'Interactive',
     href: '/self-check',
+  },
+  {
+    id: 'back-to-school-math-assessment-dublin-ca',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: 'Back-to-School Math Assessment Guide for Dublin, CA Families',
+    description:
+      'Before August, check the math skills your child needs for the next grade, from fractions and ratios to Algebra, Geometry, and IM1.',
+    readTime: '6 min read',
+    href: '/resources/back-to-school-math-assessment-dublin-ca',
+  },
+  {
+    id: 'english-tutor-vs-reading-tutor-vs-writing-class',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: 'English Tutor, Reading Tutor, or Writing Class: Which Does Your Child Need?',
+    description:
+      'Compare English tutoring, reading tutoring, and writing classes so you can choose the right support before the school-year rush.',
+    readTime: '6 min read',
+    href: '/resources/english-tutor-vs-reading-tutor-vs-writing-class',
+  },
+  {
+    id: 'math-tutoring-options-dublin-ca',
+    category: 'local',
+    categoryLabel: 'LOCAL',
+    title: 'Kumon vs. Mathnasium vs. Private Tutor: How Dublin Parents Should Compare Math Options',
+    description:
+      'A practical comparison framework for Dublin families choosing back-to-school math support.',
+    readTime: '7 min read',
+    href: '/resources/math-tutoring-options-dublin-ca',
+  },
+  {
+    id: 'middle-school-math-readiness-checklist',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: 'Middle School Math Readiness Checklist for Grades 6-8',
+    description:
+      'A practical August checklist for fractions, ratios, equations, graphing, word problems, and IM1 readiness.',
+    readTime: '6 min read',
+    href: '/resources/middle-school-math-readiness-checklist',
   },
   {
     id: 'reading-fluency-vs-comprehension',
@@ -260,7 +310,7 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
     id: 'child-struggles-with-writing-dublin-ca',
     category: 'academic',
     categoryLabel: 'ACADEMIC',
-    title: 'Does Your Child Have a Writing Problem — or a Confidence Problem?',
+    title: 'Why Your Child Struggles With Writing: Skill Gap or Confidence Gap?',
     description:
       'Blank-page freeze, short answers, and writing avoidance can signal skill gaps, confidence gaps, or both.',
     readTime: '6 min read',

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -30,9 +30,9 @@ export const MATH_FINALS_PRACTICE_SESSION_DESCRIPTION =
 export const metadataConfig: Record<string, PageMetadataConfig> = {
   // Home page
   '/': {
-    title: 'K-12 Online Tutoring & Coding Classes | GrowWise',
+    title: 'K-12 Tutoring, Coding & SAT Prep Dublin CA | GrowWise',
     description:
-      'GrowWise helps Grades 1-12 students build confidence with math, English, coding, STEAM, and SAT prep online or in Dublin, CA. Book a free assessment.',
+      'Dublin, CA tutoring for Grades 1-12: math, English, coding, STEAM, SAT prep, and summer programs. Book a free assessment.',
     keywords:
       'tutoring Dublin CA, Grades 1-12 education, STEAM programs, math tutor, English tutor, coding classes, SAT prep Dublin, personalized learning',
     path: '',
@@ -66,6 +66,15 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
       'GrowWise newsletter, parent education tips, K-12 tutoring updates, Dublin tutoring newsletter, student learning insights',
     path: '/bulletin',
     image: '/og-image.jpg',
+  },
+
+  '/resources/downloads': {
+    title: 'Free Math & English Study Plans | GrowWise',
+    description:
+      'Download starter resources and create a free 4-week Math or English practice plan for your child. No login required.',
+    keywords:
+      'free study plan, math practice sheets, English practice sheets, printable worksheets, 4-week study plan, GrowWise resources',
+    path: '/resources/downloads',
   },
 
   '/dublin-ca': {
@@ -106,63 +115,63 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/academic/math': {
-    title: 'Math Tutoring Programs Online — Grades 1–12 | GrowWise',
+    title: 'Math Tutoring Dublin CA | Grades 1-12',
     description:
-      'Structured math programs for Grades 1–12. Live online small groups. Elementary, middle school, and high school tracks. Book a free assessment.',
+      'Back-to-school math tutoring in Dublin, CA for Grades 1-12. Elementary, middle school, high school, and advanced math. Free assessment.',
     keywords:
-      'math tutoring online, online math program grades 1-12, elementary math tutoring, middle school math help, IM1 tutoring, high school math tutoring, AP calculus tutoring online, math small group online, 3-month math program, math tutoring small group',
+      'math tutoring Dublin CA, math tutor near me, back to school math tutoring, elementary math tutoring, middle school math tutoring, high school math tutoring, IM1 tutoring, Algebra 1 tutor, Algebra 2 tutor, geometry tutoring, Pleasanton math tutor, San Ramon math tutor, Tri-Valley math tutoring, math small group tutoring, math assessment',
     path: '/academic/math',
   },
 
   '/academic/math/elementary': {
-    title: 'Elementary Math Tutoring Online — Grades 1–5 | GrowWise',
+    title: 'Elementary Math Tutoring Dublin CA | Grades 1-5',
     description:
-      'Structured math programs for Grades 1–5. Number sense, fractions, word problem reasoning. Live online small groups. Diagnostic-first. 3-month programs.',
+      'Elementary math tutoring in Dublin, CA for Grades 1-5. Number sense, fractions, word problems, and August readiness assessment.',
     keywords:
-      'elementary math tutoring online, grade 1-5 math help, fractions tutoring grade 4, math word problem help elementary, grade 3 math struggles, place value tutoring, elementary math small group online, math program grades 1 5',
+      'elementary math tutoring Dublin CA, elementary math tutor near me, grade 1-5 math help, fractions tutoring grade 4, math word problem help elementary, common core math help, place value tutoring, August math readiness',
     path: '/academic/math/elementary',
   },
 
   '/academic/math/middle-school': {
-    title: 'Middle School Math Tutoring — IM1, IM2 | GrowWise',
+    title: 'Middle School Math Tutoring Dublin CA | IM1 Prep',
     description: buildMiddleSchoolMetaDescription(),
     keywords:
-      'middle school math tutoring online, IM1 tutoring, IM2 tutoring, pre-algebra tutoring online, integrated math 1 tutoring, grades 6-8 math program, standard track math, accelerated math tutoring',
+      'middle school math tutoring Dublin CA, IM1 tutoring, IM2 tutoring, pre-algebra tutoring, integrated math 1 tutoring, grades 6-8 math program, accelerated math readiness, 7th grade math help, August math assessment',
     path: '/academic/math/middle-school',
   },
 
   '/academic/english': {
-    title: 'English Tutoring Programs Grades 1-8 | Dublin CA | GrowWise',
+    title: 'English Tutoring Dublin CA | Reading & Writing',
     description:
-      'English tutoring for Grades 1-8 in Dublin, CA and online. Reading comprehension, writing, grammar, vocabulary, and essays in small groups.',
+      'Back-to-school English tutoring in Dublin, CA for Grades 1-8. Reading comprehension, writing, grammar, vocabulary, and essays.',
     keywords:
-      'English tutoring Dublin CA, English tutor Dublin, reading comprehension tutoring, essay writing help, grammar tutoring, vocabulary development, English Language Arts, ELA tutoring, writing tutor, reading tutor, English classes Dublin CA, English help Dublin, English tutoring near me, Grades 1-8 English programs',
+      'English tutoring Dublin CA, English tutor near me, reading tutor near me, writing tutor near me, back to school English tutoring, reading comprehension tutoring, essay writing help, grammar tutoring, vocabulary development, English Language Arts, ELA tutoring, English classes Dublin CA, Pleasanton English tutor, San Ramon English tutor, Tri-Valley reading and writing tutoring, Grades 1-8 English programs',
     path: '/academic/english',
   },
 
   '/academic/english/elementary': {
-    title: 'Elementary English Tutoring Online — Grades 1–5 | GrowWise',
+    title: 'Elementary English Tutoring Dublin CA | Grades 1-5',
     description:
-      'English for Grades 1-5: reading fluency, vocabulary, grammar, and writing in live small groups. Diagnostic-first, online or in Dublin, CA.',
+      'Elementary English tutoring in Dublin, CA for Grades 1-5. Reading fluency, comprehension, grammar, writing, and August readiness.',
     keywords:
-      'elementary English tutoring online, reading below grade level grades 1-5, my child hates writing, child reads but does not understand, California Common Core ELA, English tutoring Dublin CA, Pleasanton San Ramon Tri-Valley',
+      'elementary English tutoring Dublin CA, English tutor near me, reading tutor near me, writing tutor near me, reading below grade level grades 1-5, child reads but does not understand, grammar tutoring, English writing classes near me',
     path: '/academic/english/elementary',
   },
 
   '/courses/sat-prep': {
-    title: 'SAT Prep Tutoring in Dublin, CA | GrowWise',
+    title: 'SAT Prep Dublin CA | Classes & Tutoring | GrowWise',
     description:
-      'SAT prep in Dublin, CA with practice tests, proven strategies, and expert tutors. Small groups. Book a free assessment today.',
+      'SAT prep in Dublin, CA with small groups, practice tests, math and reading/writing strategy, and expert tutors. Book a free assessment.',
     keywords:
       'SAT prep Dublin CA, SAT preparation, SAT course, SAT tutoring Dublin, SAT test prep, SAT strategies, SAT practice tests, SAT classes Dublin CA, SAT help, SAT tutor near me, SAT prep course, SAT score improvement, college entrance exam prep',
     path: '/courses/sat-prep',
   },
 
   '/academic/math/high-school': {
-    title: 'High School Math Tutoring Dublin CA | GrowWise',
+    title: 'High School Math Tutoring Dublin CA | Algebra & Geometry',
     description: buildHighSchoolMetaDescription(),
     keywords:
-      'high school math tutoring Dublin CA, algebra tutoring, algebra 1, algebra 2, geometry tutoring, pre-calculus, AP precalculus, integrated math, integrated math 1, integrated math 2, DUSD accelerated math placement, high school math courses Dublin CA, advanced math tutoring, high school math tutoring online, AP calculus tutoring, algebra 2 tutoring, SAT math prep online, grades 9-12 math program',
+      'high school math tutoring Dublin CA, algebra tutor near me, algebra 1 tutoring, algebra 2 tutor near me, geometry tutor Dublin CA, geometry classes near me, pre-calculus tutoring, integrated math 3 tutoring, DUSD accelerated math placement, August math readiness, grades 9-12 math program',
     path: '/academic/math/high-school',
   },
 
@@ -413,9 +422,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/camps/summer': {
-    title: 'Math, Robotics, Coding & AI Camps Dublin CA | GrowWise',
+    title: 'Summer Camps Dublin CA | Math, Robotics, Coding & AI',
     description:
-      'Summer camps in Dublin, CA for Grades 1–12: Math, Robotics, Coding, AI, game development, and writing. Weekly June–August 2026. Reserve a spot.',
+      '2026 summer camps in Dublin, CA for Grades 1-12: math, robotics, coding, AI, game development, and writing. Reserve a weekly spot.',
     keywords:
       'summer camp Dublin CA, summer camps Dublin CA 2026, STEAM summer camp Dublin, coding summer camp Dublin CA, math summer camp Dublin CA, summer camp Tri-Valley, summer programs for kids Dublin CA, summer coding camp Dublin CA, summer STEAM camp Dublin CA 2026, coding camp kids Tri-Valley, summer math camp Dublin CA, AI camp for kids Dublin CA, robotics camp kids Dublin CA, game development camp kids, young authors camp summer 2026, summer camp 2026 Dublin CA, STEM camp Pleasanton, STEM camp San Ramon',
     path: '/camps/summer',
@@ -559,9 +568,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/tutoring-dublin-ca': {
-    title: 'K-12 Tutoring in Dublin CA | 2026 Parent Guide',
+    title: 'Tutoring Dublin CA | Best K-12 Options for 2026',
     description:
-      'Dublin, CA tutoring guide for Grades 1-12. Compare program types, diagnostic depth, class size, and what Tri-Valley parents should ask before enrolling.',
+      'Compare Dublin, CA tutoring options for Grades 1-12: class size, diagnostics, math, English, SAT prep, and questions to ask before enrolling.',
     keywords:
       'tutoring Dublin CA, tutoring Dublin California, K-12 tutoring Dublin California, math tutoring Dublin CA, tutoring near me Dublin CA, after school tutoring Dublin CA Tri-Valley, tutoring Pleasanton CA, tutoring San Ramon CA, coding classes Dublin CA kids, SAT prep Dublin CA, academic programs Tri-Valley',
     path: '/resources/tutoring-dublin-ca',
@@ -659,12 +668,52 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/child-struggles-with-writing-dublin-ca': {
-    title: 'Child Struggles With Writing | Dublin CA Parent Guide',
+    title: 'Why Your Child Struggles With Writing | Dublin CA',
     description:
-      'Blank-page freeze, short answers, and writing avoidance can signal skill gaps, confidence gaps, or both. Learn what helps students move forward.',
+      'Blank-page freeze, short answers, weak paragraphs, and writing avoidance can signal skill gaps, confidence gaps, or both.',
     keywords:
-      'child struggles with writing, writing help Dublin CA, child avoids writing, blank page freeze writing, writing confidence kids, summer writing program Dublin CA',
+      'child struggles with writing, writing tutor near me, middle school writing tutor, writing help Dublin CA, English writing classes near me, child avoids writing, blank page freeze writing, writing confidence kids',
     path: '/resources/child-struggles-with-writing-dublin-ca',
+    type: 'article',
+  },
+
+  '/resources/back-to-school-math-assessment-dublin-ca': {
+    title: 'Back-to-School Math Assessment Dublin CA | GrowWise',
+    description:
+      'Before August, check math readiness for fractions, ratios, algebra, geometry, and IM1 so your child starts the school year with fewer gaps.',
+    keywords:
+      'math tutor near me, math tutoring Dublin CA, back to school math assessment, middle school math tutoring, elementary math tutoring Dublin, algebra tutor near me, geometry tutor Dublin CA, integrated math tutoring',
+    path: '/resources/back-to-school-math-assessment-dublin-ca',
+    type: 'article',
+  },
+
+  '/resources/english-tutor-vs-reading-tutor-vs-writing-class': {
+    title: 'English Tutor vs Reading Tutor vs Writing Class',
+    description:
+      'Compare English tutoring, reading tutoring, and writing classes so parents can choose the right support before the August school-year rush.',
+    keywords:
+      'english tutor near me, English tutoring Dublin CA, reading tutor near me, reading tutoring near me, writing tutor Dublin CA, english writing classes near me, reading and writing classes near me',
+    path: '/resources/english-tutor-vs-reading-tutor-vs-writing-class',
+    type: 'article',
+  },
+
+  '/resources/math-tutoring-options-dublin-ca': {
+    title: 'Kumon vs Mathnasium vs Tutor Dublin CA Guide',
+    description:
+      'Compare worksheet practice, math centers, private tutors, and diagnostic-first math tutoring before choosing back-to-school support in Dublin, CA.',
+    keywords:
+      'Kumon Dublin CA, Mathnasium Dublin CA, Russian Math Dublin CA, Tutoring Club Dublin, private math tutor Dublin CA, best math tutoring Dublin CA, math tutoring near me, math tutor near me',
+    path: '/resources/math-tutoring-options-dublin-ca',
+    type: 'article',
+  },
+
+  '/resources/middle-school-math-readiness-checklist': {
+    title: 'Middle School Math Readiness Checklist | Grades 6-8',
+    description:
+      'Use this Grades 6-8 math readiness checklist before August to check fractions, ratios, equations, word problems, graphing, and IM1 prep.',
+    keywords:
+      'middle school math readiness checklist, middle school math tutoring, 6th grade math help, 7th grade math help, 8th grade math help, IM1 readiness, integrated math 1 prep, math tutoring Dublin CA',
+    path: '/resources/middle-school-math-readiness-checklist',
     type: 'article',
   },
 
@@ -689,9 +738,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/python-vs-scratch': {
-    title: 'Python vs Scratch for Kids | Parent Guide | GrowWise',
+    title: 'Python vs Scratch for Kids | Which to Learn First?',
     description:
-      'Scratch or Python? Use this age-by-age parent guide to know when to start, when to switch, and why many kids benefit from learning both in order.',
+      'Scratch or Python first? Compare starting age, when to switch, what each language teaches, and how kids move toward real coding.',
     keywords:
       'Python vs Scratch for kids, should kids learn Scratch or Python first, when to switch from Scratch to Python, best coding language for kids, Scratch for kids ages 6-10, Python for kids ages 10-14',
     path: '/resources/python-vs-scratch',
@@ -699,9 +748,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/reading-fluency-vs-comprehension': {
-    title: 'Fluency vs Comprehension: Reading Gaps | GrowWise',
+    title: 'Reading Fluency vs Comprehension | Parent Guide',
     description:
-      'Your child can decode every word but still not understand what they read. Learn how to tell fluency from comprehension gaps—and why support matters.',
+      'Compare reading fluency vs comprehension gaps, warning signs, and what support should target when a child reads words but misses meaning.',
     keywords:
       'reading fluency vs comprehension, reading fluency comprehension difference, child reads but doesn\'t understand, reading program, reading comprehension gap, reading fluency gap, child struggles with reading comprehension',
     path: '/resources/reading-fluency-vs-comprehension',
@@ -728,9 +777,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/careless-math-mistakes': {
-    title: 'Why Kids Make Careless Math Mistakes on Tests | GrowWise',
+    title: 'Careless Math Mistakes | Why Kids Lose Points',
     description:
-      'Careless math mistakes follow specific patterns. Learn how to spot the real blocker, fix the habit, and help your child stop losing points on tests.',
+      'Learn why kids make careless math mistakes, the common patterns behind lost points, and how to fix them before the next test.',
     keywords:
       'careless mistakes in math, why kids lose points on math tests, child makes careless math mistakes, how to stop careless mistakes in math, child understands math but gets wrong answers, math mistake patterns, procedural errors in math',
     path: '/resources/careless-math-mistakes',
@@ -738,9 +787,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/what-is-vibe-coding': {
-    title: "What Is Vibe Coding? A Parent's Guide (2026) | GrowWise",
+    title: 'What Is Vibe Coding? Parent Guide for Kids',
     description:
-      'Vibe coding helps kids build apps with AI, but fundamentals still matter. Learn the benefits, risks, right age, and what programs should teach.',
+      'Vibe coding lets kids build with AI, but fundamentals still matter. Learn the right age, benefits, risks, and what programs should teach.',
     keywords:
       'what is vibe coding, vibe coding for kids, vibe coding explained for parents, should kids learn vibe coding, vibe coding 2026, AI coding for kids, coding for kids 2026, AI-assisted coding children',
     path: '/resources/what-is-vibe-coding',
@@ -758,9 +807,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/when-to-start-sat-prep': {
-    title: 'When Should My Child Start SAT Prep? | GrowWise',
+    title: 'When to Start SAT Prep | Timeline by Grade',
     description:
-      'Grade 8, 9, or 10? Learn when SAT prep should start, why foundations come first, and how to build the right grade-by-grade test prep timeline.',
+      'See when SAT prep should start in grades 8, 9, 10, or 11, what to fix first, and how parents can plan a smarter prep timeline.',
     keywords:
       'when to start SAT prep, what grade to start SAT preparation, when should my child start SAT prep, SAT prep grade 8 9 10, how early to start SAT prep, digital SAT prep 2026, SAT preparation timeline high school, PSAT preparation grades 8-10, SAT math foundation gaps',
     path: '/resources/when-to-start-sat-prep',

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -60,6 +60,7 @@ const corePages: SitemapEntry[] = [
   { path: '/programs', priority: 0.8, changefreq: 'monthly' },
   { path: '/growwise-blogs', priority: 0.85, changefreq: 'weekly' },
   { path: '/resources', priority: 0.85, changefreq: 'weekly' },
+  { path: '/resources/downloads', priority: 0.85, changefreq: 'weekly' },
 ]
 
 const coursePages: SitemapEntry[] = [
@@ -119,6 +120,9 @@ const campLandingHub: SitemapEntry = {
 
 /** Blog post paths (same slugs as under `src/app/[locale]/growwise-blogs/`). */
 const blogPostPaths = [
+  '/growwise-blogs/child-reads-but-doesnt-understand-passage',
+  '/growwise-blogs/why-is-my-child-struggling-with-fractions',
+  '/growwise-blogs/common-core-math-strategies-parents',
   '/growwise-blogs/can-chatgpt-replace-a-tutor-ai-homework-help',
   '/growwise-blogs/does-my-child-need-reading-help-checklist',
   '/growwise-blogs/your-child-got-a-b-plus-doesnt-mean-they-understand-the-math',


### PR DESCRIPTION
Adds a parent-owned Math and English practice platform page at /resources/downloads.\n\nSummary:\n- Adds a guided parent practice workspace with JTBD framing\n- Adds Math and English practice shelves\n- Adds a no-login weekly plan builder and parent view\n- Wires the page into Resources, metadata, and sitemap data\n\nValidation:\n- Focused lint completed with no new errors in the changed page\n- Full Next build previously passed before later local dev/build server hangs appeared unrelated to this page