### PR TITLE
Fix SEO crawl health redirects and soft 404s

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,6 +42,7 @@ const nextConfig: NextConfig = {
   // Performance optimizations
   compress: true, // Enable gzip compression
   poweredByHeader: false, // Remove X-Powered-By header for security
+  skipTrailingSlashRedirect: true,
   
   // Image optimization
   images: {

--- a/scripts/seo-full-sitemap-audit.mjs
+++ b/scripts/seo-full-sitemap-audit.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { CANONICAL_ORIGIN, collectSitemapUrls } from './indexnow-lib.mjs'
+import {
+  auditUrl,
+  extractCanonical,
+  extractMeta,
+  extractTitle,
+  extractJsonLdTypes,
+} from './seo-ops-lib.mjs'
+
+const DEFAULT_OUT = 'artifacts/seo/full-sitemap-audit.json'
+const REDIRECT_SOURCE_PATTERNS = [
+  /https:\/\/www\.growwiseschool\.org/i,
+  /https:\/\/growwiseschool\.org\/en(?:\/|$)/i,
+  /^\/en(?:\/|$)/i,
+  /^\/courses\/(?:math|english|high-school-math)(?:\/|[?#]|$)/i,
+  /^\/camps\/academic-summer-sprint-dublin-ca(?:\/|[?#]|$)/i,
+  /^\/detective(?:\/|[?#]|$)/i,
+  /^\/results(?:\/|[?#]|$)/i,
+  /^\/math-courses-in-dublin-ca-growwise(?:\/|[?#]|$)/i,
+]
+
+function parseArgs(argv) {
+  const options = {
+    origin: process.env.SEO_AUDIT_BASE_URL || CANONICAL_ORIGIN,
+    out: DEFAULT_OUT,
+    concurrency: Number(process.env.SEO_AUDIT_CONCURRENCY || 8),
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--base') options.origin = argv[++i]
+    else if (arg === '--out') options.out = argv[++i]
+    else if (arg === '--concurrency') options.concurrency = Number(argv[++i])
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  if (!Number.isInteger(options.concurrency) || options.concurrency < 1) {
+    throw new Error('--concurrency must be a positive integer')
+  }
+  return options
+}
+
+async function checkFirstHop(url, timeoutMs = 15_000) {
+  const response = await fetch(url, {
+    method: 'HEAD',
+    redirect: 'manual',
+    headers: { 'User-Agent': 'GrowWise-Full-Sitemap-Audit/1.0' },
+    signal: AbortSignal.timeout(timeoutMs),
+  })
+  return {
+    status: response.status,
+    location: response.headers.get('location'),
+  }
+}
+
+function getHrefValues(html) {
+  return [...html.matchAll(/<a\b[^>]*\shref=["']([^"']+)["']/gi)].map((m) => m[1])
+}
+
+function isInternalHref(href, origin) {
+  if (!href || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) return false
+  try {
+    const url = new URL(href, origin)
+    return url.hostname === new URL(origin).hostname
+  } catch {
+    return false
+  }
+}
+
+function findRedirectLikeInternalLinks(html, origin) {
+  return [...new Set(
+    getHrefValues(html)
+      .filter((href) => isInternalHref(href, origin))
+      .filter((href) => REDIRECT_SOURCE_PATTERNS.some((pattern) => pattern.test(href))),
+  )].sort()
+}
+
+async function fetchHtml(url, timeoutMs = 15_000) {
+  const response = await fetch(url, {
+    redirect: 'follow',
+    headers: { 'User-Agent': 'GrowWise-Full-Sitemap-Audit/1.0' },
+    signal: AbortSignal.timeout(timeoutMs),
+  })
+  return {
+    status: response.status,
+    html: await response.text(),
+  }
+}
+
+function classifyPageIssues({ url, firstHop, page, html, origin }) {
+  const issues = [...(page.issues || [])]
+  const canonical = extractCanonical(html)
+  const robots = extractMeta(html, 'robots')
+  const title = extractTitle(html)
+  const description = extractMeta(html, 'description')
+  const schemaTypes = extractJsonLdTypes(html)
+  const redirectLikeInternalLinks = findRedirectLikeInternalLinks(html, origin)
+
+  if (firstHop.status >= 300 && firstHop.status < 400) {
+    issues.push({
+      severity: 'error',
+      code: 'SITEMAP_URL_REDIRECTS',
+      message: `Sitemap URL first hop is HTTP ${firstHop.status} to ${firstHop.location || '(no location)'}`,
+    })
+  }
+  if (redirectLikeInternalLinks.length > 0) {
+    issues.push({
+      severity: 'warning',
+      code: 'INTERNAL_REDIRECT_LINKS',
+      message: `${redirectLikeInternalLinks.length} internal link(s) look like legacy/redirect sources`,
+    })
+  }
+  if (title && (title.length < 25 || title.length > 70)) {
+    issues.push({
+      severity: 'warning',
+      code: 'TITLE_LENGTH_OUT_OF_RANGE',
+      message: `Title length ${title.length}`,
+    })
+  }
+  if (description && (description.length < 120 || description.length > 170)) {
+    issues.push({
+      severity: 'warning',
+      code: 'META_DESCRIPTION_LENGTH_OUT_OF_RANGE',
+      message: `Meta description length ${description.length}`,
+    })
+  }
+
+  return {
+    url,
+    ok: issues.every((issue) => issue.severity !== 'error'),
+    firstHop,
+    status: page.status,
+    canonical,
+    robots: robots ?? null,
+    titleLength: title?.length ?? 0,
+    descriptionLength: description?.length ?? 0,
+    schemaTypes,
+    internalLinkCount: page.internalLinkCount,
+    redirectLikeInternalLinks,
+    issues,
+  }
+}
+
+async function auditOne(url, sitemapUrls, origin) {
+  const [firstHop, fetched, page] = await Promise.all([
+    checkFirstHop(url),
+    fetchHtml(url),
+    auditUrl({ url, sitemapUrls }),
+  ])
+  return classifyPageIssues({
+    url,
+    firstHop,
+    page,
+    html: fetched.html,
+    origin,
+  })
+}
+
+async function mapLimit(items, limit, mapper) {
+  const results = new Array(items.length)
+  let next = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next
+      next += 1
+      results[index] = await mapper(items[index], index)
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+function summarize(pages) {
+  const allIssues = pages.flatMap((page) => page.issues.map((issue) => ({ ...issue, url: page.url })))
+  const byCode = {}
+  for (const issue of allIssues) {
+    byCode[issue.code] = (byCode[issue.code] || 0) + 1
+  }
+  return {
+    pagesChecked: pages.length,
+    pagesOk: pages.filter((page) => page.ok).length,
+    pagesWithErrors: pages.filter((page) => page.issues.some((issue) => issue.severity === 'error')).length,
+    pagesWithWarnings: pages.filter((page) => page.issues.some((issue) => issue.severity === 'warning')).length,
+    issueCount: allIssues.length,
+    errorCount: allIssues.filter((issue) => issue.severity === 'error').length,
+    warningCount: allIssues.filter((issue) => issue.severity === 'warning').length,
+    byCode,
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const urls = await collectSitemapUrls({ origin: options.origin })
+  const sitemapUrls = new Set(urls)
+  const pages = await mapLimit(urls, options.concurrency, (url) => auditOne(url, sitemapUrls, options.origin))
+  const report = {
+    runAt: new Date().toISOString(),
+    origin: options.origin,
+    summary: summarize(pages),
+    pages,
+  }
+
+  mkdirSync(dirname(options.out), { recursive: true })
+  writeFileSync(options.out, `${JSON.stringify(report, null, 2)}\n`)
+
+  console.log(`Full sitemap audit saved: ${options.out}`)
+  console.log(JSON.stringify(report.summary, null, 2))
+  if (report.summary.errorCount > 0) process.exitCode = 1
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : error)
+  process.exitCode = 1
+})

--- a/src/app/[locale]/growwise-blogs/high-school-math-finals-prep-dublin-tri-valley/page.tsx
+++ b/src/app/[locale]/growwise-blogs/high-school-math-finals-prep-dublin-tri-valley/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({
   const { locale } = await params
   const baseUrl = getCanonicalSiteUrl()
   return {
-    title: 'How to Prepare for High School Math Finals | Dublin Parent Guide | GrowWise',
+    title: 'High School Math Finals Prep Dublin CA | GrowWise',
     description:
       'High school math finals prep in Dublin, CA. Exam-style practice for Algebra 1 through AP Precalculus. In-center sessions at GrowWise School.',
     alternates: {

--- a/src/app/[locale]/growwise-blogs/unlock-your-future-the-best-programming-languages-for-career-advancement/page.tsx
+++ b/src/app/[locale]/growwise-blogs/unlock-your-future-the-best-programming-languages-for-career-advancement/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const baseUrl = getCanonicalSiteUrl()
   return { 
     title: 'Best Coding Languages for Students | GrowWise', 
-    description: 'Compare Python, JavaScript, Java, and project practice so parents can choose the right coding path for a student.',
+    description: 'Compare Python, JavaScript, Java, and project practice so parents can choose the right coding path for middle and high school students.',
     alternates: {
       canonical: absoluteSiteUrl('/growwise-blogs/unlock-your-future-the-best-programming-languages-for-career-advancement', locale, baseUrl)
     }

--- a/src/app/[locale]/resources/student-corner/layout.tsx
+++ b/src/app/[locale]/resources/student-corner/layout.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
+import { absoluteSiteUrl } from '@/lib/publicPath'
+import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl'
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const baseUrl = getCanonicalSiteUrl()
   return {
     title: 'Student Corner | Student Writing & Project Showcase | GrowWise',
     description:
       'Explore GrowWise Student Corner, a showcase destination for student articles, short stories, creative writing, coding projects, and portfolio work.',
+    alternates: {
+      canonical: absoluteSiteUrl('/resources/student-corner', locale, baseUrl),
+    },
   }
 }
 

--- a/src/lib/__tests__/publicPath.test.ts
+++ b/src/lib/__tests__/publicPath.test.ts
@@ -14,6 +14,32 @@ describe('publicPath', () => {
   it('adds leading slash when missing', () => {
     expect(publicPath('workshop-calendar', 'en')).toBe('/workshop-calendar');
   });
+
+  it('strips default locale prefixes from generated URLs', () => {
+    expect(publicPath('/en/about', 'en')).toBe('/about');
+    expect(publicPath('/en/growwise-blogs?page=3', 'en')).toBe('/growwise-blogs?page=3');
+  });
+
+  it('normalizes legacy redirect URLs to their canonical targets', () => {
+    expect(publicPath('/math-courses-in-dublin-ca-growwise/', 'en')).toBe('/academic/math');
+    expect(publicPath('/courses/english', 'en')).toBe('/academic/english');
+    expect(publicPath('/courses/high-school-math', 'en')).toBe('/academic/math/high-school');
+    expect(publicPath('/camps/academic-summer-sprint-dublin-ca', 'en')).toBe(
+      '/camps/academic-summer-programs-dublin-ca',
+    );
+    expect(publicPath('/english-courses-in-dublin-ca-growwise/', 'en')).toBe('/academic/english');
+    expect(publicPath('/academic/reading', 'en')).toBe('/academic/english');
+    expect(publicPath('/math-tutoring-dublin-ca/elementary', 'en')).toBe('/academic/math/elementary');
+    expect(publicPath('/camps/summer-writing-dublin-ca', 'en')).toBe('/camps/summer-reading-writing-dublin-ca');
+    expect(publicPath('/detective', 'en')).toBe('/self-check');
+    expect(publicPath('/results', 'en')).toBe('/self-check');
+  });
+
+  it('preserves query and hash suffixes while canonicalizing paths', () => {
+    expect(publicPath('/courses/math?source=nav#pricing', 'en')).toBe(
+      '/academic/math?source=nav#pricing',
+    );
+  });
 });
 
 describe('pathWithoutLocalePrefix', () => {

--- a/src/lib/publicPath.ts
+++ b/src/lib/publicPath.ts
@@ -1,11 +1,6 @@
 import { DEFAULT_LOCALE, isLocaleEnabled } from '@/i18n/localeConfig';
-import { LEGACY_PATH_REDIRECTS } from '@/lib/seo/legacy-path-redirects';
+import { normalizeCanonicalPathAlias } from '@/lib/seo/canonical-path-aliases';
 import { getCanonicalSiteUrl } from '@/lib/seo/siteUrl';
-
-function applyLegacyPublicPathAlias(pathname: string): string {
-  const hit = LEGACY_PATH_REDIRECTS.find((r) => r.from === pathname);
-  return hit ? hit.to : pathname;
-}
 
 /**
  * Strips a leading locale segment from a pathname when present.
@@ -34,7 +29,7 @@ export function publicPath(path: string, locale: string): string {
   }
   if (!normalized.startsWith('/')) normalized = `/${normalized}`;
   if (normalized === '') normalized = '/';
-  normalized = applyLegacyPublicPathAlias(normalized);
+  normalized = normalizeCanonicalPathAlias(pathWithoutLocalePrefix(normalized));
 
   if (locale === DEFAULT_LOCALE) {
     return normalized === '' ? '/' : normalized;

--- a/src/lib/seo/__tests__/indexnow-production-routing.test.ts
+++ b/src/lib/seo/__tests__/indexnow-production-routing.test.ts
@@ -28,4 +28,17 @@ describe('IndexNow production routing', () => {
       "{ source: '/sitemap.xml', destination: '/sitemap-index.xml' }",
     )
   })
+
+  it('redirects the old Kumon comparison slug to the indexable math tutoring options article', () => {
+    const middleware = readFileSync(
+      path.join(ROOT, 'src/middleware.ts'),
+      'utf8',
+    )
+    expect(middleware).toContain(
+      "'/resources/kumon-vs-mathnasium-vs-private-tutor-dublin-ca'",
+    )
+    expect(middleware).toContain(
+      "'/resources/math-tutoring-options-dublin-ca'",
+    )
+  })
 })

--- a/src/lib/seo/__tests__/legacy-path-redirects.test.ts
+++ b/src/lib/seo/__tests__/legacy-path-redirects.test.ts
@@ -1,4 +1,5 @@
 import { LEGACY_PATH_REDIRECTS } from '../legacy-path-redirects'
+import { getCanonicalPathAlias } from '../canonical-path-aliases'
 
 describe('LEGACY_PATH_REDIRECTS', () => {
   it('includes math-courses Dublin legacy slug', () => {
@@ -26,5 +27,12 @@ describe('LEGACY_PATH_REDIRECTS', () => {
   it('redirects math-tutoring-dublin-ca to dublin-ca', () => {
     const entry = LEGACY_PATH_REDIRECTS.find((r) => r.from === '/math-tutoring-dublin-ca')
     expect(entry?.to).toBe('/dublin-ca')
+  })
+
+  it('canonicalizes legacy paths before generic slash or locale redirects', () => {
+    expect(getCanonicalPathAlias('/math-courses-in-dublin-ca-growwise/')).toBe('/academic/math')
+    expect(getCanonicalPathAlias('/en/courses/math')).toBe('/academic/math')
+    expect(getCanonicalPathAlias('/en/growwise-blogs')).toBe('/growwise-blogs')
+    expect(getCanonicalPathAlias('/en')).toBe('/')
   })
 })

--- a/src/lib/seo/canonical-path-aliases.ts
+++ b/src/lib/seo/canonical-path-aliases.ts
@@ -1,0 +1,43 @@
+import { LEGACY_PATH_REDIRECTS } from '@/lib/seo/legacy-path-redirects';
+
+const DIRECT_CANONICAL_PATH_ALIASES = [
+  { from: '/camps/academic-summer-sprint-dublin-ca', to: '/camps/academic-summer-programs-dublin-ca' },
+  { from: '/detective', to: '/self-check' },
+  { from: '/results', to: '/self-check' },
+  { from: '/english-courses-in-dublin-ca-growwise', to: '/academic/english' },
+  { from: '/academic/reading', to: '/academic/english' },
+  { from: '/math-tutoring-dublin-ca/elementary', to: '/academic/math/elementary' },
+  { from: '/camps/summer-writing-dublin-ca', to: '/camps/summer-reading-writing-dublin-ca' },
+] as const;
+
+const CANONICAL_PATH_ALIAS_MAP = new Map<string, string>([
+  ...LEGACY_PATH_REDIRECTS.map(({ from, to }) => [from, to] as const),
+  ...DIRECT_CANONICAL_PATH_ALIASES.map(({ from, to }) => [from, to] as const),
+]);
+
+const LEGACY_LOCALE_PREFIX_PATTERN = /^\/(?:en|hi|zh|es)(?=\/|$)/;
+
+export function normalizeCanonicalPathAlias(path: string): string {
+  if (!path || path.startsWith('#') || path.startsWith('?')) return path;
+
+  const match = path.match(/^([^?#]*)(.*)$/);
+  const rawPathname = match?.[1] || '/';
+  const suffix = match?.[2] || '';
+  const pathname = rawPathname !== '/' && rawPathname.endsWith('/')
+    ? rawPathname.slice(0, -1)
+    : rawPathname;
+
+  return `${CANONICAL_PATH_ALIAS_MAP.get(pathname) ?? pathname}${suffix}`;
+}
+
+export function getCanonicalPathAlias(pathname: string): string | null {
+  const normalized = normalizeCanonicalPathAlias(pathname);
+  if (normalized !== pathname) return normalized;
+
+  const withoutLocalePrefix = pathname.replace(LEGACY_LOCALE_PREFIX_PATTERN, '') || '/';
+  if (withoutLocalePrefix !== pathname) {
+    return normalizeCanonicalPathAlias(withoutLocalePrefix);
+  }
+
+  return null;
+}

--- a/src/lib/seo/metadataConfig.ts
+++ b/src/lib/seo/metadataConfig.ts
@@ -51,7 +51,7 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   '/from-nextdoor': {
     title: 'GrowWise in Dublin, CA — Trusted by Neighbors',
     description:
-      'Dublin parents choose GrowWise for STEM, coding, and tutoring. Top-rated locally. Book a free assessment.',
+      'Dublin parents choose GrowWise for math, English, coding, and STEAM tutoring. See local reviews and book a free assessment.',
     keywords:
       'tutoring Dublin CA, GrowWise Dublin, Nextdoor tutoring Dublin, coding classes Dublin, Tri-Valley tutoring, learning center Dublin California, tutoring Dublin California',
     path: '/from-nextdoor',
@@ -250,7 +250,7 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   '/future-skills/design-creative-media': {
     title: 'Design & Creative Media Certification Pathway',
     description:
-      'Creative design, visual communication, portfolio projects, and Adobe certification readiness for Grades 5-10.',
+      'Creative design, visual communication, portfolio projects, and Adobe certification readiness for Grades 5-10 at GrowWise Dublin.',
     keywords:
       'Canva design classes for kids, creative media classes students, Adobe Certified Professional prep, Certiport Authorized Testing Center Dublin, Photoshop certification prep students, Illustrator certification prep, Premiere Pro certification prep, design portfolio for students, digital design classes Dublin CA',
     path: '/future-skills/design-creative-media',
@@ -259,7 +259,7 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   '/future-skills/python-certification': {
     title: 'Python Certification Pathway | GrowWise',
     description:
-      'Python fundamentals, project fluency, Certiport Python readiness, and PCEP/OpenEDG pathway in progress for Grades 7-12.',
+      'Python fundamentals, project fluency, Certiport Python readiness, and PCEP/OpenEDG pathway prep for Grades 7-12 in Dublin.',
     keywords:
       'Python certification for students, Certiport Python readiness, PCEP OpenEDG pathway in progress, ITS Python Certiport Dublin, Python coding classes Dublin CA, high school computer science preparation, Python project builder, Python certification readiness for teens',
     path: '/future-skills/python-certification',
@@ -340,7 +340,7 @@ export const metadataConfig: Record<string, PageMetadataConfig> = {
   '/self-check': {
     title: 'Academic Self-Check for Students | GrowWise Dublin CA',
     description:
-      'Answer 8 questions to see your math or English strengths and the gaps holding you back - in under 10 minutes.',
+      'Answer 8 questions to see your math or English strengths, hidden skill gaps, and next best step in under 10 minutes.',
     keywords:
       'math self-check, free math diagnostic, math mistake patterns, math tutoring Dublin CA, child math assessment, math gap finder, GrowWise School',
     path: '/self-check',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,8 @@ import createMiddleware from 'next-intl/middleware';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { ENABLED_LOCALES, DEFAULT_LOCALE } from '@/i18n/localeConfig';
+import { getCanonicalPathAlias } from '@/lib/seo/canonical-path-aliases';
+import { buildBlogPaths, buildPagesPaths } from '@/lib/seo/sitemapData';
 
 /**
  * Strip www subdomain to enforce single canonical domain (301 redirect).
@@ -25,7 +27,7 @@ function redirectWwwToDomain(request: NextRequest): NextResponse | null {
 function removeTrailingSlash(request: NextRequest): NextResponse | null {
   const pathname = request.nextUrl.pathname;
   if (pathname !== '/' && pathname.endsWith('/')) {
-    const url = request.nextUrl.clone();
+    const url = new URL(request.url);
     url.pathname = pathname.slice(0, -1);
     return NextResponse.redirect(url, 301);
   }
@@ -88,6 +90,15 @@ function redirectLegacyResourceAliases(request: NextRequest): NextResponse | nul
   return null;
 }
 
+function redirectCanonicalPathAliases(request: NextRequest): NextResponse | null {
+  const canonicalPath = getCanonicalPathAlias(request.nextUrl.pathname);
+  if (!canonicalPath) return null;
+
+  const url = new URL(request.url);
+  url.pathname = canonicalPath;
+  return NextResponse.redirect(url, 301);
+}
+
 const intlMiddleware = createMiddleware({
   locales: [...ENABLED_LOCALES],
   defaultLocale: DEFAULT_LOCALE,
@@ -108,6 +119,26 @@ const ROOT_PUBLIC_FILES = new Set([
   '/window.svg',
 ]);
 
+const KNOWN_PUBLIC_PATHS = new Set([
+  ...buildPagesPaths(),
+  ...buildBlogPaths(),
+  '/book-assessment/thank-you',
+  '/cart',
+  '/checkout',
+  '/checkout/success',
+  '/contact/thank-you',
+  '/dashboard',
+  '/enroll/thank-you',
+  '/enroll-academic/thank-you',
+  '/login',
+  '/math-finals-practice-session/thank-you',
+  '/self-check/done',
+  '/testimonials-test',
+  '/camps/summer/guide-success',
+  '/camps/summer/lottery-success',
+  '/camps/summer/summercamp-success',
+]);
+
 function notFoundResponse(): NextResponse {
   return new NextResponse(
     '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,follow"><title>Page not found | GrowWise</title></head><body><main><h1>Page not found</h1><p>The page you are looking for does not exist or may have been moved.</p><p><a href="/">Back to home</a></p></main></body></html>',
@@ -119,6 +150,19 @@ function notFoundResponse(): NextResponse {
       },
     },
   );
+}
+
+function hard404UnknownPublicPath(request: NextRequest): NextResponse | null {
+  const pathname = request.nextUrl.pathname;
+  if (pathname === '/' || ROOT_PUBLIC_FILES.has(pathname)) {
+    return null;
+  }
+
+  if (KNOWN_PUBLIC_PATHS.has(pathname)) {
+    return null;
+  }
+
+  return notFoundResponse();
 }
 
 function hard404UnknownDottedPath(request: NextRequest): NextResponse | null {
@@ -163,10 +207,6 @@ export default function middleware(request: NextRequest) {
   const wwwRedirect = redirectWwwToDomain(request);
   if (wwwRedirect) return wwwRedirect;
 
-  // Remove trailing slashes (except root) to normalize URLs
-  const noTrailing = removeTrailingSlash(request);
-  if (noTrailing) return noTrailing;
-
   const pathname = request.nextUrl.pathname;
   // Non-localized App Router segments (`app/camp/...` at repo root). Running next-intl on these
   // can fight with `[locale]/camp/[slug]` and caused redirect loops to the same URL.
@@ -176,6 +216,13 @@ export default function middleware(request: NextRequest) {
 
   const rewritten = rewriteLocalePrefixedNextAssets(request);
   if (rewritten) return rewritten;
+  const canonicalAlias = redirectCanonicalPathAliases(request);
+  if (canonicalAlias) return canonicalAlias;
+
+  // Remove trailing slashes (except root) to normalize URLs
+  const noTrailing = removeTrailingSlash(request);
+  if (noTrailing) return noTrailing;
+
   const legacyLocale = redirectLegacyLocalePrefix(request);
   if (legacyLocale) return legacyLocale;
   const legacyResourceAlias = redirectLegacyResourceAliases(request);
@@ -183,6 +230,8 @@ export default function middleware(request: NextRequest) {
   if (ROOT_PUBLIC_FILES.has(pathname)) {
     return NextResponse.next();
   }
+  const hard404Unknown = hard404UnknownPublicPath(request);
+  if (hard404Unknown) return hard404Unknown;
   const hard404 = hard404UnknownDottedPath(request);
   if (hard404) return hard404;
   return intlMiddleware(request);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -80,6 +80,11 @@ function redirectLegacyResourceAliases(request: NextRequest): NextResponse | nul
     url.pathname = '/readinesschecklist';
     return NextResponse.redirect(url, 301);
   }
+  if (request.nextUrl.pathname === '/resources/kumon-vs-mathnasium-vs-private-tutor-dublin-ca') {
+    const url = request.nextUrl.clone();
+    url.pathname = '/resources/math-tutoring-options-dublin-ca';
+    return NextResponse.redirect(url, 301);
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Canonicalize legacy crawl paths to final indexable pages and keep generated internal URLs off redirected sources.
- Add hard 404 handling for unknown public paths, including the singular /course namespace, to prevent soft-200 crawl waste.
- Fix sitemap page metadata warnings and /resources/student-corner self-canonical.
- Add a reusable full-sitemap SEO audit script for status, redirects, canonicals, metadata, schema, and internal legacy-link checks.

## Validation
- Production full sitemap audit before local fixes: 113 URLs checked, 0 hard errors, 7 warnings.
- Local built app: all 113 sitemap URLs returned 200.
- Local built app: /course, /course/math, and /asdf-nope returned 404.
- Local built app: legacy paths redirect to canonical pages:
  - /academic/reading -> /academic/english
  - /math-tutoring-dublin-ca/elementary -> /academic/math/elementary
  - /camps/summer-writing-dublin-ca -> /camps/summer-reading-writing-dublin-ca
  - /english-courses-in-dublin-ca-growwise/ -> /academic/english
- npm test -- --runTestsByPath src/lib/seo/__tests__/metadata-length-limits.test.ts src/lib/__tests__/publicPath.test.ts src/lib/seo/__tests__/legacy-path-redirects.test.ts src/lib/seo/__tests__/sitemapData.test.ts src/lib/seo/__tests__/seo-jsonld-route-audit.test.ts
- npm run build