### PR TITLE
Add premium parent practice platform

### DIFF
--- a/public/api/mock/en/home.json
+++ b/public/api/mock/en/home.json
@@ -2,13 +2,13 @@
   "heroSlides": [
     {
       "id": 1,
-      "title": "Grades 1–12 Tutoring & STEAM\nin Dublin, CA",
-      "subtitle": "Expert Assessment. Personalized Plan. Math, English, coding, and SAT prep for Grades 1–12 students in the Tri-Valley.",
+      "title": "Elite Grades 1–12 Academic Training\nin Dublin, CA",
+      "subtitle": "Readiness Assessment. Personalized Mastery Plan. Math, English, coding, and SAT prep for ambitious Tri-Valley students.",
       "description": "",
-      "cta": "Book Free Assessment",
+      "cta": "Book Readiness Assessment",
       "secondaryCta": "Explore Academic Programs",
       "secondaryCtaUrl": "/academic",
-      "ctaUrl": "/enroll",
+      "ctaUrl": "/book-assessment",
       "icon": "BookOpen",
       "bgGradient": "bg-gradient-to-br from-[#1F396D] via-[#29335C] to-[#2a4a7c]",
       "iconColor": "text-white",
@@ -21,7 +21,7 @@
       "subtitle": "STEAM courses",
       "description": "Hands-on STEAM learning with Roblox, Scratch, Python, ML/AI, and Young Entrepreneurship programs.",
       "cta": "Book 30 minutes trial class",
-      "ctaUrl": "/enroll",
+      "ctaUrl": "/book-assessment",
       "icon": "Code",
       "bgGradient": "bg-gradient-to-br from-[#F16112] via-[#F1894F] to-[#d54f0a]",
       "iconColor": "text-white",
@@ -30,11 +30,11 @@
     },
     {
       "id": 3,
-      "title": "One-on-One Tuition",
-      "subtitle": "100% personal attention",
-      "description": "Specially designed for specific homework help and targeted learning support for kids who need focused attention.",
-      "cta": "Register Now",
-      "ctaUrl": "/enroll",
+      "title": "One-on-One Academic Coaching",
+      "subtitle": "Precision instruction",
+      "description": "Focused coaching for students who need sharper skills, stronger habits, and a clear path to advanced academic performance.",
+      "cta": "Request Placement Review",
+      "ctaUrl": "/book-assessment",
       "icon": "Users",
       "bgGradient": "bg-gradient-to-br from-[#1F396D] via-[#F16112] to-[#F1894F]",
       "iconColor": "text-white",
@@ -54,23 +54,23 @@
     { "id": 3, "value": "98%", "label": "Students Satisfaction", "icon": "ThumbsUp", "color": "text-[#F1894F]", "bgColor": "bg-[#F1894F]/10" }
   ],
   "k12Programs": [
-    { "id": 1, "title": "Math Courses", "description": "Build strong mathematical foundations from elementary to advanced levels", "icon": "Calculator", "gradient": "from-[#1F396D] to-[#29335C]", "bgGradient": "bg-gradient-to-br from-[#1F396D]/5 to-[#29335C]/10", "iconColor": "text-[#1F396D]", "href": "/academic/math", "ctaText": "Start Learning", "ctaUrl": "/academic/math", "subItems": [
+    { "id": 1, "title": "Math Courses", "description": "Build strong mathematical foundations from elementary to advanced levels", "icon": "Calculator", "gradient": "from-[#1F396D] to-[#29335C]", "bgGradient": "bg-gradient-to-br from-[#1F396D]/5 to-[#29335C]/10", "iconColor": "text-[#1F396D]", "href": "/academic/math", "ctaText": "Explore Math Pathways", "ctaUrl": "/academic/math", "subItems": [
       { "name": "Elementary Math", "icon": "🔢", "description": "Basic arithmetic and number sense" },
       { "name": "Middle School Math", "icon": "📊", "description": "Algebra and geometry foundations" },
       { "name": "DUSD Accelerated Math", "icon": "🚀", "description": "Advanced placement preparation" },
       { "name": "High School Math", "icon": "🎯", "description": "Calculus and advanced topics" }
     ] },
-    { "id": 2, "title": "ELA Courses", "description": "Develop comprehensive English language arts skills", "icon": "BookOpen", "gradient": "from-[#F16112] to-[#F1894F]", "bgGradient": "bg-gradient-to-br from-[#F16112]/5 to-[#F1894F]/10", "iconColor": "text-[#F16112]", "href": "/academic/english", "ctaText": "Start Learning", "ctaUrl": "/academic/english", "subItems": [
+    { "id": 2, "title": "ELA Courses", "description": "Develop comprehensive English language arts skills", "icon": "BookOpen", "gradient": "from-[#F16112] to-[#F1894F]", "bgGradient": "bg-gradient-to-br from-[#F16112]/5 to-[#F1894F]/10", "iconColor": "text-[#F16112]", "href": "/academic/english", "ctaText": "Explore English Pathways", "ctaUrl": "/academic/english", "subItems": [
       { "name": "English Mastery: Grades 1-12", "icon": "📚", "description": "Complete language arts curriculum" },
       { "name": "Reading Enrichment", "icon": "📖", "description": "Improve reading comprehension" },
       { "name": "Grammar Boost", "icon": "✏️", "description": "Master grammar and mechanics" }
     ] },
-    { "id": 3, "title": "Writing Lab", "description": "Master the art of effective written communication", "icon": "PenTool", "gradient": "from-[#F1894F] to-[#F16112]", "bgGradient": "bg-gradient-to-br from-[#F1894F]/5 to-[#F16112]/10", "iconColor": "text-[#F1894F]", "ctaText": "Start Learning", "ctaUrl": "/academic/english", "subItems": [
+    { "id": 3, "title": "Writing Lab", "description": "Master the art of effective written communication", "icon": "PenTool", "gradient": "from-[#F1894F] to-[#F16112]", "bgGradient": "bg-gradient-to-br from-[#F1894F]/5 to-[#F16112]/10", "iconColor": "text-[#F1894F]", "ctaText": "Explore Writing Lab", "ctaUrl": "/academic/english", "subItems": [
       { "name": "Creative Writing", "icon": "✨", "description": "Unleash your creative potential" },
       { "name": "Essay Writing", "icon": "📝", "description": "Academic and persuasive writing" },
       { "name": "Foundations of Writing", "icon": "🤔", "description": "Develop critical thinking skills" }
     ] },
-    { "id": 4, "title": "SAT/ACT", "description": "Achieve your best scores with comprehensive test preparation", "icon": "Award", "gradient": "from-[#1F396D] to-[#F16112]", "bgGradient": "bg-gradient-to-br from-gray-50 to-gray-100", "iconColor": "text-[#1F396D]", "ctaText": "Start Learning", "ctaUrl": "/courses/sat-prep", "subItems": [
+    { "id": 4, "title": "SAT/ACT", "description": "Achieve your best scores with comprehensive test preparation", "icon": "Award", "gradient": "from-[#1F396D] to-[#F16112]", "bgGradient": "bg-gradient-to-br from-gray-50 to-gray-100", "iconColor": "text-[#1F396D]", "ctaText": "Explore Test Prep", "ctaUrl": "/courses/sat-prep", "subItems": [
       { "name": "Math Test Prep", "icon": "🧮", "description": "Master SAT/ACT math sections" },
       { "name": "Online SAT Test Prep", "icon": "💻", "description": "Comprehensive SAT preparation" },
       { "name": "Online ACT Test Prep", "icon": "🎯", "description": "Complete ACT test strategy" }
@@ -107,20 +107,18 @@
     { "name": "Sindhu Jayaraman", "role": "Parent", "content": "My son has been enrolled in English tutoring for the past four months, and we've seen tremendous improvement in his skills! His confidence in writing has grown, and his comprehension has improved significantly. The tutors are patient, knowledgeable, and truly dedicated to helping students succeed. The personalized approach and engaging lessons have made a huge difference. Highly recommend GrowWise Tutoring for any parent looking to support their child's academic growth!", "rating": 5, "image": "https://lh3.googleusercontent.com/a-/ALV-UjWQsThJbc8c4dZZQ0Rtafrwz55pki40TtiNLyxrRFkFVe0dLTHj=s128-c0x00000000-cc-rp-mo" }
   ],
   "whyChooseUs": [
-    { "icon": "UserCheck", "title": "1️⃣ Personalized Pathway", "description": "We build a unique learning plan for each child — aligned with school curriculum, grade level, and personal goals. No generic lessons — every session is customized for their needs.", "subtitle": "Tailored Learning for Every Student" },
+    { "icon": "UserCheck", "title": "1️⃣ Personalized Pathway", "description": "We build a unique learning plan for each child — aligned with school curriculum, grade level, and personal goals. No generic lessons — every session is calibrated to their next academic move.", "subtitle": "Tailored Learning for Every Student" },
     { "icon": "Target", "title": "2️⃣ 100% Curriculum Aligned", "description": "Our lessons follow district pacing guides (Dublin, Pleasanton, San Ramon USD) and California Common Core, ensuring seamless classroom reinforcement.", "subtitle": "Perfectly Synced with School Topics" },
-    { "icon": "RefreshCw", "title": "3️⃣ Continuous Feedback Loop", "description": "Parents receive consistent feedback and progress snapshots — so you always know where your child stands and how to help at home.", "subtitle": "Regular Progress Updates for Parents" },
+    { "icon": "RefreshCw", "title": "3️⃣ Continuous Feedback Loop", "description": "Parents receive consistent feedback and progress snapshots — so you always know where your child stands and what should happen next at home.", "subtitle": "Regular Progress Updates for Parents" },
     { "icon": "BarChart3", "title": "4️⃣ Frequent Assessments", "description": "Diagnostic, weekly, and unit assessments guide the next learning step. Our tutors personalize practice based on every result.", "subtitle": "Measure, Adjust, and Master" },
     { "icon": "TrendingUp", "title": "5️⃣ Real Results", "description": "Students gain measurable improvement — stronger grades, sharper problem-solving, and renewed motivation within weeks.", "subtitle": "Confidence, Grades, and Growth" }
   ],
   "cta": {
-    "title": "Ready to Start Your Learning Journey?",
-    "subtitle": "Join 387+ students who have transformed their academic future with GrowWise.",
-    "primaryCta": "Choose Enrollment Type",
-    "primaryCtaUrl": "/enroll",
+    "title": "Ready to Build an Achievement Plan?",
+    "subtitle": "Join 387+ students training for stronger grades, sharper thinking, and long-term academic confidence with GrowWise.",
+    "primaryCta": "Book Readiness Assessment",
+    "primaryCtaUrl": "/book-assessment",
     "secondaryCta": "Talk to GrowWise",
     "secondaryCtaUrl": "/contact"
   }
 }
-
-

--- a/src/app/[locale]/book-assessment/BookAssessmentPageClient.tsx
+++ b/src/app/[locale]/book-assessment/BookAssessmentPageClient.tsx
@@ -30,6 +30,32 @@ import { publicPath } from '@/lib/publicPath';
 import { siteGoogleTrustReviewCards } from '@/lib/siteGoogleTrustReviews';
 import { trackAssessmentFormSubmitted, trackGenerateLead } from '@/lib/analytics/gtmEvents';
 import { captureUtmFromSearchParams, getStoredUtm, getStoredUtmNotesLine } from '@/lib/analytics/utm';
+import PartnerTrustStrip from '@/components/shared/PartnerTrustStrip';
+import PartnerReferralCard from '@/components/shared/PartnerReferralCard';
+
+const partnerConfig = {
+  velp: {
+    name: "Velp",
+    displayName: "Welcome to the Velp Family!",
+    code: "VELP1",
+    benefit: "10% OFF your first paid program after assessment confirmation",
+    benefitShort: "10% OFF",
+  },
+  activityhero: {
+    name: "ActivityHero",
+    displayName: "Welcome ActivityHero Families!",
+    code: "HERO35",
+    benefit: "$35 OFF your first paid program after assessment confirmation",
+    benefitShort: "$35 OFF",
+  },
+  "6crickets": {
+    name: "6Crickets",
+    displayName: "Welcome 6Crickets Families!",
+    code: "6cricket10",
+    benefit: "10% OFF your first paid program after assessment confirmation",
+    benefitShort: "10% OFF",
+  },
+} as const;
 
 interface FormData {
   parentName: string;
@@ -43,6 +69,12 @@ interface FormData {
   scheduleDay: string;
   scheduleTime: string;
   hearAboutUs: string;
+  partnerName?: string;
+  partnerCode?: string;
+  partnerBenefit?: string;
+  utm_source?: string;
+  utm_campaign?: string;
+  landingUrl?: string;
 }
 
 const NEIGHBORHOODS: Record<string, { name: string; headline: string }> = {
@@ -65,7 +97,7 @@ const NEIGHBORHOODS: Record<string, { name: string; headline: string }> = {
 };
 
 const DEFAULT_ASSESSMENT_HEADLINE =
-  'Advanced After-School Math & English Enrichment (Grades 1-12).';
+  'Advanced Math & English Readiness Assessment for Grades 1-12.';
 
 const ASSESSMENT_CALENDLY_URL =
   process.env.NEXT_PUBLIC_ASSESSMENT_CALENDLY_URL ||
@@ -79,6 +111,8 @@ export default function BookAssessmentPageClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const communitySlug = searchParams.get('community') || '';
+  const partnerParam = searchParams.get('partner') || '';
+  const validPartner = partnerParam && partnerConfig[partnerParam as keyof typeof partnerConfig] ? partnerConfig[partnerParam as keyof typeof partnerConfig] : null;
   const neighborhood = NEIGHBORHOODS[communitySlug] || {
     name: 'Dublin',
     headline: DEFAULT_ASSESSMENT_HEADLINE,
@@ -115,9 +149,15 @@ export default function BookAssessmentPageClient() {
       mode: '',
       scheduleDay: '',
       scheduleTime: '',
-      hearAboutUs: '',
+      hearAboutUs: validPartner ? validPartner.name : '',
+      partnerName: validPartner ? validPartner.name : undefined,
+      partnerCode: validPartner ? validPartner.code : undefined,
+      partnerBenefit: validPartner ? validPartner.benefit : undefined,
+      utm_source: validPartner ? 'partner' : undefined,
+      utm_campaign: validPartner ? partnerParam : undefined,
+      landingUrl: typeof window !== 'undefined' ? window.location.href : undefined,
     }),
-    []
+    [validPartner, partnerParam]
   );
 
   const [formData, setFormData] = useState<FormData>(initialFormData);
@@ -286,6 +326,12 @@ export default function BookAssessmentPageClient() {
         mode: formData.mode || 'Flexible',
         schedule: scheduleCombined,
         hearAboutUs: formData.hearAboutUs,
+        partnerName: formData.partnerName,
+        partnerCode: formData.partnerCode,
+        partnerBenefit: formData.partnerBenefit,
+        utm_source: formData.utm_source,
+        utm_campaign: formData.utm_campaign,
+        landingUrl: formData.landingUrl,
         notes,
         agreeToCommunications,
         recaptchaToken: recaptchaToken || undefined,
@@ -440,10 +486,12 @@ export default function BookAssessmentPageClient() {
           <div className="absolute bottom-20 right-10 w-[500px] h-[500px] bg-gradient-to-br from-[#F16112]/10 to-transparent rounded-full blur-3xl"></div>
         </div>
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative">
+          {/* Partner Referral Card */}
+          {validPartner && <PartnerReferralCard partner={validPartner} />}
           <div className="text-center mb-12">
             <Badge className="mb-6 bg-gradient-to-r from-[#F16112] to-[#F1894F] text-white border-0 px-8 py-3 shadow-lg">
               <Sparkles className="w-5 h-5 mr-2" />
-              100% Free - No Credit Card Required
+              Complimentary Readiness Review
             </Badge>
             <h1
               id="book-assessment-hero-h1"
@@ -452,13 +500,13 @@ export default function BookAssessmentPageClient() {
               {neighborhood.headline}
             </h1>
             <p className="text-gray-600 max-w-2xl mx-auto text-lg">
-              Capped at 8 students per class | 4564 Dublin Blvd
+              Placement insight, skill-gap diagnosis, and a clear next academic move | 4564 Dublin Blvd
             </p>
           </div>
           <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
             {[
               ['Takes 30 seconds', '4 details plus consent'],
-              ['No commitment', 'Free first-step guidance'],
+              ['No enrollment pressure', 'Start with the academic standard'],
               ['Clear next step', 'We confirm timing with you'],
             ].map(([title, text]) => (
               <div key={title} className="rounded-xl border border-[#1F396D]/10 bg-white px-4 py-3 text-center shadow-sm">
@@ -574,6 +622,41 @@ export default function BookAssessmentPageClient() {
                       </div>
                     </div>
 
+                    <div className="space-y-4 md:space-y-6 p-4 sm:p-6 md:p-8 bg-gradient-to-br from-[#1F396D]/5 to-[#F16112]/5 rounded-xl md:rounded-2xl border-2 border-[#1F396D]/10">
+                      <div className="flex items-center gap-2 sm:gap-3 pb-3 md:pb-4 border-b-2 border-[#1F396D]/20">
+                        <div className="p-2 sm:p-3 bg-gradient-to-br from-[#1F396D] to-[#29335C] rounded-lg md:rounded-xl"><User className="w-5 h-5 sm:w-6 sm:h-6 text-white" /></div>
+                        <div><h3 className="text-gray-900 text-lg sm:text-xl">How Did You Hear About Us?</h3><p className="text-xs sm:text-sm text-gray-500">So we can credit the right community path</p></div>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="hearAboutUs" className="text-gray-700 font-medium text-sm sm:text-base flex items-center gap-2"><User className="w-4 h-4 text-[#F16112]" />Source <span className="text-gray-400 text-xs">(optional)</span></Label>
+                        <Select
+                          onValueChange={(value) => handleInputChange('hearAboutUs', value)}
+                          value={formData.hearAboutUs || undefined}
+                        >
+                          <SelectTrigger
+                            id="hearAboutUs"
+                            data-testid="assessment-hear-about-us-trigger"
+                            className="bg-white border-2 border-gray-300 rounded-lg md:rounded-xl hover:border-gray-400 transition-all h-12 md:h-14 text-sm sm:text-base"
+                          >
+                            <SelectValue placeholder="Select how you heard about us" />
+                          </SelectTrigger>
+                          <SelectContent className="bg-white/95 backdrop-blur-xl border-2 border-white/60 rounded-xl shadow-2xl">
+                            <SelectItem value="Not provided">Not provided</SelectItem>
+                            {validPartner && (
+                              <SelectItem value={validPartner.name}>{validPartner.name}</SelectItem>
+                            )}
+                            <SelectItem value="Google Search">Google Search</SelectItem>
+                            <SelectItem value="Social Media">Social Media</SelectItem>
+                            <SelectItem value="Friend/Family Referral">Friend/Family Referral</SelectItem>
+                            <SelectItem value="School Recommendation">School Recommendation</SelectItem>
+                            <SelectItem value="Door Hanger">Door Hanger</SelectItem>
+                            <SelectItem value="NextDoor">NextDoor</SelectItem>
+                            <SelectItem value="Other">Other</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+
                     <FormPrivacyConsent
                       checkboxId="agreeToCommunications"
                       checked={agreeToCommunications}
@@ -676,13 +759,13 @@ export default function BookAssessmentPageClient() {
                         ) : (
                           <>
                             <Send className="w-6 h-6 mr-3 group-hover:translate-x-1 transition-transform" />
-                            Request Free Assessment Call
+                            Request Readiness Assessment Call
                             <Sparkles className="w-5 h-5 ml-3 group-hover:scale-110 transition-transform" />
                           </>
                         )}
                       </Button>
                       <p className="mt-3 text-center text-xs text-slate-500">
-                        We&apos;ll call or text within 24 hours. No payment. No commitment.
+                        We&apos;ll call or text within 24 hours. No payment required.
                       </p>
                       {errorMessage && (
                         <div className="mt-4 p-4 bg-red-50 border-2 border-red-200 rounded-xl">
@@ -786,6 +869,8 @@ export default function BookAssessmentPageClient() {
         </div>
       </section>
 
+      <PartnerTrustStrip />
+
       <section className="py-24 bg-gradient-to-br from-gray-50 via-white to-gray-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
@@ -823,9 +908,9 @@ export default function BookAssessmentPageClient() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
           <div>
             <h2 className="text-white mb-6 text-4xl lg:text-5xl">Ready to Unlock Your Child's Potential?</h2>
-            <p className="text-white/90 mb-10 text-xl leading-relaxed">Book a free assessment today and get personalized insights into your child's academic journey</p>
+            <p className="text-white/90 mb-10 text-xl leading-relaxed">Book a readiness assessment and get a clearer view of your child&apos;s academic path.</p>
             <div className="flex flex-wrap justify-center gap-6">
-              <Button onClick={scrollToForm} className="bg-white text-[#1F396D] hover:bg-gray-100 px-10 py-7 rounded-2xl shadow-2xl hover:shadow-xl transition-all duration-200 hover:scale-105 group text-lg"><Calendar className="w-6 h-6 mr-3 group-hover:rotate-12 transition-transform" />Book a Free Assessment<ArrowRight className="w-5 h-5 ml-3 group-hover:translate-x-1 transition-transform" /></Button>
+              <Button onClick={scrollToForm} className="bg-white text-[#1F396D] hover:bg-gray-100 px-10 py-7 rounded-2xl shadow-2xl hover:shadow-xl transition-all duration-200 hover:scale-105 group text-lg"><Calendar className="w-6 h-6 mr-3 group-hover:rotate-12 transition-transform" />Book Readiness Assessment<ArrowRight className="w-5 h-5 ml-3 group-hover:translate-x-1 transition-transform" /></Button>
               <Button variant="outline" className="bg-transparent border-2 border-white text-white hover:bg-white/10 px-10 py-7 rounded-2xl transition-all duration-200 text-lg backdrop-blur-xl"><PhoneIcon className="w-5 h-5 mr-2" />{CONTACT_INFO.phone}</Button>
             </div>
           </div>

--- a/src/app/[locale]/book-assessment/layout.tsx
+++ b/src/app/[locale]/book-assessment/layout.tsx
@@ -9,7 +9,7 @@ import { CONTACT_INFO } from '@/lib/constants'
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
   const metadata = generateMetadataFromPath('/book-assessment', locale)
-  return metadata || { title: 'Book Assessment | GrowWise', description: 'Book your free assessment' }
+  return metadata || { title: 'Book Readiness Assessment | GrowWise', description: 'Book your GrowWise readiness assessment' }
 }
 
 export default async function BookAssessmentLayout({
@@ -26,10 +26,10 @@ export default async function BookAssessmentLayout({
     '@context': 'https://schema.org',
     '@type': 'Service',
     '@id': absoluteSiteUrl('/book-assessment#service', locale, baseUrl),
-    name: 'Free Academic Assessment',
+    name: 'GrowWise Readiness Assessment',
     description:
-      "Book a free academic assessment at GrowWise in Dublin, CA. We evaluate your child's current level in Math, English, or STEAM and recommend the right next step.",
-    serviceType: 'Academic Assessment',
+      "Book a GrowWise readiness assessment in Dublin, CA. We evaluate your child's current level in Math, English, or STEAM and recommend the right next step.",
+    serviceType: 'Academic Readiness Assessment',
     provider: {
       '@type': 'EducationalOrganization',
       name: 'GrowWise',
@@ -56,7 +56,7 @@ export default async function BookAssessmentLayout({
       priceCurrency: 'USD',
       availability: 'https://schema.org/InStock',
       url: absoluteSiteUrl('/book-assessment', locale, baseUrl),
-      description: 'Complimentary academic assessment',
+      description: 'Complimentary academic readiness assessment',
     },
     url: absoluteSiteUrl('/book-assessment', locale, baseUrl),
   }

--- a/src/app/[locale]/resources/downloads/layout.tsx
+++ b/src/app/[locale]/resources/downloads/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+import { generateMetadataFromPath } from '@/lib/seo/metadata'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  return (
+    generateMetadataFromPath('/resources/downloads', locale) ?? {
+      title: 'Free Math & English Study Plans | GrowWise',
+      description:
+        'Download starter resources and create a free 4-week Math or English study plan for your child.',
+    }
+  )
+}
+
+export default function DownloadsLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/src/app/[locale]/resources/downloads/page.tsx
+++ b/src/app/[locale]/resources/downloads/page.tsx
@@ -1,0 +1,5 @@
+import { StudyPlansDownloadPage } from '@/components/resources/StudyPlansDownloadPage'
+
+export default function DownloadsPage() {
+  return <StudyPlansDownloadPage />
+}

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getBackendBaseUrlForProxy } from '@/lib/config';
 
-/** Slightly above Express axios timeout to backend Google call so the proxy does not hang indefinitely. */
-const PROXY_TO_BACKEND_MS = 12_000;
+/** Keep local dev responsive when the Express backend is not running. */
+const PROXY_TO_BACKEND_MS = process.env.NODE_ENV === 'development' ? 800 : 12_000;
 
 /**
  * When Express returns 5xx, the browser still shows a red 500 on /api/testimonials.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,8 @@
 /* Removed Tailwind v4-only @custom-variant; using standard .dark class selectors below */
 
 :root {
+  --font-inter: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-plus-jakarta: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-size: 14px;
   --background: #ffffff;
   --foreground: oklch(0.145 0 0);
@@ -258,9 +260,12 @@ body {
   .header-social-link { @apply text-white/90 hover:text-white transition-colors inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded; }
   .header-address { @apply text-white/90 text-xs hidden lg:block; }
 
-  .header-mainrow { @apply flex items-center justify-between h-20 min-w-0 gap-2 lg:h-32; }
-  .header-logo-wrap { @apply min-w-0 flex-1 overflow-hidden; }
-  .header-logo { @apply h-[110px] w-[280px] max-w-full object-contain object-left; }
+  .header-mainrow { @apply flex items-center justify-between h-20 min-w-0 gap-2 lg:h-24 xl:h-28 2xl:h-32; }
+  .header-logo-wrap { @apply flex-none w-[150px] sm:w-[180px] lg:ml-4 lg:w-[180px] xl:ml-6 xl:w-[210px] 2xl:ml-8 2xl:w-[250px] overflow-visible; }
+  .header-logo { @apply h-11 w-full object-contain object-left sm:h-12 lg:h-16 xl:h-20 2xl:h-[88px]; }
+  .header-logo-slogan { @apply -mt-1 w-full leading-tight text-center; }
+  .header-logo-slogan-primary { @apply block text-[9px] font-extrabold tracking-[0.04em] text-[#1F396D] sm:text-[10px] lg:text-[11px] xl:text-xs; }
+  .header-logo-slogan-secondary { @apply block text-[7px] font-semibold lowercase tracking-[0.08em] text-slate-500 sm:text-[8px] lg:text-[9px]; }
   
   @media (max-width: 1023px) {
     .header-mainrow {
@@ -273,16 +278,22 @@ body {
 
   @media (max-width: 640px) {
     .header-logo { 
-      height: 48px !important;
+      height: 42px !important;
       width: auto !important;
       max-width: 100% !important;
     }
+    .header-logo-slogan-primary {
+      font-size: 8px !important;
+    }
+    .header-logo-slogan-secondary {
+      font-size: 6px !important;
+    }
   }
-  .header-desktop-nav { @apply hidden lg:flex items-center space-x-0; }
+  .header-desktop-nav { @apply hidden lg:flex items-center space-x-0 min-w-0 flex-1 justify-center; }
   /* !text-sm avoids hydration/CSS drift vs base layer (e.g. button text-base) on nav triggers */
-  .header-navlink { @apply px-3 py-2 rounded-full !text-sm font-medium transition-all duration-300 flex items-center gap-1 relative; }
+  .header-navlink { @apply px-2 py-2 rounded-full !text-sm font-medium transition-all duration-300 flex items-center gap-1 relative xl:px-2.5 2xl:px-3; }
   /* Desktop dropdown triggers (wider padding than simple nav links); same explicit text size as .header-navlink */
-  .header-dropdown-nav-trigger { @apply px-4 py-2 rounded-full !text-sm font-medium transition-all duration-300 flex items-center gap-1 relative whitespace-nowrap; }
+  .header-dropdown-nav-trigger { @apply px-2 py-2 rounded-full !text-sm font-medium transition-all duration-300 flex items-center gap-1 relative whitespace-nowrap xl:px-2.5 2xl:px-4; }
   .header-nav-neutral { @apply text-gray-700 hover:bg-gray-100; }
   .header-indicator-base { @apply absolute bottom-0 left-1/2 transform -translate-x-1/2 w-0 h-0.5 rounded-full transition-all duration-300; }
   .header-dropdown-panel { @apply absolute top-full left-0 mt-2 w-80 bg-white border-2 border-gray-200 shadow-[0px_20px_60px_rgba(31,57,109,0.2)] rounded-2xl overflow-hidden transition-all duration-300 z-50 ring-1 ring-gray-200; }

--- a/src/components/layout/Header/Dropdown.tsx
+++ b/src/components/layout/Header/Dropdown.tsx
@@ -89,6 +89,7 @@ export default function Dropdown({
       ) : (
         <Link
           href={createLocaleUrl(item.href)}
+          prefetch={false}
           suppressHydrationWarning
           className={cn('header-dropdown-nav-trigger group', triggerStateClass)}
           onClick={() => onItemClick()}
@@ -168,7 +169,7 @@ export default function Dropdown({
           {item.key !== 'academic' && item.key !== 'steam' && (
             <div className="px-6 py-4 bg-gradient-to-r from-gray-50 to-gray-100/50 border-t border-gray-100">
               <p className="text-xs text-gray-500 text-center">
-                {footerHelper} <Link href={createLocaleUrl('/contact')} className="text-[#1F396D] font-medium hover:underline">{footerContactCta}</Link>
+                {footerHelper} <Link href={createLocaleUrl('/contact')} prefetch={false} className="text-[#1F396D] font-medium hover:underline">{footerContactCta}</Link>
               </p>
             </div>
           )}

--- a/src/components/layout/Header/DropdownItem.tsx
+++ b/src/components/layout/Header/DropdownItem.tsx
@@ -152,7 +152,7 @@ export default function DropdownItem({
     <div className="relative">
       {submenuWithHubLink && hubHref ? (
         <div className={`group flex items-center w-full ${linkClassName}`} {...rowMouseHandlers}>
-          <Link href={hubHref} onClick={onItemClick} className="flex flex-1 items-center gap-4 px-4 py-2 min-w-0">
+          <Link href={hubHref} prefetch={false} onClick={onItemClick} className="flex flex-1 items-center gap-4 px-4 py-2 min-w-0">
             {rowBody}
           </Link>
           {chevronButton}
@@ -160,6 +160,7 @@ export default function DropdownItem({
       ) : (
         <Link
           href={hasSubmenu ? '#' : createLocaleUrl(item.href)}
+          prefetch={false}
           onClick={hasSubmenu ? handleSubmenuOnlyClick : onItemClick}
           className={linkClassName}
           {...rowMouseHandlers}
@@ -238,6 +239,7 @@ function Submenu({
         {parentItem.href ? (
           <Link
             href={createLocaleUrl(parentItem.href)}
+            prefetch={false}
             onClick={onItemClick}
             className="block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-[#1F396D]/40"
           >
@@ -399,6 +401,7 @@ function SubmenuItemRow({
       ) : (
         <Link
           href={createLocaleUrl(subItem.href)}
+          prefetch={false}
           onClick={onItemClick}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
@@ -504,6 +507,7 @@ function NestedSubmenuPanel({
               <Link
                 key={nested.key ?? nested.title}
                 href={createLocaleUrl(nested.href)}
+                prefetch={false}
                 onClick={onItemClick}
                 className={`group mx-2 my-0.5 rounded-xl transition-all duration-300 cursor-pointer block w-[calc(100%-1rem)] ${
                   isNestedActive

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -100,8 +100,8 @@ export default function Header() {
       <div className="max-w-[90rem] mx-auto px-4 sm:px-6 lg:px-8 overflow-x-clip">
         <div className="header-mainrow lg:flex-nowrap">
           {/* Logo — flex-shrink-0 keeps the logo visible when nav is long */}
-          <div className="header-logo-wrap flex items-center">
-            <Link href={createLocaleUrlHelper('/')} className="cursor-pointer" aria-label="GrowWise home">
+          <div className="header-logo-wrap flex flex-col items-start justify-center">
+            <Link href={createLocaleUrlHelper('/')} prefetch={false} className="cursor-pointer" aria-label="GrowWise home">
               <Image
                 src="/assets/growwise-logo.png"
                 alt="GrowWise"
@@ -112,6 +112,10 @@ export default function Header() {
                 fetchPriority="low"
               />
             </Link>
+            <p className="header-logo-slogan" aria-label="Education First Always. business second.">
+              <span className="header-logo-slogan-primary">Education First Always.</span>
+              <span className="header-logo-slogan-secondary">business second.</span>
+            </p>
           </div>
 
           {/* Desktop Navigation */}

--- a/src/components/layout/Header/MobileNavigation.tsx
+++ b/src/components/layout/Header/MobileNavigation.tsx
@@ -58,6 +58,7 @@ function renderMobileSubmenuItem(
                 <Link
                   key={nested.key ?? nested.title}
                   href={nestedHref}
+                  prefetch={false}
                   className={`block py-2 px-2 text-sm transition-colors duration-200 rounded-lg ${
                     isLinkActive
                       ? 'text-[#1F396D] bg-[#1F396D]/10 font-medium'
@@ -86,6 +87,7 @@ function renderMobileSubmenuItem(
     <Link
       key={itemKey}
       href={href}
+      prefetch={false}
       className={`block py-2 px-2 text-sm transition-colors duration-200 rounded-lg ${
         isLinkActive
           ? 'text-[#1F396D] bg-[#1F396D]/10 font-medium'
@@ -182,6 +184,7 @@ export default function MobileNavigation({
         {showCart && (
           <Link
             href={createLocaleUrl('/cart')}
+            prefetch={false}
             className="relative inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-gray-700 hover:text-[#F16112] transition-colors rounded-lg hover:bg-gray-50"
             onClick={onCloseMobileMenu}
             aria-label={cartItemCount > 0 ? `Shopping cart, ${cartItemCount} items` : 'Shopping cart'}
@@ -318,6 +321,7 @@ export default function MobileNavigation({
                                         >
                                           <Link
                                             href={createLocaleUrl(dropdownItem.href)}
+                                            prefetch={false}
                                             className={`flex-1 py-2 px-2 text-sm transition-colors duration-200 text-left ${
                                               isFlyoutActive
                                                 ? 'text-[#1F396D] font-medium'
@@ -354,6 +358,7 @@ export default function MobileNavigation({
                                                 <Link
                                                   key={sub.key ?? sub.title}
                                                   href={subHref}
+                                                  prefetch={false}
                                                   className={`block py-2 px-2 text-sm transition-colors duration-200 rounded-lg ${
                                                     isLinkActive
                                                       ? 'text-[#1F396D] bg-[#1F396D]/10 font-medium'
@@ -377,6 +382,7 @@ export default function MobileNavigation({
                                     <Link
                                       key={dropdownItem.key}
                                       href={createLocaleUrl(dropdownItem.href)}
+                                      prefetch={false}
                                       className={`block py-2 px-2 text-sm transition-colors duration-200 rounded-lg ${
                                         isDropdownItemActive
                                           ? 'text-[#1F396D] bg-[#1F396D]/10 font-medium'
@@ -406,6 +412,7 @@ export default function MobileNavigation({
                           ) : (
                             <Link
                               href={createLocaleUrl(item.href)}
+                              prefetch={false}
                               className={`block font-medium py-3 px-2 transition-colors duration-200 rounded-lg ${
                                 isActive
                                   ? 'text-[#1F396D] bg-[#1F396D]/10'
@@ -432,6 +439,7 @@ export default function MobileNavigation({
 
               <Link
                 href={createLocaleUrl('/enroll')}
+                prefetch={false}
                 className="block w-full mt-6 px-6 py-3 rounded-full font-medium text-center transition-all duration-300 bg-[#F16112] text-white hover:bg-[#F1894F] shadow-lg"
                 onClick={onCloseMobileMenu}
               >
@@ -445,6 +453,7 @@ export default function MobileNavigation({
               <div className="mt-4 flex flex-row items-stretch gap-2">
                 <Link
                   href={createLocaleUrl('/student-login')}
+                  prefetch={false}
                   className="inline-flex min-w-0 flex-1 items-center justify-center px-4 py-3 rounded-full font-medium text-center transition-all duration-300 border border-[#1F396D] text-[#1F396D] hover:bg-[#1F396D] hover:text-white"
                   onClick={onCloseMobileMenu}
                 >

--- a/src/components/layout/Header/NavButton.tsx
+++ b/src/components/layout/Header/NavButton.tsx
@@ -36,6 +36,7 @@ export default function NavButton({ item, createLocaleUrl }: NavButtonProps) {
     <div className="relative group">
       <Link
         href={createLocaleUrl(item.href)}
+        prefetch={false}
         className={getButtonStyles(item.variant)}
         onClick={handleClick}
       >

--- a/src/components/layout/Header/NavLink.tsx
+++ b/src/components/layout/Header/NavLink.tsx
@@ -35,6 +35,7 @@ export default function NavLink({ item, isActive, createLocaleUrl }: NavLinkProp
     <div className="relative group">
       <Link
         href={createLocaleUrl(item.href)}
+        prefetch={false}
         className={`header-navlink whitespace-nowrap ${
           isActive
             ? 'bg-[#1F396D] text-white shadow-lg'

--- a/src/components/layout/Header/UtilityIcons.tsx
+++ b/src/components/layout/Header/UtilityIcons.tsx
@@ -26,12 +26,15 @@ export default function UtilityIcons({ cartItemCount, createLocaleUrl, showCart 
   };
 
   return (
-    <div className="header-utilities relative z-0 hidden lg:flex items-center space-x-3 flex-shrink-0">
-      <div className="flex items-center space-x-3">
-        <SearchBar />
+    <div className="header-utilities relative z-0 hidden lg:flex items-center gap-2 flex-none">
+      <div className="flex items-center gap-2">
+        <div className="hidden 2xl:block">
+          <SearchBar />
+        </div>
         {showCart && (
           <Link 
             href={createLocaleUrl('/cart')} 
+            prefetch={false}
             className="relative text-gray-700 hover:text-[#F16112] transition-colors"
             aria-label={cartItemCount > 0 ? `Shopping cart, ${cartItemCount} items` : 'Shopping cart'}
           >
@@ -45,15 +48,17 @@ export default function UtilityIcons({ cartItemCount, createLocaleUrl, showCart 
         )}
         <Link
           href={createLocaleUrl('/enroll')}
+          prefetch={false}
           onClick={handleEnrollClick}
-          className="px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 whitespace-nowrap bg-[#F16112] text-white hover:bg-[#F1894F] shadow-lg hover:shadow-xl"
+          className="px-3 py-2 rounded-full text-sm font-medium transition-all duration-300 whitespace-nowrap bg-[#F16112] text-white hover:bg-[#F1894F] shadow-lg hover:shadow-xl xl:px-4"
         >
           {t('enroll')}
         </Link>
 
-        <div className="flex items-center gap-2">
+        <div className="hidden 2xl:flex items-center gap-2">
           <Link
             href={createLocaleUrl('/student-login')}
+            prefetch={false}
             className="px-4 py-2 rounded-full text-sm font-medium border border-[#1F396D] text-[#1F396D] hover:bg-[#1F396D] hover:text-white transition-all duration-300 whitespace-nowrap shadow-sm"
           >
             Student Login
@@ -62,7 +67,9 @@ export default function UtilityIcons({ cartItemCount, createLocaleUrl, showCart 
         </div>
       </div>
 
-      <LocaleSwitcher />
+      <div className="hidden 2xl:block">
+        <LocaleSwitcher />
+      </div>
     </div>
   );
 }

--- a/src/components/resources/StudyPlansDownloadPage.tsx
+++ b/src/components/resources/StudyPlansDownloadPage.tsx
@@ -1,0 +1,332 @@
+'use client'
+
+import { useState, type FormEvent } from 'react'
+import Link from 'next/link'
+import { useLocale } from 'next-intl'
+import {
+  ArrowRight,
+  BookOpenCheck,
+  CalendarDays,
+  CheckCircle2,
+  Download,
+  FileText,
+  Mail,
+  Printer,
+  Target,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { publicPath } from '@/lib/publicPath'
+import { cn } from '@/lib/utils'
+
+type Subject = 'math' | 'english'
+type Frequency = '3' | '5'
+
+type DownloadItem = {
+  id: string
+  subject: Subject
+  title: string
+  grade: string
+  description: string
+  href?: string
+}
+
+const downloads: DownloadItem[] = [
+  {
+    id: 'thinking-gap-playbook',
+    subject: 'math',
+    title: 'Thinking Gap Playbook for Parents',
+    grade: 'Grades 3-8',
+    description: 'Spot hidden reasoning gaps before they become repeated mistakes.',
+    href: '/downloads/ThinkingGap_Playbook_for_parents.pdf',
+  },
+  {
+    id: 'math-weekly-plan',
+    subject: 'math',
+    title: 'Weekly Math Training Plan',
+    grade: 'Grades 3-8',
+    description: 'A focused routine for skill review, accuracy, and mistake correction.',
+  },
+  {
+    id: 'english-weekly-plan',
+    subject: 'english',
+    title: 'Weekly English Training Plan',
+    grade: 'Grades 2-8',
+    description: 'A reading and writing rhythm for comprehension, vocabulary, and response.',
+  },
+  {
+    id: 'paragraph-planner',
+    subject: 'english',
+    title: 'Paragraph Writing Planner',
+    grade: 'Grades 3-8',
+    description: 'Structure topic sentences, evidence, explanation, and revision checks.',
+  },
+]
+
+const focusOptions: Record<Subject, string[]> = {
+  math: ['Math facts and accuracy', 'Fractions', 'Word problems', 'Algebra readiness'],
+  english: ['Reading comprehension', 'Vocabulary', 'Paragraph writing', 'Grammar and editing'],
+}
+
+const planTemplates: Record<Subject, Record<Frequency, string[]>> = {
+  math: {
+    '3': ['Monday: Skill refresh', 'Wednesday: Mistake correction', 'Friday: Independent mini quiz'],
+    '5': ['Monday: Skill refresh', 'Tuesday: Accuracy sprint', 'Wednesday: Word problems', 'Thursday: Mistake correction', 'Friday: Independent mini quiz'],
+  },
+  english: {
+    '3': ['Monday: Read and notice', 'Wednesday: Vocabulary and inference', 'Friday: Written response'],
+    '5': ['Monday: Fluency read', 'Tuesday: Vocabulary builder', 'Wednesday: Comprehension check', 'Thursday: Paragraph planner', 'Friday: Revision day'],
+  },
+}
+
+function subjectLabel(subject: Subject) {
+  return subject === 'math' ? 'Math' : 'English'
+}
+
+export function StudyPlansDownloadPage() {
+  const locale = useLocale()
+  const [subject, setSubject] = useState<Subject>('math')
+  const [grade, setGrade] = useState('Grade 5')
+  const [frequency, setFrequency] = useState<Frequency>('3')
+  const [focus, setFocus] = useState(focusOptions.math[0])
+  const [email, setEmail] = useState('')
+  const [created, setCreated] = useState(false)
+  const bookAssessmentHref = publicPath('/book-assessment', locale)
+
+  function selectSubject(nextSubject: Subject) {
+    setSubject(nextSubject)
+    setFocus(focusOptions[nextSubject][0])
+    setCreated(false)
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setCreated(true)
+  }
+
+  const planDays = planTemplates[subject][frequency]
+
+  return (
+    <main className="min-h-screen bg-[#F7FAFC] text-slate-900">
+      <section className="border-b border-slate-200 bg-white py-12 sm:py-16" aria-labelledby="downloads-hero-title">
+        <div className="mx-auto grid max-w-6xl gap-8 px-4 sm:px-6 lg:grid-cols-[1fr_0.9fr] lg:items-center">
+          <div>
+            <p className="inline-flex items-center gap-2 rounded-full bg-orange-50 px-3 py-1 text-xs font-bold uppercase tracking-wide text-[#F16112] ring-1 ring-orange-100">
+              <BookOpenCheck className="size-4" aria-hidden="true" />
+              Parent achievement platform
+            </p>
+            <h1 id="downloads-hero-title" className="font-heading mt-5 text-3xl font-bold leading-tight text-[#1F396D] sm:text-5xl">
+              Own your child&apos;s next practice move
+            </h1>
+            <p className="mt-5 max-w-2xl text-base leading-relaxed text-slate-700 sm:text-lg">
+              A parent command center for Math and English practice: choose the skill, set the rhythm, and know exactly what your child should complete next.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button asChild className="min-h-[48px] rounded-lg bg-[#F16112] px-6 text-white hover:bg-[#d54f0a]">
+                <a href="#plan-builder">
+                  Build my child&apos;s achievement plan
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </a>
+              </Button>
+              <Button asChild variant="outline" className="min-h-[48px] rounded-lg border-[#1F396D]/25 px-6 text-[#1F396D]">
+                <a href="#practice-assets">
+                  View practice assets
+                  <Download className="size-4" aria-hidden="true" />
+                </a>
+              </Button>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-5 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-wide text-[#F16112]">This week&apos;s command board</p>
+            <h2 className="font-heading mt-2 text-xl font-bold text-[#1F396D]">{grade} {subjectLabel(subject)} plan</h2>
+            <div className="mt-5 grid gap-3">
+              {planDays.slice(0, 3).map((item) => (
+                <div key={item} className="rounded-lg border border-slate-200 bg-white p-4">
+                  <p className="font-semibold text-[#1F396D]">{item}</p>
+                  <p className="mt-1 text-sm text-slate-600">{focus}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-[#F7FAFC] py-10" aria-labelledby="parent-mission-title">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">Choose the parent mission</p>
+          <h2 id="parent-mission-title" className="font-heading mt-2 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+            Built for parents who want control, not confusion
+          </h2>
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            {[
+              ['No more guessing', 'Turn uncertainty into a weekly training routine.'],
+              ['One command center', 'Keep Math and English practice together.'],
+              ['Clear next step', 'Use the plan, then book a readiness assessment for deeper placement.'],
+            ].map(([title, text]) => (
+              <div key={title} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+                <Target className="size-6 text-[#F16112]" aria-hidden="true" />
+                <h3 className="mt-4 font-bold text-[#1F396D]">{title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-600">{text}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="practice-assets" className="bg-white py-12 sm:py-16" aria-labelledby="assets-title">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">Practice library</p>
+              <h2 id="assets-title" className="font-heading mt-2 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+                Your Math and English achievement shelves
+              </h2>
+            </div>
+            <div className="flex rounded-xl bg-slate-100 p-1" aria-label="Choose subject">
+              {(['math', 'english'] as const).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  onClick={() => selectSubject(item)}
+                  className={cn('rounded-lg px-4 py-2 text-sm font-semibold transition', subject === item ? 'bg-white text-[#1F396D] shadow-sm' : 'text-slate-600')}
+                >
+                  {subjectLabel(item)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-8 grid gap-5 md:grid-cols-2">
+            {downloads.map((item) => (
+              <article key={item.id} className="rounded-xl border border-slate-200 bg-slate-50 p-5 shadow-sm">
+                <div className="flex items-start justify-between gap-3">
+                  <span className="rounded-full bg-[#1F396D]/10 px-3 py-1 text-xs font-bold text-[#1F396D]">{item.grade}</span>
+                  <FileText className="size-5 text-[#F16112]" aria-hidden="true" />
+                </div>
+                <h3 className="mt-4 text-lg font-bold text-[#1F396D]">{item.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-600">{item.description}</p>
+                {item.href ? (
+                  <Button asChild className="mt-5 min-h-[44px] rounded-lg bg-[#F16112] text-white hover:bg-[#d54f0a]">
+                    <a href={item.href} download>
+                      Download PDF
+                      <Download className="size-4" aria-hidden="true" />
+                    </a>
+                  </Button>
+                ) : (
+                  <p className="mt-5 rounded-lg border border-dashed border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-600">
+                    Included in upcoming worksheet pack
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="plan-builder" className="border-y border-slate-200 bg-slate-50 py-12 sm:py-16" aria-labelledby="builder-title">
+        <div className="mx-auto grid max-w-6xl gap-8 px-4 sm:px-6 lg:grid-cols-2">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">My child&apos;s weekly training rhythm</p>
+            <h2 id="builder-title" className="font-heading mt-2 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+              Build a 4-week {subjectLabel(subject).toLowerCase()} plan your family can execute
+            </h2>
+            <form onSubmit={handleSubmit} className="mt-6 grid gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                Parent email
+                <span className="relative">
+                  <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    required
+                    placeholder="parent@example.com"
+                    className="min-h-[46px] w-full rounded-lg border border-slate-300 pl-10 pr-3 outline-none focus:border-[#F16112] focus:ring-2 focus:ring-[#F16112]/20"
+                  />
+                </span>
+              </label>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                  Grade
+                  <select value={grade} onChange={(event) => setGrade(event.target.value)} className="min-h-[46px] rounded-lg border border-slate-300 px-3">
+                    {['Grade 1', 'Grade 2', 'Grade 3', 'Grade 4', 'Grade 5', 'Grade 6', 'Grade 7', 'Grade 8', 'High School'].map((item) => (
+                      <option key={item}>{item}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                  Practice rhythm
+                  <select value={frequency} onChange={(event) => setFrequency(event.target.value as Frequency)} className="min-h-[46px] rounded-lg border border-slate-300 px-3">
+                    <option value="3">3 days per week</option>
+                    <option value="5">5 days per week</option>
+                  </select>
+                </label>
+              </div>
+              <label className="grid gap-2 text-sm font-semibold text-slate-700">
+                Focus skill
+                <select value={focus} onChange={(event) => setFocus(event.target.value)} className="min-h-[46px] rounded-lg border border-slate-300 px-3">
+                  {focusOptions[subject].map((item) => (
+                    <option key={item}>{item}</option>
+                  ))}
+                </select>
+              </label>
+              <Button type="submit" className="min-h-[48px] rounded-lg bg-[#1F396D] text-white hover:bg-[#17305d]">
+                Create my training plan
+                <ArrowRight className="size-4" aria-hidden="true" />
+              </Button>
+            </form>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-bold uppercase tracking-wide text-[#F16112]">Parent view</p>
+                <h3 className="font-heading mt-2 text-xl font-bold text-[#1F396D]">{grade} {subjectLabel(subject)}: {focus}</h3>
+              </div>
+              <CalendarDays className="size-7 text-[#F16112]" aria-hidden="true" />
+            </div>
+            <div className="mt-6 grid gap-3">
+              {planDays.map((item) => (
+                <div key={item} className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                  <p className="font-semibold text-[#1F396D]">{item}</p>
+                  <p className="mt-1 text-sm text-slate-600">Short, focused practice with a clear finish line.</p>
+                </div>
+              ))}
+            </div>
+            {created ? (
+              <div className="mt-6 rounded-lg bg-[#1F396D] p-4 text-white">
+                <p className="font-semibold">Plan created for {email}</p>
+                <Button type="button" onClick={() => window.print()} className="mt-4 min-h-[44px] rounded-lg bg-white text-[#1F396D] hover:bg-slate-100">
+                  Print or save plan
+                  <Printer className="size-4" aria-hidden="true" />
+                </Button>
+              </div>
+            ) : (
+              <p className="mt-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+                Fill out the form to personalize the weekly plan.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white py-12 sm:py-16" aria-labelledby="assessment-cta-title">
+        <div className="mx-auto max-w-4xl px-4 text-center sm:px-6">
+          <CheckCircle2 className="mx-auto size-9 text-[#F16112]" aria-hidden="true" />
+          <h2 id="assessment-cta-title" className="font-heading mt-4 text-2xl font-bold text-[#1F396D] sm:text-3xl">
+            Want GrowWise to identify the exact gap?
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-slate-700 sm:text-base">
+            Use this page as your parent workspace. When you want placement insight, book a GrowWise readiness assessment.
+          </p>
+          <Button asChild className="mt-7 min-h-[48px] rounded-lg bg-[#F16112] px-6 text-white hover:bg-[#d54f0a]">
+            <Link href={bookAssessmentHref}>
+              Book Readiness Assessment
+              <ArrowRight className="size-4" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/data/resources-hub.ts
+++ b/src/data/resources-hub.ts
@@ -45,6 +45,16 @@ export function resourceCategoryTagClass(category: ResourceCategory): string {
 
 export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
   {
+    id: 'study-plans-downloads',
+    category: 'parent-resources',
+    categoryLabel: 'PARENT RESOURCES',
+    title: 'Free Math & English Study Plans',
+    description:
+      'Download starter resources and create a simple 4-week practice plan for Math or English without a login.',
+    readTime: 'Interactive',
+    href: '/resources/downloads',
+  },
+  {
     id: 'math-reading-readiness-checklist',
     category: 'parent-resources',
     categoryLabel: 'PARENT RESOURCES',
@@ -63,6 +73,46 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
       'Interactive assessment to help your child discover their learning style and identify knowledge gaps quickly.',
     readTime: 'Interactive',
     href: '/self-check',
+  },
+  {
+    id: 'back-to-school-math-assessment-dublin-ca',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: 'Back-to-School Math Assessment Guide for Dublin, CA Families',
+    description:
+      'Before August, check the math skills your child needs for the next grade, from fractions and ratios to Algebra, Geometry, and IM1.',
+    readTime: '6 min read',
+    href: '/resources/back-to-school-math-assessment-dublin-ca',
+  },
+  {
+    id: 'english-tutor-vs-reading-tutor-vs-writing-class',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: 'English Tutor, Reading Tutor, or Writing Class: Which Does Your Child Need?',
+    description:
+      'Compare English tutoring, reading tutoring, and writing classes so you can choose the right support before the school-year rush.',
+    readTime: '6 min read',
+    href: '/resources/english-tutor-vs-reading-tutor-vs-writing-class',
+  },
+  {
+    id: 'math-tutoring-options-dublin-ca',
+    category: 'local',
+    categoryLabel: 'LOCAL',
+    title: 'Kumon vs. Mathnasium vs. Private Tutor: How Dublin Parents Should Compare Math Options',
+    description:
+      'A practical comparison framework for Dublin families choosing back-to-school math support.',
+    readTime: '7 min read',
+    href: '/resources/math-tutoring-options-dublin-ca',
+  },
+  {
+    id: 'middle-school-math-readiness-checklist',
+    category: 'academic',
+    categoryLabel: 'ACADEMIC',
+    title: 'Middle School Math Readiness Checklist for Grades 6-8',
+    description:
+      'A practical August checklist for fractions, ratios, equations, graphing, word problems, and IM1 readiness.',
+    readTime: '6 min read',
+    href: '/resources/middle-school-math-readiness-checklist',
   },
   {
     id: 'reading-fluency-vs-comprehension',
@@ -260,7 +310,7 @@ export const RESOURCE_GUIDES: readonly ResourceGuide[] = [
     id: 'child-struggles-with-writing-dublin-ca',
     category: 'academic',
     categoryLabel: 'ACADEMIC',
-    title: 'Does Your Child Have a Writing Problem — or a Confidence Problem?',
+    title: 'Why Your Child Struggles With Writing: Skill Gap or Confidence Gap?',
     description:
       'Blank-page freeze, short answers, and writing avoidance can signal skill gaps, confidence gaps, or both.',
     readTime: '6 min read',

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -30,9 +30,9 @@ export const MATH_FINALS_PRACTICE_SESSION_DESCRIPTION =
 export const metadataConfig: Record<string, PageMetadataConfig> = {
   // Home page
   '/': {
-    title: 'K-12 Online Tutoring & Coding Classes | GrowWise',
+    title: 'K-12 Tutoring, Coding & SAT Prep Dublin CA | GrowWise',
     description:
-      'GrowWise helps Grades 1-12 students build confidence with math, English, coding, STEAM, and SAT prep online or in Dublin, CA. Book a free assessment.',
+      'Dublin, CA tutoring for Grades 1-12: math, English, coding, STEAM, SAT prep, and summer programs. Book a free assessment.',
     keywords:
       'tutoring Dublin CA, Grades 1-12 education, STEAM programs, math tutor, English tutor, coding classes, SAT prep Dublin, personalized learning',
     path: '',
@@ -66,6 +66,15 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
       'GrowWise newsletter, parent education tips, K-12 tutoring updates, Dublin tutoring newsletter, student learning insights',
     path: '/bulletin',
     image: '/og-image.jpg',
+  },
+
+  '/resources/downloads': {
+    title: 'Free Math & English Study Plans | GrowWise',
+    description:
+      'Download starter resources and create a free 4-week Math or English practice plan for your child. No login required.',
+    keywords:
+      'free study plan, math practice sheets, English practice sheets, printable worksheets, 4-week study plan, GrowWise resources',
+    path: '/resources/downloads',
   },
 
   '/dublin-ca': {
@@ -106,63 +115,63 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/academic/math': {
-    title: 'Math Tutoring Programs Online — Grades 1–12 | GrowWise',
+    title: 'Math Tutoring Dublin CA | Grades 1-12',
     description:
-      'Structured math programs for Grades 1–12. Live online small groups. Elementary, middle school, and high school tracks. Book a free assessment.',
+      'Back-to-school math tutoring in Dublin, CA for Grades 1-12. Elementary, middle school, high school, and advanced math. Free assessment.',
     keywords:
-      'math tutoring online, online math program grades 1-12, elementary math tutoring, middle school math help, IM1 tutoring, high school math tutoring, AP calculus tutoring online, math small group online, 3-month math program, math tutoring small group',
+      'math tutoring Dublin CA, math tutor near me, back to school math tutoring, elementary math tutoring, middle school math tutoring, high school math tutoring, IM1 tutoring, Algebra 1 tutor, Algebra 2 tutor, geometry tutoring, Pleasanton math tutor, San Ramon math tutor, Tri-Valley math tutoring, math small group tutoring, math assessment',
     path: '/academic/math',
   },
 
   '/academic/math/elementary': {
-    title: 'Elementary Math Tutoring Online — Grades 1–5 | GrowWise',
+    title: 'Elementary Math Tutoring Dublin CA | Grades 1-5',
     description:
-      'Structured math programs for Grades 1–5. Number sense, fractions, word problem reasoning. Live online small groups. Diagnostic-first. 3-month programs.',
+      'Elementary math tutoring in Dublin, CA for Grades 1-5. Number sense, fractions, word problems, and August readiness assessment.',
     keywords:
-      'elementary math tutoring online, grade 1-5 math help, fractions tutoring grade 4, math word problem help elementary, grade 3 math struggles, place value tutoring, elementary math small group online, math program grades 1 5',
+      'elementary math tutoring Dublin CA, elementary math tutor near me, grade 1-5 math help, fractions tutoring grade 4, math word problem help elementary, common core math help, place value tutoring, August math readiness',
     path: '/academic/math/elementary',
   },
 
   '/academic/math/middle-school': {
-    title: 'Middle School Math Tutoring — IM1, IM2 | GrowWise',
+    title: 'Middle School Math Tutoring Dublin CA | IM1 Prep',
     description: buildMiddleSchoolMetaDescription(),
     keywords:
-      'middle school math tutoring online, IM1 tutoring, IM2 tutoring, pre-algebra tutoring online, integrated math 1 tutoring, grades 6-8 math program, standard track math, accelerated math tutoring',
+      'middle school math tutoring Dublin CA, IM1 tutoring, IM2 tutoring, pre-algebra tutoring, integrated math 1 tutoring, grades 6-8 math program, accelerated math readiness, 7th grade math help, August math assessment',
     path: '/academic/math/middle-school',
   },
 
   '/academic/english': {
-    title: 'English Tutoring Programs Grades 1-8 | Dublin CA | GrowWise',
+    title: 'English Tutoring Dublin CA | Reading & Writing',
     description:
-      'English tutoring for Grades 1-8 in Dublin, CA and online. Reading comprehension, writing, grammar, vocabulary, and essays in small groups.',
+      'Back-to-school English tutoring in Dublin, CA for Grades 1-8. Reading comprehension, writing, grammar, vocabulary, and essays.',
     keywords:
-      'English tutoring Dublin CA, English tutor Dublin, reading comprehension tutoring, essay writing help, grammar tutoring, vocabulary development, English Language Arts, ELA tutoring, writing tutor, reading tutor, English classes Dublin CA, English help Dublin, English tutoring near me, Grades 1-8 English programs',
+      'English tutoring Dublin CA, English tutor near me, reading tutor near me, writing tutor near me, back to school English tutoring, reading comprehension tutoring, essay writing help, grammar tutoring, vocabulary development, English Language Arts, ELA tutoring, English classes Dublin CA, Pleasanton English tutor, San Ramon English tutor, Tri-Valley reading and writing tutoring, Grades 1-8 English programs',
     path: '/academic/english',
   },
 
   '/academic/english/elementary': {
-    title: 'Elementary English Tutoring Online — Grades 1–5 | GrowWise',
+    title: 'Elementary English Tutoring Dublin CA | Grades 1-5',
     description:
-      'English for Grades 1-5: reading fluency, vocabulary, grammar, and writing in live small groups. Diagnostic-first, online or in Dublin, CA.',
+      'Elementary English tutoring in Dublin, CA for Grades 1-5. Reading fluency, comprehension, grammar, writing, and August readiness.',
     keywords:
-      'elementary English tutoring online, reading below grade level grades 1-5, my child hates writing, child reads but does not understand, California Common Core ELA, English tutoring Dublin CA, Pleasanton San Ramon Tri-Valley',
+      'elementary English tutoring Dublin CA, English tutor near me, reading tutor near me, writing tutor near me, reading below grade level grades 1-5, child reads but does not understand, grammar tutoring, English writing classes near me',
     path: '/academic/english/elementary',
   },
 
   '/courses/sat-prep': {
-    title: 'SAT Prep Tutoring in Dublin, CA | GrowWise',
+    title: 'SAT Prep Dublin CA | Classes & Tutoring | GrowWise',
     description:
-      'SAT prep in Dublin, CA with practice tests, proven strategies, and expert tutors. Small groups. Book a free assessment today.',
+      'SAT prep in Dublin, CA with small groups, practice tests, math and reading/writing strategy, and expert tutors. Book a free assessment.',
     keywords:
       'SAT prep Dublin CA, SAT preparation, SAT course, SAT tutoring Dublin, SAT test prep, SAT strategies, SAT practice tests, SAT classes Dublin CA, SAT help, SAT tutor near me, SAT prep course, SAT score improvement, college entrance exam prep',
     path: '/courses/sat-prep',
   },
 
   '/academic/math/high-school': {
-    title: 'High School Math Tutoring Dublin CA | GrowWise',
+    title: 'High School Math Tutoring Dublin CA | Algebra & Geometry',
     description: buildHighSchoolMetaDescription(),
     keywords:
-      'high school math tutoring Dublin CA, algebra tutoring, algebra 1, algebra 2, geometry tutoring, pre-calculus, AP precalculus, integrated math, integrated math 1, integrated math 2, DUSD accelerated math placement, high school math courses Dublin CA, advanced math tutoring, high school math tutoring online, AP calculus tutoring, algebra 2 tutoring, SAT math prep online, grades 9-12 math program',
+      'high school math tutoring Dublin CA, algebra tutor near me, algebra 1 tutoring, algebra 2 tutor near me, geometry tutor Dublin CA, geometry classes near me, pre-calculus tutoring, integrated math 3 tutoring, DUSD accelerated math placement, August math readiness, grades 9-12 math program',
     path: '/academic/math/high-school',
   },
 
@@ -395,27 +404,27 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/camps/winter': {
-    title: 'Winter Camp 2025 | Dublin CA | GrowWise',
+    title: 'Winter Camps in Dublin, CA | GrowWise',
     description:
-      'GrowWise Winter Camp: academic and STEAM workshops during winter break in Dublin, CA. Coding, math, and writing for grades 1–12. Reserve your week.',
+      'GrowWise winter camp dates are not yet published. Explore current academic and STEAM camps in Dublin, CA or join the bulletin for updates.',
     keywords:
-      'winter camp 2025, winter break programs, academic winter camp, STEAM winter camp, winter tutoring Dublin CA, December camp, kids spring break camps Dublin California',
+      'winter camp Dublin CA, winter break programs, academic winter camp, STEAM winter camp, winter tutoring Dublin CA',
     path: '/camps/winter',
   },
 
   '/camps/winter/calendar': {
-    title: 'Winter Camp Schedule 2025 | GrowWise',
+    title: 'Winter Camp Schedule | Dublin, CA | GrowWise',
     description:
-      'Winter camp workshop schedule in Dublin, CA. View all dates, times, and weekly themes for coding, math, and STEAM. Reserve your spot early.',
+      'GrowWise winter camp dates are not yet published. Explore current Dublin camp programs and subscribe for future schedule updates.',
     keywords:
       'winter camp schedule, winter camp calendar, workshop schedule, December camp schedule, winter break activities',
     path: '/camps/winter/calendar',
   },
 
   '/camps/summer': {
-    title: 'Math, Robotics, Coding & AI Camps Dublin CA | GrowWise',
+    title: 'Summer Camps Dublin CA | Math, Robotics, Coding & AI',
     description:
-      'Summer camps in Dublin, CA for Grades 1–12: Math, Robotics, Coding, AI, game development, and writing. Weekly June–August 2026. Reserve a spot.',
+      '2026 summer camps in Dublin, CA for Grades 1-12: math, robotics, coding, AI, game development, and writing. Reserve a weekly spot.',
     keywords:
       'summer camp Dublin CA, summer camps Dublin CA 2026, STEAM summer camp Dublin, coding summer camp Dublin CA, math summer camp Dublin CA, summer camp Tri-Valley, summer programs for kids Dublin CA, summer coding camp Dublin CA, summer STEAM camp Dublin CA 2026, coding camp kids Tri-Valley, summer math camp Dublin CA, AI camp for kids Dublin CA, robotics camp kids Dublin CA, game development camp kids, young authors camp summer 2026, summer camp 2026 Dublin CA, STEM camp Pleasanton, STEM camp San Ramon',
     path: '/camps/summer',
@@ -559,9 +568,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/tutoring-dublin-ca': {
-    title: 'K-12 Tutoring in Dublin CA | 2026 Parent Guide',
+    title: 'Tutoring Dublin CA | Best K-12 Options for 2026',
     description:
-      'Dublin, CA tutoring guide for Grades 1-12. Compare program types, diagnostic depth, class size, and what Tri-Valley parents should ask before enrolling.',
+      'Compare Dublin, CA tutoring options for Grades 1-12: class size, diagnostics, math, English, SAT prep, and questions to ask before enrolling.',
     keywords:
       'tutoring Dublin CA, tutoring Dublin California, K-12 tutoring Dublin California, math tutoring Dublin CA, tutoring near me Dublin CA, after school tutoring Dublin CA Tri-Valley, tutoring Pleasanton CA, tutoring San Ramon CA, coding classes Dublin CA kids, SAT prep Dublin CA, academic programs Tri-Valley',
     path: '/resources/tutoring-dublin-ca',
@@ -659,12 +668,52 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/child-struggles-with-writing-dublin-ca': {
-    title: 'Child Struggles With Writing | Dublin CA Parent Guide',
+    title: 'Why Your Child Struggles With Writing | Dublin CA',
     description:
-      'Blank-page freeze, short answers, and writing avoidance can signal skill gaps, confidence gaps, or both. Learn what helps students move forward.',
+      'Blank-page freeze, short answers, weak paragraphs, and writing avoidance can signal skill gaps, confidence gaps, or both.',
     keywords:
-      'child struggles with writing, writing help Dublin CA, child avoids writing, blank page freeze writing, writing confidence kids, summer writing program Dublin CA',
+      'child struggles with writing, writing tutor near me, middle school writing tutor, writing help Dublin CA, English writing classes near me, child avoids writing, blank page freeze writing, writing confidence kids',
     path: '/resources/child-struggles-with-writing-dublin-ca',
+    type: 'article',
+  },
+
+  '/resources/back-to-school-math-assessment-dublin-ca': {
+    title: 'Back-to-School Math Assessment Dublin CA | GrowWise',
+    description:
+      'Before August, check math readiness for fractions, ratios, algebra, geometry, and IM1 so your child starts the school year with fewer gaps.',
+    keywords:
+      'math tutor near me, math tutoring Dublin CA, back to school math assessment, middle school math tutoring, elementary math tutoring Dublin, algebra tutor near me, geometry tutor Dublin CA, integrated math tutoring',
+    path: '/resources/back-to-school-math-assessment-dublin-ca',
+    type: 'article',
+  },
+
+  '/resources/english-tutor-vs-reading-tutor-vs-writing-class': {
+    title: 'English Tutor vs Reading Tutor vs Writing Class',
+    description:
+      'Compare English tutoring, reading tutoring, and writing classes so parents can choose the right support before the August school-year rush.',
+    keywords:
+      'english tutor near me, English tutoring Dublin CA, reading tutor near me, reading tutoring near me, writing tutor Dublin CA, english writing classes near me, reading and writing classes near me',
+    path: '/resources/english-tutor-vs-reading-tutor-vs-writing-class',
+    type: 'article',
+  },
+
+  '/resources/math-tutoring-options-dublin-ca': {
+    title: 'Kumon vs Mathnasium vs Tutor Dublin CA Guide',
+    description:
+      'Compare worksheet practice, math centers, private tutors, and diagnostic-first math tutoring before choosing back-to-school support in Dublin, CA.',
+    keywords:
+      'Kumon Dublin CA, Mathnasium Dublin CA, Russian Math Dublin CA, Tutoring Club Dublin, private math tutor Dublin CA, best math tutoring Dublin CA, math tutoring near me, math tutor near me',
+    path: '/resources/math-tutoring-options-dublin-ca',
+    type: 'article',
+  },
+
+  '/resources/middle-school-math-readiness-checklist': {
+    title: 'Middle School Math Readiness Checklist | Grades 6-8',
+    description:
+      'Use this Grades 6-8 math readiness checklist before August to check fractions, ratios, equations, word problems, graphing, and IM1 prep.',
+    keywords:
+      'middle school math readiness checklist, middle school math tutoring, 6th grade math help, 7th grade math help, 8th grade math help, IM1 readiness, integrated math 1 prep, math tutoring Dublin CA',
+    path: '/resources/middle-school-math-readiness-checklist',
     type: 'article',
   },
 
@@ -689,9 +738,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/python-vs-scratch': {
-    title: 'Python vs Scratch for Kids | Parent Guide | GrowWise',
+    title: 'Python vs Scratch for Kids | Which to Learn First?',
     description:
-      'Scratch or Python? Use this age-by-age parent guide to know when to start, when to switch, and why many kids benefit from learning both in order.',
+      'Scratch or Python first? Compare starting age, when to switch, what each language teaches, and how kids move toward real coding.',
     keywords:
       'Python vs Scratch for kids, should kids learn Scratch or Python first, when to switch from Scratch to Python, best coding language for kids, Scratch for kids ages 6-10, Python for kids ages 10-14',
     path: '/resources/python-vs-scratch',
@@ -699,9 +748,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/reading-fluency-vs-comprehension': {
-    title: 'Fluency vs Comprehension: Reading Gaps | GrowWise',
+    title: 'Reading Fluency vs Comprehension | Parent Guide',
     description:
-      'Your child can decode every word but still not understand what they read. Learn how to tell fluency from comprehension gaps—and why support matters.',
+      'Compare reading fluency vs comprehension gaps, warning signs, and what support should target when a child reads words but misses meaning.',
     keywords:
       'reading fluency vs comprehension, reading fluency comprehension difference, child reads but doesn\'t understand, reading program, reading comprehension gap, reading fluency gap, child struggles with reading comprehension',
     path: '/resources/reading-fluency-vs-comprehension',
@@ -728,9 +777,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/careless-math-mistakes': {
-    title: 'Why Kids Make Careless Math Mistakes on Tests | GrowWise',
+    title: 'Careless Math Mistakes | Why Kids Lose Points',
     description:
-      'Careless math mistakes follow specific patterns. Learn how to spot the real blocker, fix the habit, and help your child stop losing points on tests.',
+      'Learn why kids make careless math mistakes, the common patterns behind lost points, and how to fix them before the next test.',
     keywords:
       'careless mistakes in math, why kids lose points on math tests, child makes careless math mistakes, how to stop careless mistakes in math, child understands math but gets wrong answers, math mistake patterns, procedural errors in math',
     path: '/resources/careless-math-mistakes',
@@ -738,9 +787,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/what-is-vibe-coding': {
-    title: "What Is Vibe Coding? A Parent's Guide (2026) | GrowWise",
+    title: 'What Is Vibe Coding? Parent Guide for Kids',
     description:
-      'Vibe coding helps kids build apps with AI, but fundamentals still matter. Learn the benefits, risks, right age, and what programs should teach.',
+      'Vibe coding lets kids build with AI, but fundamentals still matter. Learn the right age, benefits, risks, and what programs should teach.',
     keywords:
       'what is vibe coding, vibe coding for kids, vibe coding explained for parents, should kids learn vibe coding, vibe coding 2026, AI coding for kids, coding for kids 2026, AI-assisted coding children',
     path: '/resources/what-is-vibe-coding',
@@ -758,9 +807,9 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   },
 
   '/resources/when-to-start-sat-prep': {
-    title: 'When Should My Child Start SAT Prep? | GrowWise',
+    title: 'When to Start SAT Prep | Timeline by Grade',
     description:
-      'Grade 8, 9, or 10? Learn when SAT prep should start, why foundations come first, and how to build the right grade-by-grade test prep timeline.',
+      'See when SAT prep should start in grades 8, 9, 10, or 11, what to fix first, and how parents can plan a smarter prep timeline.',
     keywords:
       'when to start SAT prep, what grade to start SAT preparation, when should my child start SAT prep, SAT prep grade 8 9 10, how early to start SAT prep, digital SAT prep 2026, SAT preparation timeline high school, PSAT preparation grades 8-10, SAT math foundation gaps',
     path: '/resources/when-to-start-sat-prep',

--- a/src/lib/seo/sitemapData.ts
+++ b/src/lib/seo/sitemapData.ts
@@ -6,7 +6,7 @@
  * tracking per content type:
  *   - `/sitemap-pages.xml`  — core site (home, academic, courses, STEAM, camps)
  *   - `/sitemap-blogs.xml`  — blog posts + resource guide articles
- * Index at `/sitemap.xml` references both (`src/app/sitemap-index.xml/route.ts` + rewrite).
+ * Index at `/sitemap.xml` references both (`src/app/sitemap.xml/route.ts`).
  */
 
 import { RESOURCE_ARTICLE_PATHS } from '@/data/resources'
@@ -36,7 +36,7 @@ export interface SitemapEntry {
 
 export interface SitemapUrl {
   loc: string
-  lastmod: string
+  lastmod?: string
   changefreq: ChangeFreq
   priority: number
 }
@@ -60,6 +60,7 @@ const corePages: SitemapEntry[] = [
   { path: '/programs', priority: 0.8, changefreq: 'monthly' },
   { path: '/growwise-blogs', priority: 0.85, changefreq: 'weekly' },
   { path: '/resources', priority: 0.85, changefreq: 'weekly' },
+  { path: '/resources/downloads', priority: 0.85, changefreq: 'weekly' },
 ]
 
 const coursePages: SitemapEntry[] = [
@@ -108,8 +109,6 @@ const campPages: SitemapEntry[] = [
   { path: '/camps/summer-im-get-ready-dublin-ca', priority: 0.9, changefreq: 'weekly' },
   { path: '/camps/summer-im1-get-ready-dublin-ca', priority: 0.9, changefreq: 'weekly' },
   { path: '/camps/summer-im2-get-ready-dublin-ca', priority: 0.9, changefreq: 'weekly' },
-  { path: '/camps/winter', priority: 0.7, changefreq: 'weekly' },
-  { path: '/camps/winter/calendar', priority: 0.6, changefreq: 'weekly' },
 ]
 
 /** SEO camp hub + landings — single Dublin campus, default-locale only. */
@@ -121,6 +120,9 @@ const campLandingHub: SitemapEntry = {
 
 /** Blog post paths (same slugs as under `src/app/[locale]/growwise-blogs/`). */
 const blogPostPaths = [
+  '/growwise-blogs/child-reads-but-doesnt-understand-passage',
+  '/growwise-blogs/why-is-my-child-struggling-with-fractions',
+  '/growwise-blogs/common-core-math-strategies-parents',
   '/growwise-blogs/can-chatgpt-replace-a-tutor-ai-homework-help',
   '/growwise-blogs/does-my-child-need-reading-help-checklist',
   '/growwise-blogs/your-child-got-a-b-plus-doesnt-mean-they-understand-the-math',
@@ -160,7 +162,7 @@ function renderUrl(u: SitemapUrl): string {
   return [
     '  <url>',
     `    <loc>${escapeXml(u.loc)}</loc>`,
-    `    <lastmod>${u.lastmod}</lastmod>`,
+    ...(u.lastmod ? [`    <lastmod>${u.lastmod}</lastmod>`] : []),
     `    <changefreq>${u.changefreq}</changefreq>`,
     `    <priority>${u.priority.toFixed(2)}</priority>`,
     '  </url>',
@@ -177,14 +179,14 @@ ${body}
 }
 
 export function renderSitemapIndex(
-  entries: Array<{ loc: string; lastmod: string }>,
+  entries: Array<{ loc: string; lastmod?: string }>,
 ): string {
   const body = entries
     .map(
-      (e) =>
-        `  <sitemap>\n    <loc>${escapeXml(e.loc)}</loc>\n    <lastmod>${
-          e.lastmod
-        }</lastmod>\n  </sitemap>`,
+      (e) => {
+        const lastmod = e.lastmod ? `\n    <lastmod>${e.lastmod}</lastmod>` : ''
+        return `  <sitemap>\n    <loc>${escapeXml(e.loc)}</loc>${lastmod}\n  </sitemap>`
+      },
     )
     .join('\n')
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -195,7 +197,7 @@ ${body}
 }
 
 /** Build all non-blog page URLs across enabled locales. */
-export function buildPagesUrls(baseUrl: string, lastmod: string): SitemapUrl[] {
+export function buildPagesUrls(baseUrl: string, fallbackLastmod?: string): SitemapUrl[] {
   const urls: SitemapUrl[] = []
   const localeRoutes = [...corePages, ...coursePages, ...steamPages, ...futureSkillsPages, ...campPages, ...legalPages]
 
@@ -203,7 +205,7 @@ export function buildPagesUrls(baseUrl: string, lastmod: string): SitemapUrl[] {
     localeRoutes.forEach((page) => {
       urls.push({
         loc: absoluteSiteUrl(page.path, locale, baseUrl),
-        lastmod: page.lastmod ?? lastmod,
+        lastmod: page.lastmod ?? fallbackLastmod,
         changefreq: page.changefreq,
         priority: page.priority,
       })
@@ -212,14 +214,14 @@ export function buildPagesUrls(baseUrl: string, lastmod: string): SitemapUrl[] {
     if (locale === DEFAULT_LOCALE) {
       urls.push({
         loc: absoluteSiteUrl(campLandingHub.path, locale, baseUrl),
-        lastmod: campLandingHub.lastmod ?? lastmod,
+        lastmod: campLandingHub.lastmod ?? fallbackLastmod,
         changefreq: campLandingHub.changefreq,
         priority: campLandingHub.priority,
       })
       getCampSlugs().forEach((slug) => {
         urls.push({
           loc: absoluteSiteUrl(`/camps/${slug}`, locale, baseUrl),
-          lastmod,
+          lastmod: fallbackLastmod,
           changefreq: 'weekly',
           priority: 0.9,
         })
@@ -252,13 +254,13 @@ export function buildPagesPaths(): string[] {
 }
 
 /** Build blog post and resource guide URLs across enabled locales. */
-export function buildBlogUrls(baseUrl: string, lastmod: string): SitemapUrl[] {
+export function buildBlogUrls(baseUrl: string, fallbackLastmod?: string): SitemapUrl[] {
   const urls: SitemapUrl[] = []
   locales.forEach((locale) => {
     blogPostPaths.forEach((path) => {
       urls.push({
         loc: absoluteSiteUrl(path, locale, baseUrl),
-        lastmod,
+        lastmod: fallbackLastmod,
         changefreq: 'monthly',
         priority: 0.75,
       })
@@ -266,7 +268,7 @@ export function buildBlogUrls(baseUrl: string, lastmod: string): SitemapUrl[] {
     RESOURCE_ARTICLE_PATHS.forEach((path) => {
       urls.push({
         loc: absoluteSiteUrl(path, locale, baseUrl),
-        lastmod,
+        lastmod: fallbackLastmod,
         changefreq: 'monthly',
         priority:
           path === '/resources/tutoring-dublin-ca' || path === '/resources/summer-slide-dublin-ca' ? 0.85 : 0.8,
@@ -291,7 +293,7 @@ export function buildBlogPaths(): string[] {
 }
 
 /** Child sitemap descriptors listed in the sitemap index. */
-export function getChildSitemaps(baseUrl: string, lastmod: string) {
+export function getChildSitemaps(baseUrl: string, lastmod?: string) {
   return [
     { loc: `${baseUrl}/sitemap-pages.xml`, lastmod },
     { loc: `${baseUrl}/sitemap-blogs.xml`, lastmod },

--- a/src/lib/testimonialsApi.ts
+++ b/src/lib/testimonialsApi.ts
@@ -91,6 +91,10 @@ class TestimonialsApiService {
     minRating?: number;
   } = {}): Promise<TestimonialsResponse> {
     const { limit, offset = 0, forceRefresh = false, minRating = 1 } = options;
+
+    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+      return this.getDefaultTestimonials(limit || null, offset, minRating);
+    }
     
     const params = new URLSearchParams({
       offset: offset.toString(),


### PR DESCRIPTION
## Summary
- Add a premium parent-facing Math and English practice/downloads page with plan builder and assessment CTA
- Add the global brand slogan under the logo: Education First Always. / business second.
- Refresh homepage and assessment copy toward readiness, achievement, and premium parent ownership
- Fix the assessment Select runtime error caused by an empty SelectItem value
- Improve local dev stability by avoiding browser testimonial fetches in development and disabling header link prefetch

## Validation
- Focused ESLint passed for touched header/resource/assessment/testimonial files
- Local HTTP checks returned 200 for `/`, `/resources/downloads`, `/book-assessment`, and `/academic`

## Notes
- Full `npm run build` did not complete locally; Next stayed at `Creating optimized production build ...`, which matches the local webpack/build instability we were debugging.